### PR TITLE
PedRev_FLEX_Crosswalks Bugfix

### DIFF
--- a/Controller/RUL0/6000_Street_PedMall_SAM/6100_PedRev_FLEX_PedCrossings.txt
+++ b/Controller/RUL0/6000_Street_PedMall_SAM/6100_PedRev_FLEX_PedCrossings.txt
@@ -84,7 +84,7 @@ ConsLayout=.^.
 AutoTileBase=	0x55387000
 ReplacementIntersection = 0, 0
 PlaceQueryID = 0x5B204000 ;to be replaced with 0x5C500000
-Costs        = 5
+Costs        = 0
 
 [HighwayIntersectionInfo_0x00016100]
 CopyFrom    = 0x6100
@@ -122,7 +122,7 @@ ConsLayout=..^.
 AutoTileBase=	0x55387000
 ReplacementIntersection = 0, 0
 PlaceQueryID = 0x5B204000 ;to be replaced with 0x5C500000
-Costs        = 5
+Costs        = 0
 
 [HighwayIntersectionInfo_0x00056100]
 CopyFrom    = 0x46100
@@ -159,7 +159,7 @@ ConsLayout=..^..
 AutoTileBase=	0x55387000
 ReplacementIntersection = 0, 0
 PlaceQueryID = 0x5B204000 ;to be replaced with 0x5C500000
-Costs        = 15
+Costs        = 0
 
 [HighwayIntersectionInfo_0x00096100]
 CopyFrom    = 0x86100
@@ -199,16 +199,16 @@ ConsLayout=..^.
 AutoTileBase=	0x55387000
 ReplacementIntersection = 0, 0
 PlaceQueryID = 0x5B204000 ;to be replaced with 0x5C501780
-Costs        = 10
+Costs        = 0
 
 [HighwayIntersectionInfo_0x000D6100]
-CopyFrom    = 0xD6100
+CopyFrom    = 0xC6100
 Rotate		= 1
 [HighwayIntersectionInfo_0x000E6100]
-CopyFrom    = 0xE6100
+CopyFrom    = 0xC6100
 Rotate		= 2
 [HighwayIntersectionInfo_0x000F6100]
-CopyFrom    = 0xF6100
+CopyFrom    = 0xC6100
 Rotate		= 3
 
 ;Mid-block Crosswalks - offical deployment
@@ -240,7 +240,7 @@ ConsLayout=.^.
 AutoTileBase=	0x55387000
 ReplacementIntersection = 0, 0
 PlaceQueryID = 0x5B204000 ;to be replaced with 0x5C500080
-Costs        = 10
+Costs        = 0
 
 [HighwayIntersectionInfo_0x00016101]
 CopyFrom    = 0x6101
@@ -281,7 +281,7 @@ ConsLayout=..^.
 AutoTileBase=	0x55387000
 ReplacementIntersection = 0, 0
 PlaceQueryID = 0x5B204000 ;to be replaced with 0x5C500080
-Costs        = 10
+Costs        = 0
 
 [HighwayIntersectionInfo_0x00056101]
 CopyFrom    = 0x46101
@@ -322,7 +322,7 @@ ConsLayout=..^..
 AutoTileBase=	0x55387000
 ReplacementIntersection = 0, 0
 PlaceQueryID = 0x5B204000 ;to be replaced with 0x5C500080
-Costs        = 10
+Costs        = 0
 
 [HighwayIntersectionInfo_0x00096101]
 CopyFrom    = 0x86101
@@ -367,7 +367,7 @@ ConsLayout=..^.
 AutoTileBase=	0x55387000
 ReplacementIntersection = 0, 0
 PlaceQueryID = 0x5B204000 ;to be replaced with 0x5C501880
-Costs        = 20
+Costs        = 0
 
 [HighwayIntersectionInfo_0x000D6101]
 CopyFrom    = 0xC6101
@@ -412,7 +412,7 @@ ConsLayout=.^.
 AutoTileBase=	0x55387000
 ReplacementIntersection = 0, 0
 PlaceQueryID = 0x5B204000 ;to be replaced with 0x5C500100
-Costs        = 15
+Costs        = 0
 
 [HighwayIntersectionInfo_0x00016102]
 CopyFrom    = 0x6102
@@ -457,7 +457,7 @@ ConsLayout=..^.
 AutoTileBase=	0x55387000
 ReplacementIntersection = 0, 0
 PlaceQueryID = 0x5B204000 ;to be replaced with 0x5C500100
-Costs        = 15
+Costs        = 0
 
 [HighwayIntersectionInfo_0x00056102]
 CopyFrom    = 0x46102
@@ -502,7 +502,7 @@ ConsLayout=..^..
 AutoTileBase=	0x55387000
 ReplacementIntersection = 0, 0
 PlaceQueryID = 0x5B204000 ;to be replaced with 0x5C500100
-Costs        = 15
+Costs        = 0
 
 [HighwayIntersectionInfo_0x00096102]
 CopyFrom    = 0x86102
@@ -553,7 +553,7 @@ ConsLayout=..^.
 AutoTileBase=	0x55387000
 ReplacementIntersection = 0, 0
 PlaceQueryID = 0x5B204000 ;to be replaced with 0x5C501980
-Costs        = 30
+Costs        = 0
 
 [HighwayIntersectionInfo_0x000D6102]
 CopyFrom    = 0xC6102


### PR DESCRIPTION
Corrected rotation ring copy lines of Size 1 Avenue (0xC6100 to 0xF6100), reduced construction cost of FLEX pieces.