### PR TITLE
Syntax check for po/pot files

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -34,5 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - name: Check PO/POT syntax
+      run: sh src/scripts/syntax-check-po.sh
     - name: Check RUL2 syntax
       run: sh src/scripts/syntax-check-rul2.sh

--- a/ltext/de/puzzlepieces-avenue.po
+++ b/ltext/de/puzzlepieces-avenue.po
@@ -79,6 +79,6 @@ msgctxt "2026960B-2A592FD1-54600800"
 msgid "Diagonal to Fractionally Angled Avenue transition (3x4)"
 msgstr "Übergang diagonaler Allee auf 18.4 Grad schräg verlaufende Allee (3x4)"
 
-msgctxt "2026960B-2A592FD1-5f491505"
+msgctxt "2026960B-2A592FD1-5F491505"
 msgid "Avenue 5x5 90 Degree Curve"
 msgstr ""

--- a/ltext/es/puzzlepieces-avenue.po
+++ b/ltext/es/puzzlepieces-avenue.po
@@ -84,6 +84,6 @@ msgctxt "2026960B-2A592FD1-54600800"
 msgid "Diagonal to Fractionally Angled Avenue transition (3x4)"
 msgstr ""
 
-msgctxt "2026960B-2A592FD1-5f491505"
+msgctxt "2026960B-2A592FD1-5F491505"
 msgid "Avenue 5x5 90 Degree Curve"
 msgstr ""

--- a/ltext/fr/puzzlepieces-avenue.po
+++ b/ltext/fr/puzzlepieces-avenue.po
@@ -80,6 +80,6 @@ msgctxt "2026960B-2A592FD1-54600800"
 msgid "Diagonal to Fractionally Angled Avenue transition (3x4)"
 msgstr "Avenue diagonale vers angle fractionnaire (3x4)"
 
-msgctxt "2026960B-2A592FD1-5f491505"
+msgctxt "2026960B-2A592FD1-5F491505"
 msgid "Avenue 5x5 90 Degree Curve"
 msgstr "Avenue courbe à 90° 5x5"

--- a/ltext/it/puzzlepieces-avenue.po
+++ b/ltext/it/puzzlepieces-avenue.po
@@ -84,6 +84,6 @@ msgctxt "2026960B-2A592FD1-54600800"
 msgid "Diagonal to Fractionally Angled Avenue transition (3x4)"
 msgstr "Transizione da viale diagonale a viale ad angolo frazionato (3x4)"
 
-msgctxt "2026960B-2A592FD1-5f491505"
+msgctxt "2026960B-2A592FD1-5F491505"
 msgid "Avenue 5x5 90 Degree Curve"
 msgstr "Viale Curva a 90 gradi 5x5"

--- a/ltext/ko/puzzlepieces-avenue.po
+++ b/ltext/ko/puzzlepieces-avenue.po
@@ -83,6 +83,6 @@ msgctxt "2026960B-2A592FD1-54600800"
 msgid "Diagonal to Fractionally Angled Avenue transition (3x4)"
 msgstr "분수 각도 애비뉴(FAAVE-4) :: 대각선으로 전환 (3x4)"
 
-msgctxt "2026960B-2A592FD1-5f491505"
+msgctxt "2026960B-2A592FD1-5F491505"
 msgid "Avenue 5x5 90 Degree Curve"
 msgstr "애비뉴 :: 90도 곡선 (5x5)"

--- a/ltext/pt/puzzlepieces-avenue.po
+++ b/ltext/pt/puzzlepieces-avenue.po
@@ -81,6 +81,6 @@ msgctxt "2026960B-2A592FD1-54600800"
 msgid "Diagonal to Fractionally Angled Avenue transition (3x4)"
 msgstr ""
 
-msgctxt "2026960B-2A592FD1-5f491505"
+msgctxt "2026960B-2A592FD1-5F491505"
 msgid "Avenue 5x5 90 Degree Curve"
 msgstr ""

--- a/ltext/puzzlepieces-avenue.pot
+++ b/ltext/puzzlepieces-avenue.pot
@@ -79,6 +79,6 @@ msgctxt "2026960B-2A592FD1-54600800"
 msgid "Diagonal to Fractionally Angled Avenue transition (3x4)"
 msgstr ""
 
-msgctxt "2026960B-2A592FD1-5f491505"
+msgctxt "2026960B-2A592FD1-5F491505"
 msgid "Avenue 5x5 90 Degree Curve"
 msgstr ""

--- a/ltext/sv/puzzlepieces-avenue.po
+++ b/ltext/sv/puzzlepieces-avenue.po
@@ -81,6 +81,6 @@ msgctxt "2026960B-2A592FD1-54600800"
 msgid "Diagonal to Fractionally Angled Avenue transition (3x4)"
 msgstr ""
 
-msgctxt "2026960B-2A592FD1-5f491505"
+msgctxt "2026960B-2A592FD1-5F491505"
 msgid "Avenue 5x5 90 Degree Curve"
 msgstr ""

--- a/src/scripts/syntax-check-po.sh
+++ b/src/scripts/syntax-check-po.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+# This script checks all the po/pot files for correct multi-line format and uppercased TGIs.
+# If any issues are found, they are printed to stdout and the script exits with a non-zero return code.
+set -e
+
+INDIR="./ltext"
+OUT="./syntax-check-po.log"
+
+sorted_input_files() {
+    find -L "$INDIR" -type f \( -name '*.po' -o -name '*.pot' \) -print0 | sort -z
+}
+
+strip_comments_and_whitespace() {
+    ${1:+ xargs -0} sed -e 's/^#.*//' -e 's/\s\+$//g' -e '/^\s*$/d'
+}
+# Note that we used sed and tail for concatenation which handle missing
+# newlines at the end of input files gracefully (unlike cat).
+
+strip_valid_po() {
+    # TGIs must be upper-case.
+    ID="[0-9A-F]\{8\}"
+    # Every line of a multi-line string should start and end with quotes.
+    QUOTEDTEXT='".*"'
+    sed -e "/^msgctxt\s\+\"$ID-$ID-$ID\"$/d" \
+        -e "/^msgid\s\+$QUOTEDTEXT$/d" \
+        -e "/^msgstr\s\+$QUOTEDTEXT$/d" \
+        -e "/^msgstr\s\+$QUOTEDTEXT$/d" \
+        -e "/^$QUOTEDTEXT$/d"
+}
+
+echo "Checking .po file syntax..."
+
+sorted_input_files | strip_comments_and_whitespace -0 | strip_valid_po > "$OUT"
+
+if [ -s "$OUT" ]; then
+    # the log file is not-empty
+    echo "Syntax errors in .po files (use uppercase TGIs and quotes on every line of text):"
+    cat "$OUT"
+    rm -f "$OUT"
+    exit 1
+else
+    echo "No syntax errors found."
+    rm -f "$OUT"
+    exit 0
+fi

--- a/src/scripts/syntax-check-rul2.sh
+++ b/src/scripts/syntax-check-rul2.sh
@@ -21,7 +21,7 @@ strip_drive_side() {
 # newlines at the end of input files gracefully (unlike cat).
 
 strip_comments_and_whitespace() {
-    sed -e "s/;.*//" -e "s/\s\+//g" -e '/^\s*$/d'
+    sed -e 's/;.*//' -e 's/\s\+//g' -e '/^\s*$/d'
 }
 
 strip_valid_rul2() {


### PR DESCRIPTION
A rudimentary linter that checks the multi-line format of text strings as well as upper-casing of TGIs.

It's also added to the lint action.