### PR TITLE
Add LTEXTs for 7 new street-based PRM bridges

### DIFF
--- a/ltext/bridges.pot
+++ b/ltext/bridges.pot
@@ -808,3 +808,31 @@ msgstr ""
 msgctxt "2026960B-6A231EAA-C0429F20"
 msgid "RHW-12S L2/15m Viaduct "
 msgstr ""
+
+msgctxt "2026960B-6A231EAA-30231F00"
+msgid "PRM Brick Arch Viaduct - Classic"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30241F00"
+msgid "PRM Brick Arch Viaduct - Pavement"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30251F00"
+msgid "PRM Brick Arch Viaduct - Cobblestone"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30261F00"
+msgid "PRM Brick Arch Viaduct - Wavy Brick"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30271F00"
+msgid "PRM Brick Arch Viaduct - Sandstone"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30281F00"
+msgid "PRM Brick Arch Viaduct - Retrowave"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30291F00"
+msgid "PRM Brick Arch Viaduct - Industrial"
+msgstr ""

--- a/ltext/de/bridges.po
+++ b/ltext/de/bridges.po
@@ -808,3 +808,31 @@ msgstr ""
 msgctxt "2026960B-6A231EAA-C0429F20"
 msgid "RHW-12S L2/15m Viaduct "
 msgstr ""
+
+msgctxt "2026960B-6A231EAA-30231F00"
+msgid "PRM Brick Arch Viaduct - Classic"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30241F00"
+msgid "PRM Brick Arch Viaduct - Pavement"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30251F00"
+msgid "PRM Brick Arch Viaduct - Cobblestone"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30261F00"
+msgid "PRM Brick Arch Viaduct - Wavy Brick"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30271F00"
+msgid "PRM Brick Arch Viaduct - Sandstone"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30281F00"
+msgid "PRM Brick Arch Viaduct - Retrowave"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30291F00"
+msgid "PRM Brick Arch Viaduct - Industrial"
+msgstr ""

--- a/ltext/es/bridges.po
+++ b/ltext/es/bridges.po
@@ -810,3 +810,31 @@ msgstr "Viaducto RHW-12S elevado L1 (7,5m)"
 msgctxt "2026960B-6A231EAA-C0429F20"
 msgid "RHW-12S L2/15m Viaduct "
 msgstr "Viaducto RHW-12S elevado L2 (15m)"
+
+msgctxt "2026960B-6A231EAA-30231F00"
+msgid "PRM Brick Arch Viaduct - Classic"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30241F00"
+msgid "PRM Brick Arch Viaduct - Pavement"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30251F00"
+msgid "PRM Brick Arch Viaduct - Cobblestone"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30261F00"
+msgid "PRM Brick Arch Viaduct - Wavy Brick"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30271F00"
+msgid "PRM Brick Arch Viaduct - Sandstone"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30281F00"
+msgid "PRM Brick Arch Viaduct - Retrowave"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30291F00"
+msgid "PRM Brick Arch Viaduct - Industrial"
+msgstr ""

--- a/ltext/fr/bridges.po
+++ b/ltext/fr/bridges.po
@@ -808,3 +808,31 @@ msgstr "Viaduc RHW-12S L1/7.5m "
 msgctxt "2026960B-6A231EAA-C0429F20"
 msgid "RHW-12S L2/15m Viaduct "
 msgstr "Viaduc RHW-12S L2/15m "
+
+msgctxt "2026960B-6A231EAA-30231F00"
+msgid "PRM Brick Arch Viaduct - Classic"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30241F00"
+msgid "PRM Brick Arch Viaduct - Pavement"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30251F00"
+msgid "PRM Brick Arch Viaduct - Cobblestone"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30261F00"
+msgid "PRM Brick Arch Viaduct - Wavy Brick"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30271F00"
+msgid "PRM Brick Arch Viaduct - Sandstone"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30281F00"
+msgid "PRM Brick Arch Viaduct - Retrowave"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30291F00"
+msgid "PRM Brick Arch Viaduct - Industrial"
+msgstr "Viaduc d'Antheor (Nice) en arc de brique, RRW-2"

--- a/ltext/it/bridges.po
+++ b/ltext/it/bridges.po
@@ -810,3 +810,31 @@ msgstr "RHW-12S L1/7.5m Viadotto"
 msgctxt "2026960B-6A231EAA-C0429F20"
 msgid "RHW-12S L2/15m Viaduct "
 msgstr "RHW-12S L2/15m Viadotto "
+
+msgctxt "2026960B-6A231EAA-30231F00"
+msgid "PRM Brick Arch Viaduct - Classic"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30241F00"
+msgid "PRM Brick Arch Viaduct - Pavement"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30251F00"
+msgid "PRM Brick Arch Viaduct - Cobblestone"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30261F00"
+msgid "PRM Brick Arch Viaduct - Wavy Brick"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30271F00"
+msgid "PRM Brick Arch Viaduct - Sandstone"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30281F00"
+msgid "PRM Brick Arch Viaduct - Retrowave"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30291F00"
+msgid "PRM Brick Arch Viaduct - Industrial"
+msgstr ""

--- a/ltext/ko/bridges.po
+++ b/ltext/ko/bridges.po
@@ -811,3 +811,31 @@ msgstr "RHW-12S L1/7.5m 다리 "
 msgctxt "2026960B-6A231EAA-C0429F20"
 msgid "RHW-12S L2/15m Viaduct "
 msgstr "RHW-12S L2/15m 다리 "
+
+msgctxt "2026960B-6A231EAA-30231F00"
+msgid "PRM Brick Arch Viaduct - Classic"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30241F00"
+msgid "PRM Brick Arch Viaduct - Pavement"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30251F00"
+msgid "PRM Brick Arch Viaduct - Cobblestone"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30261F00"
+msgid "PRM Brick Arch Viaduct - Wavy Brick"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30271F00"
+msgid "PRM Brick Arch Viaduct - Sandstone"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30281F00"
+msgid "PRM Brick Arch Viaduct - Retrowave"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30291F00"
+msgid "PRM Brick Arch Viaduct - Industrial"
+msgstr ""

--- a/ltext/nl/bridges.po
+++ b/ltext/nl/bridges.po
@@ -808,3 +808,31 @@ msgstr ""
 msgctxt "2026960B-6A231EAA-C0429F20"
 msgid "RHW-12S L2/15m Viaduct "
 msgstr ""
+
+msgctxt "2026960B-6A231EAA-30231F00"
+msgid "PRM Brick Arch Viaduct - Classic"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30241F00"
+msgid "PRM Brick Arch Viaduct - Pavement"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30251F00"
+msgid "PRM Brick Arch Viaduct - Cobblestone"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30261F00"
+msgid "PRM Brick Arch Viaduct - Wavy Brick"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30271F00"
+msgid "PRM Brick Arch Viaduct - Sandstone"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30281F00"
+msgid "PRM Brick Arch Viaduct - Retrowave"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30291F00"
+msgid "PRM Brick Arch Viaduct - Industrial"
+msgstr ""

--- a/ltext/pt/bridges.po
+++ b/ltext/pt/bridges.po
@@ -810,3 +810,31 @@ msgstr ""
 msgctxt "2026960B-6A231EAA-C0429F20"
 msgid "RHW-12S L2/15m Viaduct "
 msgstr ""
+
+msgctxt "2026960B-6A231EAA-30231F00"
+msgid "PRM Brick Arch Viaduct - Classic"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30241F00"
+msgid "PRM Brick Arch Viaduct - Pavement"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30251F00"
+msgid "PRM Brick Arch Viaduct - Cobblestone"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30261F00"
+msgid "PRM Brick Arch Viaduct - Wavy Brick"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30271F00"
+msgid "PRM Brick Arch Viaduct - Sandstone"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30281F00"
+msgid "PRM Brick Arch Viaduct - Retrowave"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30291F00"
+msgid "PRM Brick Arch Viaduct - Industrial"
+msgstr ""

--- a/ltext/sv/bridges.po
+++ b/ltext/sv/bridges.po
@@ -810,3 +810,31 @@ msgstr ""
 msgctxt "2026960B-6A231EAA-C0429F20"
 msgid "RHW-12S L2/15m Viaduct "
 msgstr ""
+
+msgctxt "2026960B-6A231EAA-30231F00"
+msgid "PRM Brick Arch Viaduct - Classic"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30241F00"
+msgid "PRM Brick Arch Viaduct - Pavement"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30251F00"
+msgid "PRM Brick Arch Viaduct - Cobblestone"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30261F00"
+msgid "PRM Brick Arch Viaduct - Wavy Brick"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30271F00"
+msgid "PRM Brick Arch Viaduct - Sandstone"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30281F00"
+msgid "PRM Brick Arch Viaduct - Retrowave"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30291F00"
+msgid "PRM Brick Arch Viaduct - Industrial"
+msgstr ""


### PR DESCRIPTION
Added LTEXTs for 7 new street-based PRM bridges: classic, pavement, cobblestone, wavy brick, sandstone, retrowave, and industrial