### PR TITLE
eliminate offset in FLEXRamp D1 preview

### DIFF
--- a/Controller/RUL0/5000_RHW/51F0_FlexRamps.txt
+++ b/Controller/RUL0/5000_RHW/51F0_FlexRamps.txt
@@ -258,7 +258,7 @@ Rotate		= 3
 [HighwayIntersectionInfo_0x000051F2]
 ;Added by Tarkus 6/2/2012.
 ;FlexRamp Type D1-Orthogonal Off/Exit Ramp
-Piece = 0.0, -16.0, 0, 0, 0x5783300F
+Piece = 0.0, 0.0, 0, 0, 0x5783300F
 PreviewEffect = preview_flexramp_d1orth_000
 
 CellLayout =.......


### PR DESCRIPTION
The preview model was offset by 16m which results in the preview disappearing into the ground or hovering above the ground whenever the placement 'handle' is adjacent to a slope.  The model will be adjusted to eliminate the need for offset in RUL0.