### PR TITLE
set up continuous integration with travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: scala
+sudo: false
+jdk: openjdk8
+
+jobs:
+  include:
+    - stage: test
+      name : "metarules"
+      script:
+        - sbt test
+        - ./compileAllMetarules.sh
+
+    - stage: test
+      name : "controller-compiler"
+      # download and run the controller compiler in non-interactive mode with default settings
+      before_script:
+        - wget https://www.dropbox.com/s/gqsv3t5w36ywk0j/NAMControllerCompiler_1.2.1.zip -O NAMControllerCompiler.zip
+        - unzip NAMControllerCompiler.zip -d compiler
+      script:
+        - cd compiler && java -jar NAMControllerCompiler.jar ../Controller ../target 1 0 0xFFFF 0x01FF 0x01FF 0x01FF 0x001C 0x001C 0x0008 0x0001 0xFFFF
+
+cache:
+  directories:
+    - $HOME/.ivy2/cache
+    - $HOME/.coursier/cache
+    - $HOME/.sbt

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Network-Addon-Mod
 =================
 
+[![Build Status](https://travis-ci.org/NAMTeam/Network-Addon-Mod.svg?branch=master)](https://travis-ci.org/NAMTeam/Network-Addon-Mod)
+
 Network Addon Mod for SimCity 4 Deluxe/Rush Hour @ http://sc4devotion.com/forums/index.php?board=90.0
 
 


### PR DESCRIPTION
This adds a travis-CI script which automatically runs the controller compiler and also compiles the metarules on every new commit. This helps us test that the compilation continues to work as intended. You can see a test run here, for example: https://travis-ci.org/github/memo33/Network-Addon-Mod-FTL/builds/714761073.

If the new Java-based NAM installer can be used non-interactively, we could add a test for that as well, as knowing that it works in an independent controlled environment is quite useful.

Please merge the PR if you like this addition.