### PR TITLE
Script for compiling NAM controllers

### DIFF
--- a/src/scripts/RUL2_IID_structure_full.xml
+++ b/src/scripts/RUL2_IID_structure_full.xml
@@ -1,0 +1,348 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE iid_tree SYSTEM "RUL2_IID_structure.dtd">
+<iid_tree>
+    <node name="El Rail over Avenue">
+        <regex value="0x5f85\p{XDigit}{4}"/>
+    </node>
+    <node name="Elevated Road Networks">
+        <regex value="0x5c0[0-8]\p{XDigit}{4}"/>
+        <regex value="0x57[0-4][0-9a]1[1-3][12]\p{XDigit}"/>
+    </node>
+    <node name="Ground Light Rail">
+        <regex value="0x5f88\p{XDigit}{4}"/>
+        <regex value="0x57[0-4][0-9a][147a][78]0\p{XDigit}"/>
+        <node name="Urban GLR">
+            <regex value="0x5f88[0-3]\p{XDigit}{3}"/>
+        </node>
+        <node name="Rural GLR">
+            <regex value="0x5f88[4-7]\p{XDigit}{3}"/>
+        </node>
+        <node name="GLR Extension Set 1">
+            <regex value="0x5f88[89ab]\p{XDigit}{3}"/>
+        </node>
+        <node name="GLR Extension Set 2">
+            <regex value="0x5f88[c-f]\p{XDigit}{3}"/>
+        </node>
+    </node>
+    <node name="High Speed Rail">
+        <regex value="0x5d[dc]\p{XDigit}{5}"/>
+        <regex value="0x57[0-4][0-9a][147a]9\p{XDigit}5"/>
+    </node>
+    <node name="Network Widening Mod">
+        <regex value="0x51[0-2]\p{XDigit}{5}"/>
+        <regex value="0x57[0-4][0-9a]([258b][7-9a-f]|[369c][0-5])\p{XDigit}{2}"/>
+        <node name="NWM TLA-3">
+            <regex value="0x5100\p{XDigit}{4}"/>
+            <regex value="0x57[0-4][0-9a][258b]7\p{XDigit}{2}"/>
+        </node>
+        <node name="NWM AVE-2">
+            <regex value="0x5101\p{XDigit}{4}"/>
+            <regex value="0x57[0-4][0-9a][258b]8\p{XDigit}{2}"/>
+        </node>
+        <node name="NWM ARD-3">
+            <regex value="0x5102\p{XDigit}{4}"/>
+            <regex value="0x57[0-4][0-9a][258b]9\p{XDigit}{2}"/>
+        </node>
+        <node name="NWM OWR-1">
+            <regex value="0x5103\p{XDigit}{4}"/>
+            <regex value="0x57[0-4][0-9a][258b]a\p{XDigit}{2}"/>
+        </node>
+        <node name="NWM OWR-3">
+            <regex value="0x5104\p{XDigit}{4}"/>
+            <regex value="0x57[0-4][0-9a][258b]b\p{XDigit}{2}"/>
+        </node>
+        <node name="NWM NRD-4">
+            <regex value="0x5105\p{XDigit}{4}"/>
+            <regex value="0x57[0-4][0-9a][258b]c\p{XDigit}{2}"/>
+        </node>
+        <node name="NWM TLA-5">
+            <regex value="0x5110\p{XDigit}{4}"/>
+            <regex value="0x57[0-4][0-9a][258b]d\p{XDigit}{2}"/>
+        </node>
+        <node name="NWM OWR-4">
+            <regex value="0x5111\p{XDigit}{4}"/>
+            <regex value="0x57[0-4][0-9a][258b]e\p{XDigit}{2}"/>
+        </node>
+        <node name="NWM OWR-5">
+            <regex value="0x5112\p{XDigit}{4}"/>
+            <regex value="0x57[0-4][0-9a][258b]f\p{XDigit}{2}"/>
+        </node>
+        <node name="NWM RD-4">
+            <regex value="0x5113\p{XDigit}{4}"/>
+            <regex value="0x57[0-4][0-9a][258b]0\p{XDigit}{2}"/>
+        </node>
+        <node name="NWM RD-6">
+            <regex value="0x5114\p{XDigit}{4}"/>
+            <regex value="0x57[0-4][0-9a][258b]1\p{XDigit}{2}"/>
+        </node>
+        <node name="NWM Triple-Tile Networks">
+            <regex value="0x512\p{XDigit}{5}"/>
+            <regex value="0x57[0-4][0-9a][258b][2-5]\p{XDigit}{2}"/>
+        </node>
+    </node>
+    <node name="Real Highway Mod">
+        <regex value="0x57\p{XDigit}{6}"/>
+        <node name="L0 networks">
+            <regex value="0x570\p{XDigit}{5}"/>
+            <regex value="0x57[0-5]\p{XDigit}([147a][a-f]|[258b][0-6])[048c]\p{XDigit}"/>
+            <node name="RHW-2"/>
+            <node name="RHW-3">
+                <regex value="0x5701\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[147a]b[08]\p{XDigit}"/>
+            </node>
+            <node name="MIS">
+                <regex value="0x5702\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[147a]c[08]\p{XDigit}"/>
+            </node>
+            <node name="RHW-4">
+                <regex value="0x5703\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[147a]d[048c]\p{XDigit}"/>
+            </node>
+            <node name="RHW-6S">
+                <regex value="0x5704\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[147a]e[048c]\p{XDigit}"/>
+            </node>
+            <node name="RHW-8S">
+                <regex value="0x570[5-7]\p{XDigit}{4}">
+                    <requires nodename="RHW-10S"/>
+                    <requires nodename="RHW-12S"/>
+                </regex>
+                <regex value="0x57[0-5]\p{XDigit}([147a]f|[258b][0-2])[048c]\p{XDigit}">
+                    <requires nodename="RHW-10S"/>
+                    <requires nodename="RHW-12S"/>
+                </regex>
+                <regex value="0x5705[1-9a-f]\p{XDigit}{1}[0-7]\p{XDigit}"/>
+                <regex value="0x57[0-5]\p{XDigit}[258b]0[048c]\p{XDigit}"/>
+            </node>
+            <node name="RHW-10S">
+                <regex value="0x5706\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[258b]1[048c]\p{XDigit}"/>
+            </node>
+            <node name="RHW-12S">
+                <regex value="0x5707\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[258b]2[048c]\p{XDigit}"/>
+            </node>
+            <node name="RHW-6C">
+                <regex value="0x570[89a]\p{XDigit}{4}">
+                    <requires nodename="RHW-8C"/>
+                    <requires nodename="RHW-10C"/>
+                </regex>
+                <regex value="0x57[0-5]\p{XDigit}[258b][3-6][048c]\p{XDigit}">
+                    <requires nodename="RHW-8C"/>
+                    <requires nodename="RHW-10C"/>
+                </regex>
+                <regex value="0x5708[1-9a-f]\p{XDigit}{1}[0-7]\p{XDigit}"/>
+                <regex value="0x57[0-5]\p{XDigit}[258b]4[048c]\p{XDigit}"/>
+            </node>
+            <node name="RHW-8C">
+                <regex value="0x5709\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[258b]5[048c]\p{XDigit}"/>
+            </node>
+            <node name="RHW-10C">
+                <regex value="0x570a\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[258b]6[048c]\p{XDigit}"/>
+            </node>
+        </node>
+        <node name="L1 networks">
+            <regex value="0x571\p{XDigit}{5}"/>
+            <regex value="0x57[0-5]\p{XDigit}([147a][a-f]|[258b][0-6])[159d]\p{XDigit}"/>
+            <node name="RHW-2">
+                <regex value="0x5710\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[147a]a[19]\p{XDigit}"/>
+            </node>
+            <node name="RHW-3">
+                <regex value="0x5711\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[147a]b[19]\p{XDigit}"/>
+            </node>
+            <node name="MIS">
+                <regex value="0x5712\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[147a]c[19]\p{XDigit}"/>
+            </node>
+            <node name="RHW-4">
+                <regex value="0x5713\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[147a]d[159d]\p{XDigit}"/>
+            </node>
+            <node name="RHW-6S">
+                <regex value="0x5714\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[147a]e[159d]\p{XDigit}"/>
+            </node>
+            <node name="RHW-8S">
+                <regex value="0x571[5-7]\p{XDigit}{4}">
+                    <requires nodename="RHW-10S"/>
+                    <requires nodename="RHW-12S"/>
+                </regex>
+                <regex value="0x57[0-5]\p{XDigit}([147a]f|[258b][0-2])[159d]\p{XDigit}">
+                    <requires nodename="RHW-10S"/>
+                    <requires nodename="RHW-12S"/>
+                </regex>
+                <regex value="0x5715[1-9a-f]\p{XDigit}{1}[0-7]\p{XDigit}"/>
+                <regex value="0x57[0-5]\p{XDigit}[258b]0[159d]\p{XDigit}"/>
+            </node>
+            <node name="RHW-10S">
+                <regex value="0x5716\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[258b]1[159d]\p{XDigit}"/>
+            </node>
+            <node name="RHW-12S">
+                <regex value="0x5717\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[258b]2[159d]\p{XDigit}"/>
+            </node>
+            <node name="RHW-6C">
+                <regex value="0x571[89a]\p{XDigit}{4}">
+                    <requires nodename="RHW-8C"/>
+                    <requires nodename="RHW-10C"/>
+                </regex>
+                <regex value="0x57[0-5]\p{XDigit}[258b][3-6][159d]\p{XDigit}">
+                    <requires nodename="RHW-8C"/>
+                    <requires nodename="RHW-10C"/>
+                </regex>
+                <regex value="0x5718[1-9a-f]\p{XDigit}{1}[0-7]\p{XDigit}"/>
+                <regex value="0x57[0-5]\p{XDigit}[258b]4[159d]\p{XDigit}"/>
+            </node>
+            <node name="RHW-8C">
+                <regex value="0x5719\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[258b]5[159d]\p{XDigit}"/>
+            </node>
+            <node name="RHW-10C">
+                <regex value="0x571a\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[258b]6[159d]\p{XDigit}"/>
+            </node>
+        </node>
+        <node name="L2 networks">
+            <regex value="0x572\p{XDigit}{5}"/>
+            <regex value="0x57[0-5]\p{XDigit}([147a][a-f]|[258b][0-6])[26ae]\p{XDigit}"/>
+            <node name="RHW-2">
+                <regex value="0x5720\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[147a]a[2a]\p{XDigit}"/>
+            </node>
+            <node name="RHW-3">
+                <regex value="0x5721\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[147a]b[2a]\p{XDigit}"/>
+            </node>
+            <node name="MIS">
+                <regex value="0x5722\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[147a]c[2a]\p{XDigit}"/>
+            </node>
+            <node name="RHW-4">
+                <regex value="0x5723\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[147a]d[26ae]\p{XDigit}"/>
+            </node>
+            <node name="RHW-6S">
+                <regex value="0x5724\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[147a]e[26ae]\p{XDigit}"/>
+            </node>
+            <node name="RHW-8S">
+                <regex value="0x572[5-7]\p{XDigit}{4}">
+                    <requires nodename="RHW-10S"/>
+                    <requires nodename="RHW-12S"/>
+                </regex>
+                <regex value="0x57[0-5]\p{XDigit}([147a]f|[258b][0-2])[26ae]\p{XDigit}">
+                    <requires nodename="RHW-10S"/>
+                    <requires nodename="RHW-12S"/>
+                </regex>
+                <regex value="0x5725[1-9a-f]\p{XDigit}{1}[0-7]\p{XDigit}"/>
+                <regex value="0x57[0-5]\p{XDigit}[258b]0[26ae]\p{XDigit}"/>
+            </node>
+            <node name="RHW-10S">
+                <regex value="0x5726\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[258b]1[26ae]\p{XDigit}"/>
+            </node>
+            <node name="RHW-12S">
+                <regex value="0x5727\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[258b]2[26ae]\p{XDigit}"/>
+            </node>
+            <node name="RHW-6C">
+                <regex value="0x572[89a]\p{XDigit}{4}">
+                    <requires nodename="RHW-8C"/>
+                    <requires nodename="RHW-10C"/>
+                </regex>
+                <regex value="0x57[0-5]\p{XDigit}[258b][3-6][26ae]\p{XDigit}">
+                    <requires nodename="RHW-8C"/>
+                    <requires nodename="RHW-10C"/>
+                </regex>
+                <regex value="0x5728[1-9a-f]\p{XDigit}{1}[0-7]\p{XDigit}"/>
+                <regex value="0x57[0-5]\p{XDigit}[258b]4[26ae]\p{XDigit}"/>
+            </node>
+            <node name="RHW-8C">
+                <regex value="0x5729\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[258b]5[26ae]\p{XDigit}"/>
+            </node>
+            <node name="RHW-10C">
+                <regex value="0x572a\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[258b]6[26ae]\p{XDigit}"/>
+            </node>
+        </node>
+        <node name="L3 networks">
+            <regex value="0x573\p{XDigit}{5}"/>
+            <regex value="0x57[0-5]\p{XDigit}([147a][a-f]|[258b][0-6])[37bf]\p{XDigit}"/>
+            <node name="MIS">
+                <regex value="0x5732\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[147a]c[3b]\p{XDigit}"/>
+            </node>
+            <node name="RHW-4">
+                <regex value="0x5733\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[147a]d[37bf]\p{XDigit}"/>
+            </node>
+            <node name="RHW-6S">
+                <regex value="0x5734\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[147a]e[37bf]\p{XDigit}"/>
+            </node>
+        </node>
+        <node name="L4 networks">
+            <regex value="0x574\p{XDigit}{5}"/>
+            <node name="MIS">
+                <regex value="0x5742\p{XDigit}{4}"/>
+            </node>
+            <node name="RHW-4">
+                <regex value="0x5743\p{XDigit}{4}"/>
+            </node>
+            <node name="RHW-6S">
+                <regex value="0x5744\p{XDigit}{4}"/>
+            </node>
+        </node>
+        <node name="DDRHW">
+            <regex value="0x575\p{XDigit}{5}"/>
+            <node name="RHW-4">
+                <regex value="0x5753\p{XDigit}{4}"/>
+            </node>
+        </node>
+        <node name="FARHW">
+            <regex value="0x57b\p{XDigit}{5}"/>
+        </node>
+        <node name="3L-Crossings">
+            <regex value="0x57a\p{XDigit}{5}"/>
+        </node>
+    </node>
+    <node name="Street Addon Mod">
+        <regex value="0x5e5\p{XDigit}{5}"/>
+        <node name="Set 1 - Parking Lots">
+            <regex value="0x5e5\p{XDigit}{2}1\p{XDigit}{2}"/>
+        </node>
+        <node name="Set 2 - Herringbone Brick Streets">
+            <regex value="0x5e5\p{XDigit}{2}2\p{XDigit}{2}"/>
+        </node>
+        <node name="Set 3 - PEG Dirt Streets">
+            <regex value="0x5e5\p{XDigit}{2}3\p{XDigit}{2}"/>
+        </node>
+        <node name="Set 4 - PEG Gravel Streets">
+            <regex value="0x5e5\p{XDigit}{2}4\p{XDigit}{2}"/>
+        </node>
+        <node name="Set 5 - Trolca Dirt Streets">
+            <regex value="0x5e5\p{XDigit}{2}5\p{XDigit}{2}"/>
+        </node>
+        <node name="Set 6 - Klinker Streets">
+            <regex value="0x5e5\p{XDigit}{2}6\p{XDigit}{2}"/>
+        </node>
+        <node name="Set 7 - Asphalt Streets">
+            <regex value="0x5e5\p{XDigit}{2}7\p{XDigit}{2}"/>
+        </node>
+        <node name="Set 8 - Cobblestone Streets">
+            <regex value="0x5e5\p{XDigit}{2}8\p{XDigit}{2}"/>
+        </node>
+        <node name="Set 9 - Brick Streets">
+            <regex value="0x5e5\p{XDigit}{2}9\p{XDigit}{2}"/>
+        </node>
+        <node name="Set 10 - Japanese Streets">
+            <regex value="0x5e5\p{XDigit}{2}a\p{XDigit}{2}"/>
+        </node>
+    </node>
+</iid_tree>

--- a/src/scripts/RUL2_IID_structure_noRHW.xml
+++ b/src/scripts/RUL2_IID_structure_noRHW.xml
@@ -1,0 +1,348 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE iid_tree SYSTEM "RUL2_IID_structure.dtd">
+<iid_tree>
+    <node name="El Rail over Avenue">
+        <regex value="0x5f85\p{XDigit}{4}"/>
+    </node>
+    <node name="Elevated Road Networks">
+        <regex value="0x5c0[0-8]\p{XDigit}{4}"/>
+        <regex value="0x57[0-4][0-9a]1[1-3][12]\p{XDigit}"/>
+    </node>
+    <node name="Ground Light Rail">
+        <regex value="0x5f88\p{XDigit}{4}"/>
+        <regex value="0x57[0-4][0-9a][147a][78]0\p{XDigit}"/>
+        <node name="Urban GLR">
+            <regex value="0x5f88[0-3]\p{XDigit}{3}"/>
+        </node>
+        <node name="Rural GLR">
+            <regex value="0x5f88[4-7]\p{XDigit}{3}"/>
+        </node>
+        <node name="GLR Extension Set 1">
+            <regex value="0x5f88[89ab]\p{XDigit}{3}"/>
+        </node>
+        <node name="GLR Extension Set 2">
+            <regex value="0x5f88[c-f]\p{XDigit}{3}"/>
+        </node>
+    </node>
+    <node name="High Speed Rail">
+        <regex value="0x5d[dc]\p{XDigit}{5}"/>
+        <regex value="0x57[0-4][0-9a][147a]9\p{XDigit}5"/>
+    </node>
+    <node name="Network Widening Mod">
+        <regex value="0x51[0-2]\p{XDigit}{5}"/>
+        <regex value="0x57[0-4][0-9a]([258b][7-9a-f]|[369c][0-5])\p{XDigit}{2}"/>
+        <node name="NWM TLA-3">
+            <regex value="0x5100\p{XDigit}{4}"/>
+            <regex value="0x57[0-4][0-9a][258b]7\p{XDigit}{2}"/>
+        </node>
+        <node name="NWM AVE-2">
+            <regex value="0x5101\p{XDigit}{4}"/>
+            <regex value="0x57[0-4][0-9a][258b]8\p{XDigit}{2}"/>
+        </node>
+        <node name="NWM ARD-3">
+            <regex value="0x5102\p{XDigit}{4}"/>
+            <regex value="0x57[0-4][0-9a][258b]9\p{XDigit}{2}"/>
+        </node>
+        <node name="NWM OWR-1">
+            <regex value="0x5103\p{XDigit}{4}"/>
+            <regex value="0x57[0-4][0-9a][258b]a\p{XDigit}{2}"/>
+        </node>
+        <node name="NWM OWR-3">
+            <regex value="0x5104\p{XDigit}{4}"/>
+            <regex value="0x57[0-4][0-9a][258b]b\p{XDigit}{2}"/>
+        </node>
+        <node name="NWM NRD-4">
+            <regex value="0x5105\p{XDigit}{4}"/>
+            <regex value="0x57[0-4][0-9a][258b]c\p{XDigit}{2}"/>
+        </node>
+        <node name="NWM TLA-5">
+            <regex value="0x5110\p{XDigit}{4}"/>
+            <regex value="0x57[0-4][0-9a][258b]d\p{XDigit}{2}"/>
+        </node>
+        <node name="NWM OWR-4">
+            <regex value="0x5111\p{XDigit}{4}"/>
+            <regex value="0x57[0-4][0-9a][258b]e\p{XDigit}{2}"/>
+        </node>
+        <node name="NWM OWR-5">
+            <regex value="0x5112\p{XDigit}{4}"/>
+            <regex value="0x57[0-4][0-9a][258b]f\p{XDigit}{2}"/>
+        </node>
+        <node name="NWM RD-4">
+            <regex value="0x5113\p{XDigit}{4}"/>
+            <regex value="0x57[0-4][0-9a][258b]0\p{XDigit}{2}"/>
+        </node>
+        <node name="NWM RD-6">
+            <regex value="0x5114\p{XDigit}{4}"/>
+            <regex value="0x57[0-4][0-9a][258b]1\p{XDigit}{2}"/>
+        </node>
+        <node name="NWM Triple-Tile Networks">
+            <regex value="0x512\p{XDigit}{5}"/>
+            <regex value="0x57[0-4][0-9a][258b][2-5]\p{XDigit}{2}"/>
+        </node>
+    </node>
+    <node name="Real Highway Mod" selected="true">
+        <regex value="0x57\p{XDigit}{6}"/>
+        <node name="L0 networks" selected="true">
+            <regex value="0x570\p{XDigit}{5}"/>
+            <regex value="0x57[0-5]\p{XDigit}([147a][a-f]|[258b][0-6])[048c]\p{XDigit}"/>
+            <node name="RHW-2" selected="true"/>
+            <node name="RHW-3" selected="true">
+                <regex value="0x5701\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[147a]b[08]\p{XDigit}"/>
+            </node>
+            <node name="MIS" selected="true">
+                <regex value="0x5702\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[147a]c[08]\p{XDigit}"/>
+            </node>
+            <node name="RHW-4" selected="true">
+                <regex value="0x5703\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[147a]d[048c]\p{XDigit}"/>
+            </node>
+            <node name="RHW-6S" selected="true">
+                <regex value="0x5704\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[147a]e[048c]\p{XDigit}"/>
+            </node>
+            <node name="RHW-8S" selected="true">
+                <regex value="0x570[5-7]\p{XDigit}{4}">
+                    <requires nodename="RHW-10S"/>
+                    <requires nodename="RHW-12S"/>
+                </regex>
+                <regex value="0x57[0-5]\p{XDigit}([147a]f|[258b][0-2])[048c]\p{XDigit}">
+                    <requires nodename="RHW-10S"/>
+                    <requires nodename="RHW-12S"/>
+                </regex>
+                <regex value="0x5705[1-9a-f]\p{XDigit}{1}[0-7]\p{XDigit}"/>
+                <regex value="0x57[0-5]\p{XDigit}[258b]0[048c]\p{XDigit}"/>
+            </node>
+            <node name="RHW-10S" selected="true">
+                <regex value="0x5706\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[258b]1[048c]\p{XDigit}"/>
+            </node>
+            <node name="RHW-12S" selected="true">
+                <regex value="0x5707\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[258b]2[048c]\p{XDigit}"/>
+            </node>
+            <node name="RHW-6C" selected="true">
+                <regex value="0x570[89a]\p{XDigit}{4}">
+                    <requires nodename="RHW-8C"/>
+                    <requires nodename="RHW-10C"/>
+                </regex>
+                <regex value="0x57[0-5]\p{XDigit}[258b][3-6][048c]\p{XDigit}">
+                    <requires nodename="RHW-8C"/>
+                    <requires nodename="RHW-10C"/>
+                </regex>
+                <regex value="0x5708[1-9a-f]\p{XDigit}{1}[0-7]\p{XDigit}"/>
+                <regex value="0x57[0-5]\p{XDigit}[258b]4[048c]\p{XDigit}"/>
+            </node>
+            <node name="RHW-8C" selected="true">
+                <regex value="0x5709\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[258b]5[048c]\p{XDigit}"/>
+            </node>
+            <node name="RHW-10C" selected="true">
+                <regex value="0x570a\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[258b]6[048c]\p{XDigit}"/>
+            </node>
+        </node>
+        <node name="L1 networks" selected="true">
+            <regex value="0x571\p{XDigit}{5}"/>
+            <regex value="0x57[0-5]\p{XDigit}([147a][a-f]|[258b][0-6])[159d]\p{XDigit}"/>
+            <node name="RHW-2" selected="true">
+                <regex value="0x5710\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[147a]a[19]\p{XDigit}"/>
+            </node>
+            <node name="RHW-3" selected="true">
+                <regex value="0x5711\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[147a]b[19]\p{XDigit}"/>
+            </node>
+            <node name="MIS" selected="true">
+                <regex value="0x5712\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[147a]c[19]\p{XDigit}"/>
+            </node>
+            <node name="RHW-4" selected="true">
+                <regex value="0x5713\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[147a]d[159d]\p{XDigit}"/>
+            </node>
+            <node name="RHW-6S" selected="true">
+                <regex value="0x5714\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[147a]e[159d]\p{XDigit}"/>
+            </node>
+            <node name="RHW-8S" selected="true">
+                <regex value="0x571[5-7]\p{XDigit}{4}">
+                    <requires nodename="RHW-10S"/>
+                    <requires nodename="RHW-12S"/>
+                </regex>
+                <regex value="0x57[0-5]\p{XDigit}([147a]f|[258b][0-2])[159d]\p{XDigit}">
+                    <requires nodename="RHW-10S"/>
+                    <requires nodename="RHW-12S"/>
+                </regex>
+                <regex value="0x5715[1-9a-f]\p{XDigit}{1}[0-7]\p{XDigit}"/>
+                <regex value="0x57[0-5]\p{XDigit}[258b]0[159d]\p{XDigit}"/>
+            </node>
+            <node name="RHW-10S" selected="true">
+                <regex value="0x5716\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[258b]1[159d]\p{XDigit}"/>
+            </node>
+            <node name="RHW-12S" selected="true">
+                <regex value="0x5717\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[258b]2[159d]\p{XDigit}"/>
+            </node>
+            <node name="RHW-6C" selected="true">
+                <regex value="0x571[89a]\p{XDigit}{4}">
+                    <requires nodename="RHW-8C"/>
+                    <requires nodename="RHW-10C"/>
+                </regex>
+                <regex value="0x57[0-5]\p{XDigit}[258b][3-6][159d]\p{XDigit}">
+                    <requires nodename="RHW-8C"/>
+                    <requires nodename="RHW-10C"/>
+                </regex>
+                <regex value="0x5718[1-9a-f]\p{XDigit}{1}[0-7]\p{XDigit}"/>
+                <regex value="0x57[0-5]\p{XDigit}[258b]4[159d]\p{XDigit}"/>
+            </node>
+            <node name="RHW-8C" selected="true">
+                <regex value="0x5719\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[258b]5[159d]\p{XDigit}"/>
+            </node>
+            <node name="RHW-10C" selected="true">
+                <regex value="0x571a\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[258b]6[159d]\p{XDigit}"/>
+            </node>
+        </node>
+        <node name="L2 networks" selected="true">
+            <regex value="0x572\p{XDigit}{5}"/>
+            <regex value="0x57[0-5]\p{XDigit}([147a][a-f]|[258b][0-6])[26ae]\p{XDigit}"/>
+            <node name="RHW-2" selected="true">
+                <regex value="0x5720\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[147a]a[2a]\p{XDigit}"/>
+            </node>
+            <node name="RHW-3" selected="true">
+                <regex value="0x5721\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[147a]b[2a]\p{XDigit}"/>
+            </node>
+            <node name="MIS" selected="true">
+                <regex value="0x5722\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[147a]c[2a]\p{XDigit}"/>
+            </node>
+            <node name="RHW-4" selected="true">
+                <regex value="0x5723\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[147a]d[26ae]\p{XDigit}"/>
+            </node>
+            <node name="RHW-6S" selected="true">
+                <regex value="0x5724\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[147a]e[26ae]\p{XDigit}"/>
+            </node>
+            <node name="RHW-8S" selected="true">
+                <regex value="0x572[5-7]\p{XDigit}{4}">
+                    <requires nodename="RHW-10S"/>
+                    <requires nodename="RHW-12S"/>
+                </regex>
+                <regex value="0x57[0-5]\p{XDigit}([147a]f|[258b][0-2])[26ae]\p{XDigit}">
+                    <requires nodename="RHW-10S"/>
+                    <requires nodename="RHW-12S"/>
+                </regex>
+                <regex value="0x5725[1-9a-f]\p{XDigit}{1}[0-7]\p{XDigit}"/>
+                <regex value="0x57[0-5]\p{XDigit}[258b]0[26ae]\p{XDigit}"/>
+            </node>
+            <node name="RHW-10S" selected="true">
+                <regex value="0x5726\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[258b]1[26ae]\p{XDigit}"/>
+            </node>
+            <node name="RHW-12S" selected="true">
+                <regex value="0x5727\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[258b]2[26ae]\p{XDigit}"/>
+            </node>
+            <node name="RHW-6C" selected="true">
+                <regex value="0x572[89a]\p{XDigit}{4}">
+                    <requires nodename="RHW-8C"/>
+                    <requires nodename="RHW-10C"/>
+                </regex>
+                <regex value="0x57[0-5]\p{XDigit}[258b][3-6][26ae]\p{XDigit}">
+                    <requires nodename="RHW-8C"/>
+                    <requires nodename="RHW-10C"/>
+                </regex>
+                <regex value="0x5728[1-9a-f]\p{XDigit}{1}[0-7]\p{XDigit}"/>
+                <regex value="0x57[0-5]\p{XDigit}[258b]4[26ae]\p{XDigit}"/>
+            </node>
+            <node name="RHW-8C" selected="true">
+                <regex value="0x5729\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[258b]5[26ae]\p{XDigit}"/>
+            </node>
+            <node name="RHW-10C" selected="true">
+                <regex value="0x572a\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[258b]6[26ae]\p{XDigit}"/>
+            </node>
+        </node>
+        <node name="L3 networks" selected="true">
+            <regex value="0x573\p{XDigit}{5}"/>
+            <regex value="0x57[0-5]\p{XDigit}([147a][a-f]|[258b][0-6])[37bf]\p{XDigit}"/>
+            <node name="MIS" selected="true">
+                <regex value="0x5732\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[147a]c[3b]\p{XDigit}"/>
+            </node>
+            <node name="RHW-4" selected="true">
+                <regex value="0x5733\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[147a]d[37bf]\p{XDigit}"/>
+            </node>
+            <node name="RHW-6S" selected="true">
+                <regex value="0x5734\p{XDigit}{4}"/>
+                <regex value="0x57[0-5]\p{XDigit}[147a]e[37bf]\p{XDigit}"/>
+            </node>
+        </node>
+        <node name="L4 networks" selected="true">
+            <regex value="0x574\p{XDigit}{5}"/>
+            <node name="MIS" selected="true">
+                <regex value="0x5742\p{XDigit}{4}"/>
+            </node>
+            <node name="RHW-4" selected="true">
+                <regex value="0x5743\p{XDigit}{4}"/>
+            </node>
+            <node name="RHW-6S" selected="true">
+                <regex value="0x5744\p{XDigit}{4}"/>
+            </node>
+        </node>
+        <node name="DDRHW" selected="true">
+            <regex value="0x575\p{XDigit}{5}"/>
+            <node name="RHW-4" selected="true">
+                <regex value="0x5753\p{XDigit}{4}"/>
+            </node>
+        </node>
+        <node name="FARHW" selected="true">
+            <regex value="0x57b\p{XDigit}{5}"/>
+        </node>
+        <node name="3L-Crossings" selected="true">
+            <regex value="0x57a\p{XDigit}{5}"/>
+        </node>
+    </node>
+    <node name="Street Addon Mod">
+        <regex value="0x5e5\p{XDigit}{5}"/>
+        <node name="Set 1 - Parking Lots">
+            <regex value="0x5e5\p{XDigit}{2}1\p{XDigit}{2}"/>
+        </node>
+        <node name="Set 2 - Herringbone Brick Streets">
+            <regex value="0x5e5\p{XDigit}{2}2\p{XDigit}{2}"/>
+        </node>
+        <node name="Set 3 - PEG Dirt Streets">
+            <regex value="0x5e5\p{XDigit}{2}3\p{XDigit}{2}"/>
+        </node>
+        <node name="Set 4 - PEG Gravel Streets">
+            <regex value="0x5e5\p{XDigit}{2}4\p{XDigit}{2}"/>
+        </node>
+        <node name="Set 5 - Trolca Dirt Streets">
+            <regex value="0x5e5\p{XDigit}{2}5\p{XDigit}{2}"/>
+        </node>
+        <node name="Set 6 - Klinker Streets">
+            <regex value="0x5e5\p{XDigit}{2}6\p{XDigit}{2}"/>
+        </node>
+        <node name="Set 7 - Asphalt Streets">
+            <regex value="0x5e5\p{XDigit}{2}7\p{XDigit}{2}"/>
+        </node>
+        <node name="Set 8 - Cobblestone Streets">
+            <regex value="0x5e5\p{XDigit}{2}8\p{XDigit}{2}"/>
+        </node>
+        <node name="Set 9 - Brick Streets">
+            <regex value="0x5e5\p{XDigit}{2}9\p{XDigit}{2}"/>
+        </node>
+        <node name="Set 10 - Japanese Streets">
+            <regex value="0x5e5\p{XDigit}{2}a\p{XDigit}{2}"/>
+        </node>
+    </node>
+</iid_tree>

--- a/src/scripts/compile-release-controllers.sh
+++ b/src/scripts/compile-release-controllers.sh
@@ -34,7 +34,7 @@ COMPILER_URL="https://github.com/memo33/NAMControllerCompiler/releases/download/
 if [ ! -e "$COMPILER_ARCHIVE" ]
 then
     # download compiler if it does not yet exist
-    wget -O "$COMPILER_ARCHIVE" "$COMPILER_URL"
+    curl -L "$COMPILER_URL" > "$COMPILER_ARCHIVE"
 fi
 unzip -d "$TEMP" "$COMPILER_ARCHIVE"
 

--- a/src/scripts/compile-release-controllers.sh
+++ b/src/scripts/compile-release-controllers.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+#
+# This script compiles the different variants of the NAM controller for
+# release, using the CLI of the controller compiler.
+#
+# Call it from the project root:
+#
+#   ./src/scripts/compile-release-controllers.sh
+#
+# The compiled controllers are located at `./target/controllers/`.
+#
+# The LText files still need to be adjusted manually.
+set -e
+
+if [ ! -e "Controller" ]
+then
+    echo "Call this script from the root directory of the Network-Addon-Mod repository."
+    exit 1
+fi
+
+PROJECT_ROOT="$(pwd)"
+DEST="target/controllers"
+TEMP="$DEST/temp"
+mkdir -p "$TEMP"
+
+COMPILER_ARCHIVE="target/NAMControllerCompiler_1.3.1.zip"
+COMPILER_URL="https://github.com/memo33/NAMControllerCompiler/releases/download/v1.3.1/NAMControllerCompiler_1.3.1.zip"
+
+if [ ! -e "$COMPILER_ARCHIVE" ]
+then
+    # download compiler if it does not yet exist
+    wget -O "$COMPILER_ARCHIVE" "$COMPILER_URL"
+fi
+unzip -d "$TEMP" "$COMPILER_ARCHIVE"
+
+
+# RHD 4GB Full
+cp "src/scripts/RUL2_IID_structure_full.xml" "$TEMP/resources/xml/RUL2_IID_structure.xml"
+(cd "$TEMP" && java -jar NAMControllerCompiler.jar "$PROJECT_ROOT/Controller" '../@1=0 NAM Controller_RHD_4GB_Full' 1 0 0 0 0 0 0 0 0 0 0)
+
+# LHD 4GB Full
+cp "src/scripts/RUL2_IID_structure_full.xml" "$TEMP/resources/xml/RUL2_IID_structure.xml"
+(cd "$TEMP" && java -jar NAMControllerCompiler.jar "$PROJECT_ROOT/Controller" '../@2-0 NAM Controller_LHD_4GB_Full' 0 0 0 0 0 0 0 0 0 0 0)
+
+# RHD 4GB Full
+cp "src/scripts/RUL2_IID_structure_noRHW.xml" "$TEMP/resources/xml/RUL2_IID_structure.xml"
+(cd "$TEMP" && java -jar NAMControllerCompiler.jar "$PROJECT_ROOT/Controller" '../@3-0 NAM Controller_RHD_LowRAM_NoRHW' 1 0 0 0 0 0 0 0 0 0 0)
+
+# LHD 4GB Full
+cp "src/scripts/RUL2_IID_structure_noRHW.xml" "$TEMP/resources/xml/RUL2_IID_structure.xml"
+(cd "$TEMP" && java -jar NAMControllerCompiler.jar "$PROJECT_ROOT/Controller" '../@4-0 NAM Controller_LHD_LowRAM_NoRHW' 0 0 0 0 0 0 0 0 0 0 0)
+
+rm -rf "$TEMP"

--- a/src/scripts/compile-release-controllers.sh
+++ b/src/scripts/compile-release-controllers.sh
@@ -5,11 +5,17 @@
 #
 # Call it from the project root:
 #
+#   ./src/scripts/compile-release-controllers.sh "<version>"
+#
+# The LText files are updated with the concrete version information.
+# If the <version> argument is missing, the LTexts default to just the timestamp, as usual:
+#
 #   ./src/scripts/compile-release-controllers.sh
 #
 # The compiled controllers are located at `./target/controllers/`.
-#
-# The LText files still need to be adjusted manually.
+# The selections for Full/Low-RAM variants are taken from these files:
+#   src/scripts/RUL2_IID_structure_full.xml
+#   src/scripts/RUL2_IID_structure_noRHW.xml
 set -e
 
 if [ ! -e "Controller" ]
@@ -19,12 +25,11 @@ then
 fi
 
 PROJECT_ROOT="$(pwd)"
-DEST="target/controllers"
-TEMP="$DEST/temp"
+TEMP="target/controllers/temp"
 mkdir -p "$TEMP"
 
-COMPILER_ARCHIVE="target/NAMControllerCompiler_1.3.1.zip"
-COMPILER_URL="https://github.com/memo33/NAMControllerCompiler/releases/download/v1.3.1/NAMControllerCompiler_1.3.1.zip"
+COMPILER_ARCHIVE="target/NAMControllerCompiler_2.0.0.zip"
+COMPILER_URL="https://github.com/memo33/NAMControllerCompiler/releases/download/2.0.0/NAMControllerCompiler_2.0.0.zip"
 
 if [ ! -e "$COMPILER_ARCHIVE" ]
 then
@@ -34,20 +39,44 @@ fi
 unzip -d "$TEMP" "$COMPILER_ARCHIVE"
 
 
+VERSION="$1"
+DRIVESIDE='XHD'
+VARIANT=''
+DATESTRING="$(date --utc)"
+ltext() {
+    if [ ! -z "$VERSION" ]
+    then
+        # If an argument was passed to the script, the version is non-empty.
+        printf "NAM Version $VERSION $DRIVESIDE $VARIANT compiled on $DATESTRING"
+    else
+        # Otherwise pass the empty string to the compiler.
+        printf ""
+    fi
+}
+
+
 # RHD 4GB Full
+VARIANT='(4GB Full)'
+DRIVESIDE='RHD'
 cp "src/scripts/RUL2_IID_structure_full.xml" "$TEMP/resources/xml/RUL2_IID_structure.xml"
-(cd "$TEMP" && java -jar NAMControllerCompiler.jar "$PROJECT_ROOT/Controller" '../@1=0 NAM Controller_RHD_4GB_Full' 1 0 0 0 0 0 0 0 0 0 0)
+(cd "$TEMP" && java -jar NAMControllerCompiler.jar "$PROJECT_ROOT/Controller" '../@1=0 NAM Controller_RHD_4GB_Full' 1 "$(ltext)")
 
 # LHD 4GB Full
+VARIANT='(4GB Full)'
+DRIVESIDE='LHD'
 cp "src/scripts/RUL2_IID_structure_full.xml" "$TEMP/resources/xml/RUL2_IID_structure.xml"
-(cd "$TEMP" && java -jar NAMControllerCompiler.jar "$PROJECT_ROOT/Controller" '../@2-0 NAM Controller_LHD_4GB_Full' 0 0 0 0 0 0 0 0 0 0 0)
+(cd "$TEMP" && java -jar NAMControllerCompiler.jar "$PROJECT_ROOT/Controller" '../@2-0 NAM Controller_LHD_4GB_Full' 0 "$(ltext)")
 
-# RHD 4GB Full
+# RHD no-RHW
+VARIANT='(Low-RAM no-RHW)'
+DRIVESIDE='RHD'
 cp "src/scripts/RUL2_IID_structure_noRHW.xml" "$TEMP/resources/xml/RUL2_IID_structure.xml"
-(cd "$TEMP" && java -jar NAMControllerCompiler.jar "$PROJECT_ROOT/Controller" '../@3-0 NAM Controller_RHD_LowRAM_NoRHW' 1 0 0 0 0 0 0 0 0 0 0)
+(cd "$TEMP" && java -jar NAMControllerCompiler.jar "$PROJECT_ROOT/Controller" '../@3-0 NAM Controller_RHD_LowRAM_NoRHW' 1 "$(ltext)")
 
-# LHD 4GB Full
+# LHD no-RHW
+VARIANT='(Low-RAM no-RHW)'
+DRIVESIDE='LHD'
 cp "src/scripts/RUL2_IID_structure_noRHW.xml" "$TEMP/resources/xml/RUL2_IID_structure.xml"
-(cd "$TEMP" && java -jar NAMControllerCompiler.jar "$PROJECT_ROOT/Controller" '../@4-0 NAM Controller_LHD_LowRAM_NoRHW' 0 0 0 0 0 0 0 0 0 0 0)
+(cd "$TEMP" && java -jar NAMControllerCompiler.jar "$PROJECT_ROOT/Controller" '../@4-0 NAM Controller_LHD_LowRAM_NoRHW' 0 "$(ltext)")
 
 rm -rf "$TEMP"

--- a/src/scripts/compile-release-inruls.sh
+++ b/src/scripts/compile-release-inruls.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+#
+# This script compiles all INRUL files for inclusion in the installer.
+#
+#   ./src/scripts/compile-release-inruls.sh
+#
+# The compiled INRUL files are located at `./target/controllers/`.
+
+set -e
+
+if [ ! -e "Controller" ]
+then
+    echo "Call this script from the root directory of the Network-Addon-Mod repository."
+    exit 1
+fi
+
+PROJECT_ROOT="$(pwd)"
+TEMP="target/controllers/temp"
+mkdir -p "$TEMP"
+
+BUILDRULS_ARCHIVE="target/BuildRULs_01.zip"
+BUILDRULS_URL="https://www.dropbox.com/s/ckwhy11xxaz3z1q/BuildRULs_01.zip?dl=1"
+
+if [ ! -e "$BUILDRULS_ARCHIVE" ]
+then
+    # download compiler if it does not yet exist
+    curl -L "$BUILDRULS_URL" > "$BUILDRULS_ARCHIVE"
+fi
+unzip -d "$TEMP" "$BUILDRULS_ARCHIVE"
+
+# build all INRULs
+(cd "$TEMP/BuildRULs_01" && java -jar BuildRULs.jar -f "$PROJECT_ROOT/Controller/INRULs/" "$PROJECT_ROOT/Controller/INRULs/")
+
+# RHD 4GB Full
+DESTDIR="target/controllers/@1=0 NAM Controller_RHD_4GB_Full/"
+mkdir -p "$DESTDIR"
+cp -p "$PROJECT_ROOT/Controller/INRULs/NetworkAddonMod_IndividualNetworkRULs_RHD.dat" "$DESTDIR"
+
+# LHD 4GB Full
+DESTDIR="target/controllers/@2-0 NAM Controller_LHD_4GB_Full/"
+mkdir -p "$DESTDIR"
+cp -p "$PROJECT_ROOT/Controller/INRULs/NetworkAddonMod_IndividualNetworkRULs_LHD.dat" "$DESTDIR"
+
+# RHD no-RHW
+DESTDIR="target/controllers/@3-0 NAM Controller_RHD_LowRAM_NoRHW/"
+mkdir -p "$DESTDIR"
+cp -p "$PROJECT_ROOT/Controller/INRULs/NetworkAddonMod_IndividualNetworkRULs_RHD.dat" "$DESTDIR"
+
+# LHD no-RHW
+DESTDIR="target/controllers/@4-0 NAM Controller_LHD_LowRAM_NoRHW/"
+mkdir -p "$DESTDIR"
+cp -p "$PROJECT_ROOT/Controller/INRULs/NetworkAddonMod_IndividualNetworkRULs_LHD.dat" "$DESTDIR"
+
+# Avenue turning lanes
+cp -p "$PROJECT_ROOT/Controller/INRULs/NetworkAddonMod_TurningLanes_Avenues_Plugin_INRULs.dat" "target/controllers/"
+
+rm -rf "$TEMP"


### PR DESCRIPTION
This automates the process of creating the controllers for release, using a bash script.

There is a [new release of the compiler](https://github.com/memo33/NAMControllerCompiler/releases/tag/2.0.0) for this purpose, which is automatically downloaded by the script.

Usage:

    ./src/scripts/compile-release-controllers.sh "<version>"

Feel free to make any other adjustments.
