### PR TITLE
change button LTEXTs GID from 0x123006BB to 0x123007BB

### DIFF
--- a/ltext/buttons.pot
+++ b/ltext/buttons.pot
@@ -29,7 +29,7 @@ msgid ""
 "Button contains Parallel Ramps for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-52001000"
+msgctxt "2026960B-123007BB-52001000"
 msgid ""
 "Parallel Ramps\n"
 "\n"
@@ -43,7 +43,7 @@ msgid ""
 "Button contains Overpass/Perpendicular Ramps for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-52001010"
+msgctxt "2026960B-123007BB-52001010"
 msgid ""
 "Overpass/Perpendicular Ramps\n"
 "\n"
@@ -57,7 +57,7 @@ msgid ""
 "Button contains Cloverleaves for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-52001020"
+msgctxt "2026960B-123007BB-52001020"
 msgid ""
 "Cloverleaf\n"
 "\n"
@@ -71,7 +71,7 @@ msgid ""
 "Button contains T-Intersections for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-52002000"
+msgctxt "2026960B-123007BB-52002000"
 msgid ""
 "T-Intersections\n"
 "\n"
@@ -82,7 +82,7 @@ msgctxt "2026960B-123006AA-6A470100"
 msgid "With the Canal Addon Mod you can build functional canals"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A470100"
+msgctxt "2026960B-123007BB-6A470100"
 msgid "Canal Addon Mod"
 msgstr ""
 
@@ -95,7 +95,7 @@ msgid ""
 "Drag the listed network through the FLEX/Starter Piece to construct the turn lane."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A470460"
+msgctxt "2026960B-123007BB-6A470460"
 msgid "FLEX Turn Lanes (FTLs)"
 msgstr ""
 
@@ -106,7 +106,7 @@ msgid ""
 "Button contains QuickTurn setups, which are FLEX intersections with turn lanes"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A4704A0"
+msgctxt "2026960B-123007BB-6A4704A0"
 msgid "QuickTurn (Pre-Built FLEX Turn Lane Setups)"
 msgstr ""
 
@@ -117,7 +117,7 @@ msgid ""
 "Button contains Turn Lane and Slip Lane Puzzle Pieces for various networks and configurations"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A4704E0"
+msgctxt "2026960B-123007BB-6A4704E0"
 msgid "TuLEPs (Turn Lane Extension Pieces) (OLD)"
 msgstr ""
 
@@ -128,7 +128,7 @@ msgid ""
 "Button contains Turn Lane puzzle pieces for 7-lane Turning Lane Avenue (TLA-7) and 6-lane Avenue (AVE-6) networks"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A470600"
+msgctxt "2026960B-123007BB-6A470600"
 msgid "Network Widening Mod (NWM) Triple-Tile Network Turn Lane Extension Pieces (TuLEPs)"
 msgstr ""
 
@@ -139,7 +139,7 @@ msgid ""
 "Button contains components for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A473141"
+msgctxt "2026960B-123007BB-6A473141"
 msgid ""
 "Symphony Prefab Interchange Components\n"
 "\n"
@@ -153,7 +153,7 @@ msgid ""
 "Button contains components for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A473143"
+msgctxt "2026960B-123007BB-6A473143"
 msgid ""
 "Symphony Ramp Interfaces\n"
 "\n"
@@ -167,7 +167,7 @@ msgid ""
 "The first item is the starter piece."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A474000"
+msgctxt "2026960B-123007BB-6A474000"
 msgid "Single-Track Rail (STR)"
 msgstr ""
 
@@ -180,7 +180,7 @@ msgid ""
 "Drag the RealHighway (RHW-2) network tool through the Starter Piece to construct the desired override network."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475000"
+msgctxt "2026960B-123007BB-6A475000"
 msgid "RealHighway (RHW) Starter Pieces"
 msgstr ""
 
@@ -195,7 +195,7 @@ msgid ""
 "Place down Eraser onto desired tile and redraw anything if needed"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475024"
+msgctxt "2026960B-123007BB-6A475024"
 msgid "Network Eraser"
 msgstr ""
 
@@ -206,7 +206,7 @@ msgid ""
 "Button contains Filler Pieces to build RHW networks in smaller chunks, in unstable situations"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475050"
+msgctxt "2026960B-123007BB-6A475050"
 msgid "RealHighway Filler Pieces"
 msgstr ""
 
@@ -219,7 +219,7 @@ msgid ""
 "These items are DEPRECATED, and the use of the FLEX Neighbor Connections is recommended instead."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47508C"
+msgctxt "2026960B-123007BB-6A47508C"
 msgid "Old RealHighway Neighbor Connector Puzzle Pieces  - DEPRECATED"
 msgstr ""
 
@@ -232,7 +232,7 @@ msgid ""
 "NOTE: ALL REALHIGHWAY NEIGHBOR CONNECTIONS (EXCEPT RHW-2) ARE REQUIRED TO USE NEIGHBOR CONNECTOR PIECES TO ENSURE PROPERLY FUNCTIONING NEIGHBOR CONNECTIONS--OTHERWISE ONLY FREIGHT TRUCKS WILL USE THE RHW"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475090"
+msgctxt "2026960B-123007BB-6A475090"
 msgid "RealHighway FLEX Neighbor Connector Pieces (FLEX-NC)"
 msgstr ""
 
@@ -241,7 +241,7 @@ msgid ""
 "For building DEPRECATED RealHighway Ramp Interfaces.  All of the functionality of the 47 pieces contained and many more are covered by the FLEXRamp system."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475100"
+msgctxt "2026960B-123007BB-6A475100"
 msgid "OBSOLETE RealHighway Ramp Interfaces (Static Puzzle-Based)"
 msgstr ""
 
@@ -252,7 +252,7 @@ msgid ""
 "Button contains Type B Ramp Interface Pieces for building interchanges with the RHW"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475104"
+msgctxt "2026960B-123007BB-6A475104"
 msgid "RealHighway Type B Ramp Interfaces"
 msgstr ""
 
@@ -263,7 +263,7 @@ msgid ""
 "Button contains Type E Ramp Interface Pieces for building interchanges with the RHW"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475109"
+msgctxt "2026960B-123007BB-6A475109"
 msgid "RealHighway Type E Ramp Interfaces"
 msgstr ""
 
@@ -274,7 +274,7 @@ msgid ""
 "Button contains Type D Ramp Interface Pieces for building interchanges with the RHW"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47510A"
+msgctxt "2026960B-123007BB-6A47510A"
 msgid "RealHighway Type D Ramp Interfaces"
 msgstr ""
 
@@ -285,7 +285,7 @@ msgid ""
 "Deprecated puzzle piece ramps follow Volleyball pieces - use of the FLEXRamps or Draggable Ramp Interfaces (DRIs) is recommended instead of using the deprecated puzzle pieces."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475118"
+msgctxt "2026960B-123007BB-6A475118"
 msgid "Specialized and Deprecated RealHighway Ramp Interfaces and Volleyball Crossings (Static Puzzle-Based)"
 msgstr ""
 
@@ -296,7 +296,7 @@ msgid ""
 "Button contains FLEX pieces for different overrideable ramp interfaces.  Drag appropriate networks through to convert base ramp to match."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A4751F0"
+msgctxt "2026960B-123007BB-6A4751F0"
 msgid "RealHighway FLEXRamps"
 msgstr ""
 
@@ -307,7 +307,7 @@ msgid ""
 "Button contains pieces to build Wide Curves for the RHW networks"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475220"
+msgctxt "2026960B-123007BB-6A475220"
 msgid "RealHighway Wide-Radius and Multi-Radius (Smooth) Curves"
 msgstr ""
 
@@ -320,7 +320,7 @@ msgid ""
 "These items are DEPRECATED and use of the FLEX Width Transitions (FLEX-WT) is recommended instead."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475300"
+msgctxt "2026960B-123007BB-6A475300"
 msgid "Old RealHighway Width Transition Puzzle Pieces - DEPRECATED"
 msgstr ""
 
@@ -333,7 +333,7 @@ msgid ""
 "All functionality here has been duplicated with the FLEX Height Transitions, and as such, this button is DEPRECATED."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475312"
+msgctxt "2026960B-123007BB-6A475312"
 msgid "Old RealHighway Height Transition Puzzle Pieces  - DEPRECATED"
 msgstr ""
 
@@ -344,7 +344,7 @@ msgid ""
 "Button contains pieces to transition between RHW networks of different heights.  Pieces begin as RHW-2 transitions, and dragging another RHW network into them will convert them to fit."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475330"
+msgctxt "2026960B-123007BB-6A475330"
 msgid "RealHighway FLEX Height Transitions (FLEX-HT)"
 msgstr ""
 
@@ -355,7 +355,7 @@ msgid ""
 "Button contains pieces to transition between RHW networks of different widths.  Dragging another RHW network into them will convert them to fit."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475336"
+msgctxt "2026960B-123007BB-6A475336"
 msgid "RealHighway FLEX Width Transitions (FLEX-WT)"
 msgstr ""
 
@@ -366,7 +366,7 @@ msgid ""
 "Button contains components for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475350"
+msgctxt "2026960B-123007BB-6A475350"
 msgid ""
 "Symphony Transitions\n"
 "\n"
@@ -380,7 +380,7 @@ msgid ""
 "Button contains components for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475366"
+msgctxt "2026960B-123007BB-6A475366"
 msgid ""
 "Symphony Smooth Curves\n"
 "\n"
@@ -396,7 +396,7 @@ msgid ""
 "NOTE: These pieces should NOT be confused with TuLEPs."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475400"
+msgctxt "2026960B-123007BB-6A475400"
 msgid "RealHighway Cosmetic Puzzle Pieces (for 1-Tile Networks)"
 msgstr ""
 
@@ -409,7 +409,7 @@ msgid ""
 "NOTE: These pieces should NOT be confused with TuLEPs."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475410"
+msgctxt "2026960B-123007BB-6A475410"
 msgid "RealHighway Cosmetic Piece Transitions"
 msgstr ""
 
@@ -422,7 +422,7 @@ msgid ""
 "NOTE: These pieces should NOT be confused with TuLEPs."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475440"
+msgctxt "2026960B-123007BB-6A475440"
 msgid "RealHighway Cosmetic Puzzle Pieces (for 2-Tile Networks)"
 msgstr ""
 
@@ -435,7 +435,7 @@ msgid ""
 "NOTE: These pieces should NOT be confused with TuLEPs."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475471"
+msgctxt "2026960B-123007BB-6A475471"
 msgid "RealHighway Cosmetic Puzzle Pieces (for 3-Tile Networks)"
 msgstr ""
 
@@ -448,7 +448,7 @@ msgid ""
 "<DEPRECATED>"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475500"
+msgctxt "2026960B-123007BB-6A475500"
 msgid "ERHW-over-RHW Diagonal Overpass Puzzle Pieces<DEPRECATED>"
 msgstr ""
 
@@ -461,7 +461,7 @@ msgid ""
 "Place overcrossing pieces on top of underground roadways whenever a surface network crosses over, to allow traffic to pass underground."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475600"
+msgctxt "2026960B-123007BB-6A475600"
 msgid "RHW Flexible Underpasses (FLUPs), Draggable Underground Roads (URoads), and Overcrossings"
 msgstr ""
 
@@ -472,7 +472,7 @@ msgid ""
 "Button contains flexible RHW interchange segments.  Drag appropriate networks through to convert base ramp to match, and combine to easily create a full interchange."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475700"
+msgctxt "2026960B-123007BB-6A475700"
 msgid "RealHighway QuickChanges"
 msgstr ""
 
@@ -483,7 +483,7 @@ msgid ""
 "Button contains starter/transition FLEX pieces for different RHW turn lane setups"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475900"
+msgctxt "2026960B-123007BB-6A475900"
 msgid "RealHighway FLEX Turn Lanes (FTLs)"
 msgstr ""
 
@@ -494,7 +494,7 @@ msgid ""
 "Button contains pieces to build FLEXFly Pieces"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475AF3"
+msgctxt "2026960B-123007BB-6A475AF3"
 msgid "RealHighway FLEXFly (LEGACY/DEPRECATED)"
 msgstr ""
 
@@ -505,7 +505,7 @@ msgid ""
 "Button contains pieces to build 3-Level Crossings"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475AF6"
+msgctxt "2026960B-123007BB-6A475AF6"
 msgid "RealHighway 3-Level Crossings"
 msgstr ""
 
@@ -516,7 +516,7 @@ msgid ""
 "Button contains pieces to build FLEXFly Pieces"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475B00"
+msgctxt "2026960B-123007BB-6A475B00"
 msgid "RealHighway FLEXFly"
 msgstr ""
 
@@ -529,7 +529,7 @@ msgid ""
 "NOTE: Most intersections require the use of TuLEPs."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475F00"
+msgctxt "2026960B-123007BB-6A475F00"
 msgid "Fractionally Angled RealHighway Intersections and Transitions"
 msgstr ""
 
@@ -540,7 +540,7 @@ msgid ""
 "Button contains straight pieces and curves to pieces to build Fractionally Angled RealHighway (FARHWs)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475F20"
+msgctxt "2026960B-123007BB-6A475F20"
 msgid "Fractionally Angled RealHighway"
 msgstr ""
 
@@ -551,7 +551,7 @@ msgid ""
 "Button contains pieces to build different FARHW Ramp Interfaces: The C1, F1, C2, F2, and C3 Ramp Interfaces"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475F30"
+msgctxt "2026960B-123007BB-6A475F30"
 msgid "Fractionally Angled RealHighway Ramp Interfaces"
 msgstr ""
 
@@ -562,7 +562,7 @@ msgid ""
 "Button contains Type C Ramp Interface Pieces for building interchanges with the RHW"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475F70"
+msgctxt "2026960B-123007BB-6A475F70"
 msgid "RealHighway Type C Ramp Interfaces"
 msgstr ""
 
@@ -573,7 +573,7 @@ msgid ""
 "Button contains Type F Ramp Interface Pieces for building interchanges with the RHW"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475F71"
+msgctxt "2026960B-123007BB-6A475F71"
 msgid "RealHighway Type F Ramp Interfaces"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgid ""
 "NOTE: Ped Mall Tiles should not be used directly in front of Residential Zones where their zoning arrow is."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A476005"
+msgctxt "2026960B-123007BB-6A476005"
 msgid "Pedestrian Mall Tiles"
 msgstr ""
 
@@ -594,7 +594,7 @@ msgctxt "2026960B-123006AA-6A476100"
 msgid "A collection of pedestrian crossing FLEX pieces. Use them on their own at crossing locations, or as part of pedmall corridors."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A476100"
+msgctxt "2026960B-123007BB-6A476100"
 msgid "Pedestrian Revolution Mod (PRM) FLEX Crossings"
 msgstr ""
 
@@ -605,7 +605,7 @@ msgid ""
 "Button contains several different Puzzle and Helper Pieces for Street"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A476525"
+msgctxt "2026960B-123007BB-6A476525"
 msgid "Diagonal Street Helper Pieces"
 msgstr ""
 
@@ -616,7 +616,7 @@ msgid ""
 "Button contains Starter Pieces for Street Addon Mod (SAM)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A476700"
+msgctxt "2026960B-123007BB-6A476700"
 msgid "Street Addon Mod (SAM)"
 msgstr ""
 
@@ -624,7 +624,7 @@ msgctxt "2026960B-123006AA-6A476905"
 msgid "Plop one of these pieces on a flat area. It will raise or lower the terrain, and then destroy itself, providing a level area for a raised network of your choice. This is fully compatible with all slope mods."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A476905"
+msgctxt "2026960B-123007BB-6A476905"
 msgid "Hole Digger and Raiser Lots"
 msgstr ""
 
@@ -635,7 +635,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Avenues"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A476A00"
+msgctxt "2026960B-123007BB-6A476A00"
 msgid "Avenue Intersections"
 msgstr ""
 
@@ -646,7 +646,7 @@ msgid ""
 "Button contains several different overpasses for Road"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477000"
+msgctxt "2026960B-123007BB-6A477000"
 msgid "Road Overpasses"
 msgstr ""
 
@@ -657,7 +657,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Road"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477005"
+msgctxt "2026960B-123007BB-6A477005"
 msgid "7.5m Elevated Road Viaducts"
 msgstr ""
 
@@ -668,7 +668,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Road"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477200"
+msgctxt "2026960B-123007BB-6A477200"
 msgid "15m Elevated Road Viaducts"
 msgstr ""
 
@@ -679,7 +679,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Road, One-Way Road, or Avenue"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477500"
+msgctxt "2026960B-123007BB-6A477500"
 msgid "Wide Radius Curves (for Road, One-Way Road, Avenue, and Street) (Puzzle Pieces)"
 msgstr ""
 
@@ -690,7 +690,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Road, One-Way Road, and Avenue"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477600"
+msgctxt "2026960B-123007BB-6A477600"
 msgid "Fractionally-Angled Networks (for Road, One-Way Road, and Avenue)"
 msgstr ""
 
@@ -701,7 +701,7 @@ msgid ""
 "Once a puzzle piece is selected, use the [Home] and [End] keys to cycle through the various puzzle piece orientations"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477700"
+msgctxt "2026960B-123007BB-6A477700"
 msgid "Rural Road Puzzle Pieces"
 msgstr ""
 
@@ -712,7 +712,7 @@ msgid ""
 "Button contains pieces to interface between the NAM Elevated Road Puzzle Pieces and RHW networks, including overpasses and intersections"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477800"
+msgctxt "2026960B-123007BB-6A477800"
 msgid "Road/RHW Overpass and Interface Puzzle Pieces (DEPRECATED)"
 msgstr ""
 
@@ -723,7 +723,7 @@ msgid ""
 "Button contains several different FLEX Pieces for various networks"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477900"
+msgctxt "2026960B-123007BB-6A477900"
 msgid "Multi-Radius Curve (MRC) FLEX Pieces for Surface Networks"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgid ""
 "The new Subway-based FLUPs system can be found under the Highways menu."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477A00"
+msgctxt "2026960B-123007BB-6A477A00"
 msgid "Flexible Underpasses (FLUPs)"
 msgstr ""
 
@@ -751,7 +751,7 @@ msgid ""
 "Button contains Starter Pieces for the 3, 5 and 7-lane Turning Lane Avenues (TLA-3,5,7), 2 and 6-lane Avenues (AVE-2,6), 3-lane Asymmetrical Road (ARD-3), 4 and 6-lane Roads RD-4,6) and 1, 3, 4 and 5-lane One-Way Roads (OWR-1,3,4,5)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477B00"
+msgctxt "2026960B-123007BB-6A477B00"
 msgid "Network Widening Mod (NWM) Starter Pieces"
 msgstr ""
 
@@ -762,7 +762,7 @@ msgid ""
 "Button contains Wide-Radius Curve Pieces for the single-tile NWM networks"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477B30"
+msgctxt "2026960B-123007BB-6A477B30"
 msgid "Network Widening Mod (NWM) Curve Pieces"
 msgstr ""
 
@@ -775,7 +775,7 @@ msgid ""
 "Note that most transitions involving single and dual-tile networks can be built using draggable means instead (such as direct connections or using the stub-to-stub method)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477B50"
+msgctxt "2026960B-123007BB-6A477B50"
 msgid "Network Widening Mod (NWM) Transition Pieces"
 msgstr ""
 
@@ -786,7 +786,7 @@ msgid ""
 "Button contains Neighbor Connector Pieces for the TLA-5, RD-4 and RD-6"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477BF0"
+msgctxt "2026960B-123007BB-6A477BF0"
 msgid "Network Widening Mod (NWM) Neighbor Connector Pieces"
 msgstr ""
 
@@ -797,7 +797,7 @@ msgid ""
 "Button contains FLEX Single Tile Roundabouts intersections for various road networks"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477C00"
+msgctxt "2026960B-123007BB-6A477C00"
 msgid "Single Tile Roundabouts"
 msgstr ""
 
@@ -810,7 +810,7 @@ msgid ""
 "Button contains OnSlope Transitions to start Alternate Style Road and Street Viaducts"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477E00"
+msgctxt "2026960B-123007BB-6A477E00"
 msgid "Road Viaduct Alternate Styles"
 msgstr ""
 
@@ -821,7 +821,7 @@ msgid ""
 "Button contains several different Starter and FLEX Pieces for Draggable Elevated Road Viaducts"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477F00"
+msgctxt "2026960B-123007BB-6A477F00"
 msgid "Draggable Elevated Road Viaducts"
 msgstr ""
 
@@ -834,7 +834,7 @@ msgid ""
 "Drag networks under (or over) the mid-section of the overpass to build the crossing.  Most networks and FLEX-based dual-networks are supported."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477F30"
+msgctxt "2026960B-123007BB-6A477F30"
 msgid "FLEX Overpasses"
 msgstr ""
 
@@ -845,7 +845,7 @@ msgid ""
 "Button contains several different overpasses for One-Way Road"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A478000"
+msgctxt "2026960B-123007BB-6A478000"
 msgid "One-Way Road Overpasses"
 msgstr ""
 
@@ -856,7 +856,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for One-Way Road"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A478005"
+msgctxt "2026960B-123007BB-6A478005"
 msgid "15m Elevated One-Way Road Viaducts"
 msgstr ""
 
@@ -867,7 +867,7 @@ msgid ""
 "Button contains pieces to interface between the NAM Elevated One-Way Road Puzzle Pieces and RHW networks, including overpasses and intersections"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A478800"
+msgctxt "2026960B-123007BB-6A478800"
 msgid "One-Way Road/RHW Overpass and Interface Puzzle Pieces (DEPRECATED)"
 msgstr ""
 
@@ -875,7 +875,7 @@ msgctxt "2026960B-123006AA-6A478900"
 msgid "For use of the curved pieces for the Real Expressway Network. Use the Home/End key to rotate the FLEX Piece & use TAB/Shift-TAB (Ctrl-TAB/Ctrl-Shift-TAB on macOS) to cycle through the different types of REW Straights and Curves."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A478900"
+msgctxt "2026960B-123007BB-6A478900"
 msgid "Real Expressway FLEX Piece network tool and Curves."
 msgstr ""
 
@@ -886,7 +886,7 @@ msgid ""
 "Button contains FLEX pieces for different overrideable ramp interfaces.  Drag appropriate networks through to convert base ramp to match."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A478B00"
+msgctxt "2026960B-123007BB-6A478B00"
 msgid "RealExpressway (REW) One-Way Road FLEXRamps"
 msgstr ""
 
@@ -897,7 +897,7 @@ msgid ""
 "Button contains several different overpasses for Avenue"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A479000"
+msgctxt "2026960B-123007BB-6A479000"
 msgid "Avenue Overpasses"
 msgstr ""
 
@@ -908,7 +908,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Avenue"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A479005"
+msgctxt "2026960B-123007BB-6A479005"
 msgid "7.5m Elevated Avenue Viaducts"
 msgstr ""
 
@@ -919,7 +919,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Avenue"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A479200"
+msgctxt "2026960B-123007BB-6A479200"
 msgid "15m Elevated Avenue Viaducts"
 msgstr ""
 
@@ -930,7 +930,7 @@ msgid ""
 "Button contains pieces to interface between the NAM Elevated Avenue Puzzle Pieces and RHW networks, including overpasses and intersections"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A479900"
+msgctxt "2026960B-123007BB-6A479900"
 msgid "Avenue/RHW Overpass and Interface Puzzle Pieces (DEPRECATED)"
 msgstr ""
 
@@ -943,7 +943,7 @@ msgid ""
 "FlexSPUI and Flex Diverging Diamond (FlexDDI) pieces are found under this button"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47991A"
+msgctxt "2026960B-123007BB-6A47991A"
 msgid "Specialized RHW x Surface Intersections"
 msgstr ""
 
@@ -954,7 +954,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Rail."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47A005"
+msgctxt "2026960B-123007BB-6A47A005"
 msgid "Rail Puzzle Pieces"
 msgstr ""
 
@@ -962,7 +962,7 @@ msgctxt "2026960B-123006AA-6A47A130"
 msgid "Button contains FLEX pieces to elevated the Rail network to viaduct level (using the RealRailway (RRW) standard)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47A130"
+msgctxt "2026960B-123007BB-6A47A130"
 msgid "Draggable Elevated Railways (ERRW)"
 msgstr ""
 
@@ -973,7 +973,7 @@ msgid ""
 "Once a puzzle piece is selected, use the [Home] and [End] keys to cycle through the various puzzle piece orientations"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47A358"
+msgctxt "2026960B-123007BB-6A47A358"
 msgid "Wide Radius Railroad Curve and Double Track Rail Switch Puzzle Pieces"
 msgstr ""
 
@@ -984,7 +984,7 @@ msgid ""
 "Once a puzzle piece is selected, use the [Home] and [End] keys to cycle through the various puzzle piece orientations"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47A368"
+msgctxt "2026960B-123007BB-6A47A368"
 msgid "Fractional Angle Railroad (FARR) Puzzle Pieces"
 msgstr ""
 
@@ -995,7 +995,7 @@ msgid ""
 "Button contains pieces to interface between the NAM Elevated Rail Viaduct Puzzle Pieces and RHW networks, including overpasses and intersections"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47A800"
+msgctxt "2026960B-123007BB-6A47A800"
 msgid "Rail Viaduct/RHW Overpass and Interface Puzzle Pieces"
 msgstr ""
 
@@ -1006,7 +1006,7 @@ msgid ""
 "Once a puzzle piece is selected, use the [Home] and [End] keys to cycle through the various puzzle piece orientations"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47A900"
+msgctxt "2026960B-123007BB-6A47A900"
 msgid "Wide Radius Railroad Curve and Double Track Rail Switch Puzzle Pieces"
 msgstr ""
 
@@ -1017,7 +1017,7 @@ msgid ""
 "Button contains several different Pieces for Dual/Double-Decker Networking."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AA0F"
+msgctxt "2026960B-123007BB-6A47AA0F"
 msgid ""
 "Underground Rail\n"
 "Rail Tunnel under Roads Dual Networking Puzzle Pieces"
@@ -1030,7 +1030,7 @@ msgid ""
 "Button contains several different Pieces for Dual/Double-Decker Networking."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AA10"
+msgctxt "2026960B-123007BB-6A47AA10"
 msgid ""
 "Underground Rail\n"
 "Rail Tunnel under Ped Malls Dual Networking Puzzle Pieces"
@@ -1043,7 +1043,7 @@ msgid ""
 "Button contains several different Pieces for Maxis Roadways."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AA11"
+msgctxt "2026960B-123007BB-6A47AA11"
 msgid ""
 "Underground Rail\n"
 "Maxis Roadway Intersection Pieces"
@@ -1056,7 +1056,7 @@ msgid ""
 "Button contains several different Pieces for Railways."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AA12"
+msgctxt "2026960B-123007BB-6A47AA12"
 msgid ""
 "Underground Rail\n"
 "Railway Intersection Pieces"
@@ -1069,7 +1069,7 @@ msgid ""
 "Button contains several different Pieces for Tramways."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AA13"
+msgctxt "2026960B-123007BB-6A47AA13"
 msgid ""
 "Underground Rail\n"
 "Tramway Intersection Pieces"
@@ -1082,7 +1082,7 @@ msgid ""
 "Button contains several different Pieces for Dual/Double-Decker Networking."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AA8A"
+msgctxt "2026960B-123007BB-6A47AA8A"
 msgid ""
 "Underground Rail\n"
 "Miscellaneous Puzzle Pieces"
@@ -1092,7 +1092,7 @@ msgctxt "2026960B-123006AA-6A47AC00"
 msgid "All pieces in this section are FLEX and conform to flextrack standards!"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AC00"
+msgctxt "2026960B-123007BB-6A47AC00"
 msgid "RealRailway FLEX Curve Pieces."
 msgstr ""
 
@@ -1100,7 +1100,7 @@ msgctxt "2026960B-123006AA-6A47AC10"
 msgid "All pieces in this section are FLEX and conform to flextrack standards!"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AC10"
+msgctxt "2026960B-123007BB-6A47AC10"
 msgid "RealRailway FLEX Turnout Pieces."
 msgstr ""
 
@@ -1108,7 +1108,7 @@ msgctxt "2026960B-123006AA-6A47AD00"
 msgid "All pieces in this section are FLEX and conform to flextrack and FARR standards!\n"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AD00"
+msgctxt "2026960B-123007BB-6A47AD00"
 msgid "RealRailway FLEX Fractional Angled (FA) Pieces."
 msgstr ""
 
@@ -1119,7 +1119,7 @@ msgid ""
 "Button contains several different Pieces for Dual/Double-Decker Networking."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47B03A"
+msgctxt "2026960B-123007BB-6A47B03A"
 msgid "ElevatedRail Dual/Double-Decker Network Pieces"
 msgstr ""
 
@@ -1127,7 +1127,7 @@ msgctxt "2026960B-123006AA-6A47B049"
 msgid "These puzzle pieces are to allow you to cross NWM networks with ElRail over Road."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47B049"
+msgctxt "2026960B-123007BB-6A47B049"
 msgid "ElRail over Road NWM Intersections"
 msgstr ""
 
@@ -1138,7 +1138,7 @@ msgid ""
 "The construction lot vanishes automatically. Use the Road Tool to connect the network and to build intersections."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47B060"
+msgctxt "2026960B-123007BB-6A47B060"
 msgid "ElevatedRail over Avenue/Road-4 Puzzle Pieces"
 msgstr ""
 
@@ -1146,7 +1146,7 @@ msgctxt "2026960B-123006AA-6A47B10F"
 msgid "Puzzle Pieces to build a ground level extension of the Elevated Rail network for Light Rail/Trams."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47B10F"
+msgctxt "2026960B-123007BB-6A47B10F"
 msgid "Ground Light Rail (Tram)"
 msgstr ""
 
@@ -1157,7 +1157,7 @@ msgid ""
 "Connect the Elevated Rail network with the Starter Piece. The Elevated Rail will turn into a Ground Light Rail track."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47B3FF"
+msgctxt "2026960B-123007BB-6A47B3FF"
 msgid "Draggable Ground Light Rail (Tram)"
 msgstr ""
 
@@ -1165,7 +1165,7 @@ msgctxt "2026960B-123006AA-6A47B42A"
 msgid "For building Tram-Avenue (= GroundLightRail / Avenue) - Dual Network Pieces."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47B42A"
+msgctxt "2026960B-123007BB-6A47B42A"
 msgid "Tram-Avenue (GroundLightRail / Avenue) - Dual Network Pieces"
 msgstr ""
 
@@ -1176,7 +1176,7 @@ msgid ""
 "These puzzle pieces are designed so that you may plop them first or you may plop them on existing networks."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47B900"
+msgctxt "2026960B-123007BB-6A47B900"
 msgid "High Elevated Rail Puzzle Pieces"
 msgstr ""
 
@@ -1187,7 +1187,7 @@ msgid ""
 "Button contains Tram-in-Road Puzzle Pieces"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47BA00"
+msgctxt "2026960B-123007BB-6A47BA00"
 msgid "Tram-in-Road"
 msgstr ""
 
@@ -1195,7 +1195,7 @@ msgctxt "2026960B-123006AA-6A47BBA0"
 msgid "For utilizing the Tram Puzzle Pieces"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47BBA0"
+msgctxt "2026960B-123007BB-6A47BBA0"
 msgid "Tram-on-Road & texture variations"
 msgstr ""
 
@@ -1203,7 +1203,7 @@ msgctxt "2026960B-123006AA-6A47BC60"
 msgid "For utilizing the Tram Puzzle Pieces"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47BC60"
+msgctxt "2026960B-123007BB-6A47BC60"
 msgid "Tram-on-Street"
 msgstr ""
 
@@ -1214,7 +1214,7 @@ msgid ""
 "Button contains starters for two additional Ground Light Rail styles, plus filler pieces."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47BD00"
+msgctxt "2026960B-123007BB-6A47BD00"
 msgid "Draggable Ground Light Rail (Tram)--Additional Styles"
 msgstr ""
 
@@ -1225,7 +1225,7 @@ msgid ""
 "Button contains Starter, Filler and Overpass Puzzle Pieces for High Speed Rail (HSR)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47C000"
+msgctxt "2026960B-123007BB-6A47C000"
 msgid "High Speed Rail (HSR)"
 msgstr ""
 
@@ -1238,11 +1238,11 @@ msgid ""
 "GHSR is a ground level extension of High Speed Rail (HSR)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47C200"
+msgctxt "2026960B-123007BB-6A47C200"
 msgid "Ground High Speed Rail (GHSR)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47C700"
+msgctxt "2026960B-123007BB-6A47C700"
 msgid "Monorail Wide Radius Curve Puzzle Pieces"
 msgstr ""
 
@@ -1260,7 +1260,7 @@ msgid ""
 "These puzzle pieces are designed so that you may plop them first or you may plop them on existing networks."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47C900"
+msgctxt "2026960B-123007BB-6A47C900"
 msgid "High Monorail Puzzle Pieces"
 msgstr ""
 
@@ -1268,7 +1268,7 @@ msgctxt "2026960B-123006AA-6A47CA00"
 msgid "For building Hybrid Railway straight track sections.  Hybrid Railway carries both normal Rail traffic and High Speed Rail (Monorail) traffic."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47CA00"
+msgctxt "2026960B-123007BB-6A47CA00"
 msgid "Hybrid Railway (Rail-High Speed Rail) Straight Sections"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgctxt "2026960B-123006AA-6A47CB00"
 msgid "For building Hybrid Railway curves.  Hybrid Railway carries both normal Rail traffic and High Speed Rail (Monorail) traffic."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47CB00"
+msgctxt "2026960B-123007BB-6A47CB00"
 msgid "Hybrid Railway (Rail-High Speed Rail) Curves"
 msgstr ""
 
@@ -1287,7 +1287,7 @@ msgid ""
 "Hybrid Railway carries both normal Rail traffic and High Speed Rail (Monorail) traffic."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47CD00"
+msgctxt "2026960B-123007BB-6A47CD00"
 msgid "Hybrid Railway (Rail-High Speed Rail) Switches"
 msgstr ""
 
@@ -1298,7 +1298,7 @@ msgid ""
 "Use ground-level Hybrid Railway segments, and connect to the elevated end of the transitions (or to other already elevated sections) to elevate them."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47CE00"
+msgctxt "2026960B-123007BB-6A47CE00"
 msgid "Hybrid Railway (Rail-High Speed Rail) Height Transitions"
 msgstr ""
 
@@ -1306,7 +1306,7 @@ msgctxt "2026960B-123006AA-6A47DC00"
 msgid "Button contains Ground Highway Puzzle Pieces"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47DC00"
+msgctxt "2026960B-123007BB-6A47DC00"
 msgid "Ground Highway Puzzle Pieces"
 msgstr ""
 
@@ -1317,7 +1317,7 @@ msgid ""
 "Button contains Single-Sided Perpendicular Ramps for Elevated Highway"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47E010"
+msgctxt "2026960B-123007BB-6A47E010"
 msgid ""
 "Single-Sided Perpendicular Ramps\n"
 "\n"
@@ -1331,7 +1331,7 @@ msgid ""
 "Button contains Single-Sided Parallel Ramps for both Ground Highway and Elevated Highway"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47E050"
+msgctxt "2026960B-123007BB-6A47E050"
 msgid ""
 "Single-Sided Parallel Ramps\n"
 "\n"
@@ -1342,15 +1342,15 @@ msgctxt "2026960B-123006AA-6A47E100"
 msgid "Button contains Custom Interchanges"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47E100"
+msgctxt "2026960B-123007BB-6A47E100"
 msgid "Custom Interchanges"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47FFFF"
+msgctxt "2026960B-123007BB-6A47FFFF"
 msgid "Network Addon Mod Controller"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A476200"
+msgctxt "2026960B-123007BB-6A476200"
 msgid "Draggable Pedmalls"
 msgstr ""
 

--- a/ltext/de/buttons.po
+++ b/ltext/de/buttons.po
@@ -35,7 +35,7 @@ msgid ""
 "Button contains Parallel Ramps for both Ground Highway and Elevated Highway."
 msgstr "Bauen von seitlichen Autobahnauffahrten für ebenerdige und erhöhte Autobahnen."
 
-msgctxt "2026960B-123006BB-52001000"
+msgctxt "2026960B-123007BB-52001000"
 msgid ""
 "Parallel Ramps\n"
 "\n"
@@ -49,7 +49,7 @@ msgid ""
 "Button contains Overpass/Perpendicular Ramps for both Ground Highway and Elevated Highway."
 msgstr "Bauen von Überführungen/Auffahrten für ebenerdige und erhöhte Autobahnen."
 
-msgctxt "2026960B-123006BB-52001010"
+msgctxt "2026960B-123007BB-52001010"
 msgid ""
 "Overpass/Perpendicular Ramps\n"
 "\n"
@@ -63,7 +63,7 @@ msgid ""
 "Button contains Cloverleaves for both Ground Highway and Elevated Highway."
 msgstr "Bauen von Autobahnkreuzen für ebenerdige und erhöhte Autobahnen."
 
-msgctxt "2026960B-123006BB-52001020"
+msgctxt "2026960B-123007BB-52001020"
 msgid ""
 "Cloverleaf\n"
 "\n"
@@ -77,7 +77,7 @@ msgid ""
 "Button contains T-Intersections for both Ground Highway and Elevated Highway."
 msgstr "Bauen von Autobahn-Dreiecken für ebenerdige und erhöhte Autobahnen."
 
-msgctxt "2026960B-123006BB-52002000"
+msgctxt "2026960B-123007BB-52002000"
 msgid ""
 "T-Intersections\n"
 "\n"
@@ -88,7 +88,7 @@ msgctxt "2026960B-123006AA-6A470100"
 msgid "With the Canal Addon Mod you can build functional canals"
 msgstr "Mit dem Canal Addon Mod kannst Du funktionierende Kanäle bauen."
 
-msgctxt "2026960B-123006BB-6A470100"
+msgctxt "2026960B-123007BB-6A470100"
 msgid "Canal Addon Mod"
 msgstr "Canal Addon Mod"
 
@@ -103,7 +103,7 @@ msgstr ""
 "\n"
 "Zieh das entsprechende Verkehrswerkzeug durch das FLEX-/Starter-Puzzleteil, um Abbiegespuren zu verlegen."
 
-msgctxt "2026960B-123006BB-6A470460"
+msgctxt "2026960B-123007BB-6A470460"
 msgid "FLEX Turn Lanes (FTLs)"
 msgstr "Flexible Abbiegespuren (FTLs)"
 
@@ -117,7 +117,7 @@ msgstr ""
 "\n"
 "Vorgefertigte Kreuzungen mit flexiblen Abbiegespuren, um ein schnelles Bauen zu ermöglichen"
 
-msgctxt "2026960B-123006BB-6A4704A0"
+msgctxt "2026960B-123007BB-6A4704A0"
 msgid "QuickTurn (Pre-Built FLEX Turn Lane Setups)"
 msgstr "QuickTurn-Kreuzungen"
 
@@ -131,7 +131,7 @@ msgstr ""
 "\n"
 "Enthält Abbiege-Puzzleteile für verschiedene Verkehrswege und Konfigurationen"
 
-msgctxt "2026960B-123006BB-6A4704E0"
+msgctxt "2026960B-123007BB-6A4704E0"
 msgid "TuLEPs (Turn Lane Extension Pieces) (OLD)"
 msgstr "Abbiege-Puzzleteile (veraltet)"
 
@@ -145,7 +145,7 @@ msgstr ""
 "\n"
 "Enthält Teile, um die verschiedenen NWM-Typen (TLA-7 und AVE-6) miteinander sowie selbige mit den normalen Verkehrsnetzwerken zu verbinden."
 
-msgctxt "2026960B-123006BB-6A470600"
+msgctxt "2026960B-123007BB-6A470600"
 msgid "Network Widening Mod (NWM) Triple-Tile Network Turn Lane Extension Pieces (TuLEPs)"
 msgstr "Network Widening Mod (NWM) - Drei-Felder-Netzwerk-Abbiegespur-Erweiterungsteile (TuLEPs)"
 
@@ -156,7 +156,7 @@ msgid ""
 "Button contains components for both Ground Highway and Elevated Highway."
 msgstr "Bauen von (teilweise) vorgefertigten Autobahnkreuzen für ebenerdige und erhöhte Autobahnen."
 
-msgctxt "2026960B-123006BB-6A473141"
+msgctxt "2026960B-123007BB-6A473141"
 msgid ""
 "Symphony Prefab Interchange Components\n"
 "\n"
@@ -170,7 +170,7 @@ msgid ""
 "Button contains components for both Ground Highway and Elevated Highway."
 msgstr "Bauen von Auf- und Abfahrten für ebenerdige und erhöhte Autobahnen."
 
-msgctxt "2026960B-123006BB-6A473143"
+msgctxt "2026960B-123007BB-6A473143"
 msgid ""
 "Symphony Ramp Interfaces\n"
 "\n"
@@ -187,7 +187,7 @@ msgstr ""
 "\n"
 "Das erste Puzzleteile ist ein Starter-Puzzleteil."
 
-msgctxt "2026960B-123006BB-6A474000"
+msgctxt "2026960B-123007BB-6A474000"
 msgid "Single-Track Rail (STR)"
 msgstr "Single-Track Rail (STR)"
 
@@ -199,7 +199,7 @@ msgid ""
 "Drag the RealHighway (RHW-2) network tool through the Starter Piece to construct the desired override network."
 msgstr "Zieh das Real-Highway-Werkzeug (RHW-2) durch eines der Starter-Puzzleteile, um Autobahnen mit bis zu 12 Fahrstreifen zu konstruieren, ebenerdig oder in bis zu 30 Meter Höhe (L4)."
 
-msgctxt "2026960B-123006BB-6A475000"
+msgctxt "2026960B-123007BB-6A475000"
 msgid "RealHighway (RHW) Starter Pieces"
 msgstr "Real Highway (RHW) Starter-Puzzleteile"
 
@@ -217,7 +217,7 @@ msgstr ""
 "\n"
 "Falls nötig kannst du freigewordene Felder wieder befüllen, indem du Verkehrswege nachträglich darüber ziehst."
 
-msgctxt "2026960B-123006BB-6A475024"
+msgctxt "2026960B-123007BB-6A475024"
 msgid "Network Eraser"
 msgstr "Verkehrsnetzwerk-Radierer"
 
@@ -228,7 +228,7 @@ msgid ""
 "Button contains Filler Pieces to build RHW networks in smaller chunks, in unstable situations"
 msgstr "Dient dem Befüllen kleiner Lücken und kann in instabilen Situationen nützlich sein."
 
-msgctxt "2026960B-123006BB-6A475050"
+msgctxt "2026960B-123007BB-6A475050"
 msgid "RealHighway Filler Pieces"
 msgstr "Real Highway Füll-Puzzleteile"
 
@@ -241,7 +241,7 @@ msgid ""
 "These items are DEPRECATED, and the use of the FLEX Neighbor Connections is recommended instead."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47508C"
+msgctxt "2026960B-123007BB-6A47508C"
 msgid "Old RealHighway Neighbor Connector Puzzle Pieces  - DEPRECATED"
 msgstr ""
 
@@ -254,7 +254,7 @@ msgid ""
 "NOTE: ALL REALHIGHWAY NEIGHBOR CONNECTIONS (EXCEPT RHW-2) ARE REQUIRED TO USE NEIGHBOR CONNECTOR PIECES TO ENSURE PROPERLY FUNCTIONING NEIGHBOR CONNECTIONS--OTHERWISE ONLY FREIGHT TRUCKS WILL USE THE RHW"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475090"
+msgctxt "2026960B-123007BB-6A475090"
 msgid "RealHighway FLEX Neighbor Connector Pieces (FLEX-NC)"
 msgstr ""
 
@@ -262,7 +262,7 @@ msgctxt "2026960B-123006AA-6A475100"
 msgid "For building DEPRECATED RealHighway Ramp Interfaces.  All of the functionality of the 47 pieces contained and many more are covered by the FLEXRamp system."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475100"
+msgctxt "2026960B-123007BB-6A475100"
 msgid "OBSOLETE RealHighway Ramp Interfaces (Static Puzzle-Based)"
 msgstr ""
 
@@ -273,7 +273,7 @@ msgid ""
 "Button contains Type B Ramp Interface Pieces for building interchanges with the RHW"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475104"
+msgctxt "2026960B-123007BB-6A475104"
 msgid "RealHighway Type B Ramp Interfaces"
 msgstr ""
 
@@ -284,7 +284,7 @@ msgid ""
 "Button contains Type E Ramp Interface Pieces for building interchanges with the RHW"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475109"
+msgctxt "2026960B-123007BB-6A475109"
 msgid "RealHighway Type E Ramp Interfaces"
 msgstr ""
 
@@ -295,7 +295,7 @@ msgid ""
 "Button contains Type D Ramp Interface Pieces for building interchanges with the RHW"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47510A"
+msgctxt "2026960B-123007BB-6A47510A"
 msgid "RealHighway Type D Ramp Interfaces"
 msgstr ""
 
@@ -306,7 +306,7 @@ msgid ""
 "Deprecated puzzle piece ramps follow Volleyball pieces - use of the FLEXRamps or Draggable Ramp Interfaces (DRIs) is recommended instead of using the deprecated puzzle pieces."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475118"
+msgctxt "2026960B-123007BB-6A475118"
 msgid "Specialized and Deprecated RealHighway Ramp Interfaces and Volleyball Crossings (Static Puzzle-Based)"
 msgstr ""
 
@@ -317,7 +317,7 @@ msgid ""
 "Button contains FLEX pieces for different overrideable ramp interfaces.  Drag appropriate networks through to convert base ramp to match."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A4751F0"
+msgctxt "2026960B-123007BB-6A4751F0"
 msgid "RealHighway FLEXRamps"
 msgstr ""
 
@@ -328,7 +328,7 @@ msgid ""
 "Button contains pieces to build Wide Curves for the RHW networks"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475220"
+msgctxt "2026960B-123007BB-6A475220"
 msgid "RealHighway Wide-Radius and Multi-Radius (Smooth) Curves"
 msgstr ""
 
@@ -341,7 +341,7 @@ msgid ""
 "These items are DEPRECATED and use of the FLEX Width Transitions (FLEX-WT) is recommended instead."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475300"
+msgctxt "2026960B-123007BB-6A475300"
 msgid "Old RealHighway Width Transition Puzzle Pieces - DEPRECATED"
 msgstr ""
 
@@ -354,7 +354,7 @@ msgid ""
 "All functionality here has been duplicated with the FLEX Height Transitions, and as such, this button is DEPRECATED."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475312"
+msgctxt "2026960B-123007BB-6A475312"
 msgid "Old RealHighway Height Transition Puzzle Pieces  - DEPRECATED"
 msgstr ""
 
@@ -365,7 +365,7 @@ msgid ""
 "Button contains pieces to transition between RHW networks of different heights.  Pieces begin as RHW-2 transitions, and dragging another RHW network into them will convert them to fit."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475330"
+msgctxt "2026960B-123007BB-6A475330"
 msgid "RealHighway FLEX Height Transitions (FLEX-HT)"
 msgstr ""
 
@@ -376,7 +376,7 @@ msgid ""
 "Button contains pieces to transition between RHW networks of different widths.  Dragging another RHW network into them will convert them to fit."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475336"
+msgctxt "2026960B-123007BB-6A475336"
 msgid "RealHighway FLEX Width Transitions (FLEX-WT)"
 msgstr ""
 
@@ -387,7 +387,7 @@ msgid ""
 "Button contains components for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475350"
+msgctxt "2026960B-123007BB-6A475350"
 msgid ""
 "Symphony Transitions\n"
 "\n"
@@ -401,7 +401,7 @@ msgid ""
 "Button contains components for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475366"
+msgctxt "2026960B-123007BB-6A475366"
 msgid ""
 "Symphony Smooth Curves\n"
 "\n"
@@ -417,7 +417,7 @@ msgid ""
 "NOTE: These pieces should NOT be confused with TuLEPs."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475400"
+msgctxt "2026960B-123007BB-6A475400"
 msgid "RealHighway Cosmetic Puzzle Pieces (for 1-Tile Networks)"
 msgstr ""
 
@@ -430,7 +430,7 @@ msgid ""
 "NOTE: These pieces should NOT be confused with TuLEPs."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475410"
+msgctxt "2026960B-123007BB-6A475410"
 msgid "RealHighway Cosmetic Piece Transitions"
 msgstr ""
 
@@ -443,7 +443,7 @@ msgid ""
 "NOTE: These pieces should NOT be confused with TuLEPs."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475440"
+msgctxt "2026960B-123007BB-6A475440"
 msgid "RealHighway Cosmetic Puzzle Pieces (for 2-Tile Networks)"
 msgstr ""
 
@@ -456,7 +456,7 @@ msgid ""
 "NOTE: These pieces should NOT be confused with TuLEPs."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475471"
+msgctxt "2026960B-123007BB-6A475471"
 msgid "RealHighway Cosmetic Puzzle Pieces (for 3-Tile Networks)"
 msgstr ""
 
@@ -469,7 +469,7 @@ msgid ""
 "<DEPRECATED>"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475500"
+msgctxt "2026960B-123007BB-6A475500"
 msgid "ERHW-over-RHW Diagonal Overpass Puzzle Pieces<DEPRECATED>"
 msgstr ""
 
@@ -482,7 +482,7 @@ msgid ""
 "Place overcrossing pieces on top of underground roadways whenever a surface network crosses over, to allow traffic to pass underground."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475600"
+msgctxt "2026960B-123007BB-6A475600"
 msgid "RHW Flexible Underpasses (FLUPs), Draggable Underground Roads (URoads), and Overcrossings"
 msgstr ""
 
@@ -493,7 +493,7 @@ msgid ""
 "Button contains flexible RHW interchange segments.  Drag appropriate networks through to convert base ramp to match, and combine to easily create a full interchange."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475700"
+msgctxt "2026960B-123007BB-6A475700"
 msgid "RealHighway QuickChanges"
 msgstr ""
 
@@ -504,7 +504,7 @@ msgid ""
 "Button contains starter/transition FLEX pieces for different RHW turn lane setups"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475900"
+msgctxt "2026960B-123007BB-6A475900"
 msgid "RealHighway FLEX Turn Lanes (FTLs)"
 msgstr ""
 
@@ -515,7 +515,7 @@ msgid ""
 "Button contains pieces to build FLEXFly Pieces"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475AF3"
+msgctxt "2026960B-123007BB-6A475AF3"
 msgid "RealHighway FLEXFly (LEGACY/DEPRECATED)"
 msgstr ""
 
@@ -526,7 +526,7 @@ msgid ""
 "Button contains pieces to build 3-Level Crossings"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475AF6"
+msgctxt "2026960B-123007BB-6A475AF6"
 msgid "RealHighway 3-Level Crossings"
 msgstr ""
 
@@ -537,7 +537,7 @@ msgid ""
 "Button contains pieces to build FLEXFly Pieces"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475B00"
+msgctxt "2026960B-123007BB-6A475B00"
 msgid "RealHighway FLEXFly"
 msgstr ""
 
@@ -550,7 +550,7 @@ msgid ""
 "NOTE: Most intersections require the use of TuLEPs."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475F00"
+msgctxt "2026960B-123007BB-6A475F00"
 msgid "Fractionally Angled RealHighway Intersections and Transitions"
 msgstr ""
 
@@ -561,7 +561,7 @@ msgid ""
 "Button contains straight pieces and curves to pieces to build Fractionally Angled RealHighway (FARHWs)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475F20"
+msgctxt "2026960B-123007BB-6A475F20"
 msgid "Fractionally Angled RealHighway"
 msgstr ""
 
@@ -572,7 +572,7 @@ msgid ""
 "Button contains pieces to build different FARHW Ramp Interfaces: The C1, F1, C2, F2, and C3 Ramp Interfaces"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475F30"
+msgctxt "2026960B-123007BB-6A475F30"
 msgid "Fractionally Angled RealHighway Ramp Interfaces"
 msgstr ""
 
@@ -583,7 +583,7 @@ msgid ""
 "Button contains Type C Ramp Interface Pieces for building interchanges with the RHW"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475F70"
+msgctxt "2026960B-123007BB-6A475F70"
 msgid "RealHighway Type C Ramp Interfaces"
 msgstr ""
 
@@ -594,7 +594,7 @@ msgid ""
 "Button contains Type F Ramp Interface Pieces for building interchanges with the RHW"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475F71"
+msgctxt "2026960B-123007BB-6A475F71"
 msgid "RealHighway Type F Ramp Interfaces"
 msgstr ""
 
@@ -607,7 +607,7 @@ msgid ""
 "NOTE: Ped Mall Tiles should not be used directly in front of Residential Zones where their zoning arrow is."
 msgstr "Bauen von Fußgängerzonen-Puzzleteilen."
 
-msgctxt "2026960B-123006BB-6A476005"
+msgctxt "2026960B-123007BB-6A476005"
 msgid "Pedestrian Mall Tiles"
 msgstr "Fußgängerzonen"
 
@@ -615,7 +615,7 @@ msgctxt "2026960B-123006AA-6A476100"
 msgid "A collection of pedestrian crossing FLEX pieces. Use them on their own at crossing locations, or as part of pedmall corridors."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A476100"
+msgctxt "2026960B-123007BB-6A476100"
 msgid "Pedestrian Revolution Mod (PRM) FLEX Crossings"
 msgstr ""
 
@@ -626,7 +626,7 @@ msgid ""
 "Button contains several different Puzzle and Helper Pieces for Street"
 msgstr "Bauen von diagonalen Straßen an Hängen oder zur Erstellung von Kreuzungen."
 
-msgctxt "2026960B-123006BB-6A476525"
+msgctxt "2026960B-123007BB-6A476525"
 msgid "Diagonal Street Helper Pieces"
 msgstr "Hilfspuzzleteile für diagonale Straßen"
 
@@ -637,7 +637,7 @@ msgid ""
 "Button contains Starter Pieces for Street Addon Mod (SAM)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A476700"
+msgctxt "2026960B-123007BB-6A476700"
 msgid "Street Addon Mod (SAM)"
 msgstr ""
 
@@ -645,7 +645,7 @@ msgctxt "2026960B-123006AA-6A476905"
 msgid "Plop one of these pieces on a flat area. It will raise or lower the terrain, and then destroy itself, providing a level area for a raised network of your choice. This is fully compatible with all slope mods."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A476905"
+msgctxt "2026960B-123007BB-6A476905"
 msgid "Hole Digger and Raiser Lots"
 msgstr ""
 
@@ -656,7 +656,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Avenues"
 msgstr "Bauen von Alleekreiseln, Alleedreiecken und anderen Alleekreuzungen."
 
-msgctxt "2026960B-123006BB-6A476A00"
+msgctxt "2026960B-123007BB-6A476A00"
 msgid "Avenue Intersections"
 msgstr "Alleekreuzungen"
 
@@ -667,7 +667,7 @@ msgid ""
 "Button contains several different overpasses for Road"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477000"
+msgctxt "2026960B-123007BB-6A477000"
 msgid "Road Overpasses"
 msgstr "Landstraßen-Überführungen"
 
@@ -678,7 +678,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Road"
 msgstr "Bauen von Landstraßen-Puzzleteilen."
 
-msgctxt "2026960B-123006BB-6A477005"
+msgctxt "2026960B-123007BB-6A477005"
 msgid "7.5m Elevated Road Viaducts"
 msgstr "Landstraßen-Puzzleteile (7,5m)"
 
@@ -689,7 +689,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Road"
 msgstr "Bauen von Landstraßen-Puzzleteilen."
 
-msgctxt "2026960B-123006BB-6A477200"
+msgctxt "2026960B-123007BB-6A477200"
 msgid "15m Elevated Road Viaducts"
 msgstr "Landstraßen-Puzzleteile (15m)"
 
@@ -700,7 +700,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Road, One-Way Road, or Avenue"
 msgstr "Bauen von sanft geschwungenen Landstraßenkurven (Wide Radius Road Curves), Einbahnstraßen-, Straßen- und Alleekurven."
 
-msgctxt "2026960B-123006BB-6A477500"
+msgctxt "2026960B-123007BB-6A477500"
 msgid "Wide Radius Curves (for Road, One-Way Road, Avenue, and Street) (Puzzle Pieces)"
 msgstr "Sanft geschwungene Landstraßen-, Einbahnstraßen-, Straßen- und Alleekurven"
 
@@ -711,7 +711,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Road, One-Way Road, and Avenue"
 msgstr "Bauen von schräg zum Raster verlaufenden Straßen (Fractional Angle Road, FAR)."
 
-msgctxt "2026960B-123006BB-6A477600"
+msgctxt "2026960B-123007BB-6A477600"
 msgid "Fractionally-Angled Networks (for Road, One-Way Road, and Avenue)"
 msgstr "Schräg zum Raster verlaufende Landstraßen, Einbahnstraßen und Alleen"
 
@@ -722,7 +722,7 @@ msgid ""
 "Once a puzzle piece is selected, use the [Home] and [End] keys to cycle through the various puzzle piece orientations"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477700"
+msgctxt "2026960B-123007BB-6A477700"
 msgid "Rural Road Puzzle Pieces"
 msgstr ""
 
@@ -733,7 +733,7 @@ msgid ""
 "Button contains pieces to interface between the NAM Elevated Road Puzzle Pieces and RHW networks, including overpasses and intersections"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477800"
+msgctxt "2026960B-123007BB-6A477800"
 msgid "Road/RHW Overpass and Interface Puzzle Pieces (DEPRECATED)"
 msgstr ""
 
@@ -744,7 +744,7 @@ msgid ""
 "Button contains several different FLEX Pieces for various networks"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477900"
+msgctxt "2026960B-123007BB-6A477900"
 msgid "Multi-Radius Curve (MRC) FLEX Pieces for Surface Networks"
 msgstr ""
 
@@ -764,7 +764,7 @@ msgstr ""
 "\n"
 "Baue zuerst die oberirdischen Verkehrswege, setze danach diese Puzzleteil darauf."
 
-msgctxt "2026960B-123006BB-6A477A00"
+msgctxt "2026960B-123007BB-6A477A00"
 msgid "Flexible Underpasses (FLUPs)"
 msgstr "Unterirdische Puzzleteile"
 
@@ -778,7 +778,7 @@ msgstr ""
 "\n"
 "Enthält Starter-Puzzleteile für 3- bis 7-streifige Turning Lane Avenues (TLA-3,5,7), 2- und 6-streifige Alleen (AVE-2,6), 3- bis 6-streifige Landstraßen (ARD-3, RD-4, RD-6) und 1- bis 5-streifige Einbahnstraßen (OWR-1,3,4,5)."
 
-msgctxt "2026960B-123006BB-6A477B00"
+msgctxt "2026960B-123007BB-6A477B00"
 msgid "Network Widening Mod (NWM) Starter Pieces"
 msgstr "Network Widening Mod (NWM)-Puzzleteile"
 
@@ -789,7 +789,7 @@ msgid ""
 "Button contains Wide-Radius Curve Pieces for the single-tile NWM networks"
 msgstr "Bauen von Kurven-Puzzleteilen für den Network Widening Mod (NWM) Enthält sanft geschwungene Kurven für die ein Felder breiten NWM-Netzwerke."
 
-msgctxt "2026960B-123006BB-6A477B30"
+msgctxt "2026960B-123007BB-6A477B30"
 msgid "Network Widening Mod (NWM) Curve Pieces"
 msgstr "Network Widening Mod (NWM)-Kurven-Puzzleteile"
 
@@ -802,7 +802,7 @@ msgid ""
 "Note that most transitions involving single and dual-tile networks can be built using draggable means instead (such as direct connections or using the stub-to-stub method)"
 msgstr "Bauen von Übergangs-Puzzleteilen für den Network Widening Mod (NWM). Enthält Teile, um die verschiedenen NWM-Typen miteinander sowie selbige mit den normalen Verkehrsnetzwerken zu verbinden."
 
-msgctxt "2026960B-123006BB-6A477B50"
+msgctxt "2026960B-123007BB-6A477B50"
 msgid "Network Widening Mod (NWM) Transition Pieces"
 msgstr "Network Widening Mod (NWM)-Übergangs-Puzzleteile"
 
@@ -813,7 +813,7 @@ msgid ""
 "Button contains Neighbor Connector Pieces for the TLA-5, RD-4 and RD-6"
 msgstr "Bauen von Nachbarschaftsverbindungs-Puzzleteilen für den Network Widening Mod (NWM). Enthält Nachbarschaftsverbindungsteile für TLA-5, MAVE-5 und MAVE-6."
 
-msgctxt "2026960B-123006BB-6A477BF0"
+msgctxt "2026960B-123007BB-6A477BF0"
 msgid "Network Widening Mod (NWM) Neighbor Connector Pieces"
 msgstr "Network Widening Mod (NWM)-Nachbarschaftsverbindungs-Puzzleteile"
 
@@ -824,7 +824,7 @@ msgid ""
 "Button contains FLEX Single Tile Roundabouts intersections for various road networks"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477C00"
+msgctxt "2026960B-123007BB-6A477C00"
 msgid "Single Tile Roundabouts"
 msgstr ""
 
@@ -837,7 +837,7 @@ msgid ""
 "Button contains OnSlope Transitions to start Alternate Style Road and Street Viaducts"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477E00"
+msgctxt "2026960B-123007BB-6A477E00"
 msgid "Road Viaduct Alternate Styles"
 msgstr ""
 
@@ -848,7 +848,7 @@ msgid ""
 "Button contains several different Starter and FLEX Pieces for Draggable Elevated Road Viaducts"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477F00"
+msgctxt "2026960B-123007BB-6A477F00"
 msgid "Draggable Elevated Road Viaducts"
 msgstr ""
 
@@ -861,7 +861,7 @@ msgid ""
 "Drag networks under (or over) the mid-section of the overpass to build the crossing.  Most networks and FLEX-based dual-networks are supported."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477F30"
+msgctxt "2026960B-123007BB-6A477F30"
 msgid "FLEX Overpasses"
 msgstr ""
 
@@ -872,7 +872,7 @@ msgid ""
 "Button contains several different overpasses for One-Way Road"
 msgstr "Bauen von Einbahnstraßen-Überführungen."
 
-msgctxt "2026960B-123006BB-6A478000"
+msgctxt "2026960B-123007BB-6A478000"
 msgid "One-Way Road Overpasses"
 msgstr "Einbahnstraßen-Überführungen"
 
@@ -883,7 +883,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for One-Way Road"
 msgstr "Bauen von Einbahnstraßen-Puzzleteilen."
 
-msgctxt "2026960B-123006BB-6A478005"
+msgctxt "2026960B-123007BB-6A478005"
 msgid "15m Elevated One-Way Road Viaducts"
 msgstr "Einbahnstraßen-Puzzleteile (15m)"
 
@@ -894,7 +894,7 @@ msgid ""
 "Button contains pieces to interface between the NAM Elevated One-Way Road Puzzle Pieces and RHW networks, including overpasses and intersections"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A478800"
+msgctxt "2026960B-123007BB-6A478800"
 msgid "One-Way Road/RHW Overpass and Interface Puzzle Pieces (DEPRECATED)"
 msgstr ""
 
@@ -902,7 +902,7 @@ msgctxt "2026960B-123006AA-6A478900"
 msgid "For use of the curved pieces for the Real Expressway Network. Use the Home/End key to rotate the FLEX Piece & use TAB/Shift-TAB (Ctrl-TAB/Ctrl-Shift-TAB on macOS) to cycle through the different types of REW Straights and Curves."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A478900"
+msgctxt "2026960B-123007BB-6A478900"
 msgid "Real Expressway FLEX Piece network tool and Curves."
 msgstr ""
 
@@ -913,7 +913,7 @@ msgid ""
 "Button contains FLEX pieces for different overrideable ramp interfaces.  Drag appropriate networks through to convert base ramp to match."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A478B00"
+msgctxt "2026960B-123007BB-6A478B00"
 msgid "RealExpressway (REW) One-Way Road FLEXRamps"
 msgstr ""
 
@@ -924,7 +924,7 @@ msgid ""
 "Button contains several different overpasses for Avenue"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A479000"
+msgctxt "2026960B-123007BB-6A479000"
 msgid "Avenue Overpasses"
 msgstr "Allee-Überführungen"
 
@@ -935,7 +935,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Avenue"
 msgstr "Bauen von Allee-Puzzleteilen."
 
-msgctxt "2026960B-123006BB-6A479005"
+msgctxt "2026960B-123007BB-6A479005"
 msgid "7.5m Elevated Avenue Viaducts"
 msgstr "Allee-Puzzleteile (7,5m)"
 
@@ -946,7 +946,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Avenue"
 msgstr "Bauen von Allee-Puzzleteilen."
 
-msgctxt "2026960B-123006BB-6A479200"
+msgctxt "2026960B-123007BB-6A479200"
 msgid "15m Elevated Avenue Viaducts"
 msgstr "Allee-Puzzleteile (15m)"
 
@@ -957,7 +957,7 @@ msgid ""
 "Button contains pieces to interface between the NAM Elevated Avenue Puzzle Pieces and RHW networks, including overpasses and intersections"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A479900"
+msgctxt "2026960B-123007BB-6A479900"
 msgid "Avenue/RHW Overpass and Interface Puzzle Pieces (DEPRECATED)"
 msgstr ""
 
@@ -970,7 +970,7 @@ msgid ""
 "FlexSPUI and Flex Diverging Diamond (FlexDDI) pieces are found under this button"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47991A"
+msgctxt "2026960B-123007BB-6A47991A"
 msgid "Specialized RHW x Surface Intersections"
 msgstr ""
 
@@ -981,7 +981,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Rail."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47A005"
+msgctxt "2026960B-123007BB-6A47A005"
 msgid "Rail Puzzle Pieces"
 msgstr "Eisenbahn-Puzzleteile"
 
@@ -989,7 +989,7 @@ msgctxt "2026960B-123006AA-6A47A130"
 msgid "Button contains FLEX pieces to elevated the Rail network to viaduct level (using the RealRailway (RRW) standard)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47A130"
+msgctxt "2026960B-123007BB-6A47A130"
 msgid "Draggable Elevated Railways (ERRW)"
 msgstr ""
 
@@ -1000,7 +1000,7 @@ msgid ""
 "Once a puzzle piece is selected, use the [Home] and [End] keys to cycle through the various puzzle piece orientations"
 msgstr "Bauen von Puzzleteilen für sanft geschwungene Eisenbahnkurven und doppelspurige Eisenbahnweichen. Benutze die Pos1-/Ende-Taste, um das Puzzleteil zu rotieren und die TAB-Taste, um zwischen den verschiedenen Typen zu wählen. Wenn der rote Mauszeiger grün wird, klicke mit der linken Maustaste."
 
-msgctxt "2026960B-123006BB-6A47A358"
+msgctxt "2026960B-123007BB-6A47A358"
 msgid "Wide Radius Railroad Curve and Double Track Rail Switch Puzzle Pieces"
 msgstr "Puzzleteile für sanft geschwungene Eisenbahnkurven und doppelspurige Eisenbahnweichen"
 
@@ -1011,7 +1011,7 @@ msgid ""
 "Once a puzzle piece is selected, use the [Home] and [End] keys to cycle through the various puzzle piece orientations"
 msgstr "Bauen von Puzzleteilen für schräg zum Raster verlaufende Gleise (FARR). Benutze die Pos1-/Ende-Taste, um das Puzzleteil zu rotieren und die TAB-Taste, um zwischen den verschiedenen Typen zu wählen. Wenn der rote Mauszeiger grün wird, klicke mit der linken Maustaste."
 
-msgctxt "2026960B-123006BB-6A47A368"
+msgctxt "2026960B-123007BB-6A47A368"
 msgid "Fractional Angle Railroad (FARR) Puzzle Pieces"
 msgstr "Puzzleteile für schräg zum Raster verlaufende Gleise (FARR)"
 
@@ -1022,7 +1022,7 @@ msgid ""
 "Button contains pieces to interface between the NAM Elevated Rail Viaduct Puzzle Pieces and RHW networks, including overpasses and intersections"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47A800"
+msgctxt "2026960B-123007BB-6A47A800"
 msgid "Rail Viaduct/RHW Overpass and Interface Puzzle Pieces"
 msgstr ""
 
@@ -1033,7 +1033,7 @@ msgid ""
 "Once a puzzle piece is selected, use the [Home] and [End] keys to cycle through the various puzzle piece orientations"
 msgstr "Bauen von Puzzleteilen für sanft geschwungene Eisenbahnkurven und doppelspurige Eisenbahnweichen. Benutze die Pos1-/Ende-Taste, um das Puzzleteil zu rotieren und die TAB-Taste, um zwischen den verschiedenen Typen zu wählen. Wenn der rote Mauszeiger grün wird, klicke mit der linken Maustaste."
 
-msgctxt "2026960B-123006BB-6A47A900"
+msgctxt "2026960B-123007BB-6A47A900"
 msgid "Wide Radius Railroad Curve and Double Track Rail Switch Puzzle Pieces"
 msgstr "Puzzleteile für sanft geschwungene Eisenbahnkurven und doppelspurige Eisenbahnweichen"
 
@@ -1044,7 +1044,7 @@ msgid ""
 "Button contains several different Pieces for Dual/Double-Decker Networking."
 msgstr "Bauen von unterirdischen Bahnstrecken."
 
-msgctxt "2026960B-123006BB-6A47AA0F"
+msgctxt "2026960B-123007BB-6A47AA0F"
 msgid ""
 "Underground Rail\n"
 "Rail Tunnel under Roads Dual Networking Puzzle Pieces"
@@ -1057,7 +1057,7 @@ msgid ""
 "Button contains several different Pieces for Dual/Double-Decker Networking."
 msgstr "Bauen von unterirdischen Bahnstrecken unter Fußgängerzonen."
 
-msgctxt "2026960B-123006BB-6A47AA10"
+msgctxt "2026960B-123007BB-6A47AA10"
 msgid ""
 "Underground Rail\n"
 "Rail Tunnel under Ped Malls Dual Networking Puzzle Pieces"
@@ -1070,7 +1070,7 @@ msgid ""
 "Button contains several different Pieces for Maxis Roadways."
 msgstr "Bauen von unterirdischen Bahnstrecken, die die Verkehrswege von Maxis kreuzen."
 
-msgctxt "2026960B-123006BB-6A47AA11"
+msgctxt "2026960B-123007BB-6A47AA11"
 msgid ""
 "Underground Rail\n"
 "Maxis Roadway Intersection Pieces"
@@ -1083,7 +1083,7 @@ msgid ""
 "Button contains several different Pieces for Railways."
 msgstr "Bauen von unterirdischen Bahnstrecken unter Eisenbahnstrecken."
 
-msgctxt "2026960B-123006BB-6A47AA12"
+msgctxt "2026960B-123007BB-6A47AA12"
 msgid ""
 "Underground Rail\n"
 "Railway Intersection Pieces"
@@ -1098,7 +1098,7 @@ msgid ""
 "Button contains several different Pieces for Tramways."
 msgstr "Bauen von unterirdischen Bahnstrecken unter Straßenbahnstrecken."
 
-msgctxt "2026960B-123006BB-6A47AA13"
+msgctxt "2026960B-123007BB-6A47AA13"
 msgid ""
 "Underground Rail\n"
 "Tramway Intersection Pieces"
@@ -1113,7 +1113,7 @@ msgid ""
 "Button contains several different Pieces for Dual/Double-Decker Networking."
 msgstr "Bauen von unterirdischen Bahnstrecken."
 
-msgctxt "2026960B-123006BB-6A47AA8A"
+msgctxt "2026960B-123007BB-6A47AA8A"
 msgid ""
 "Underground Rail\n"
 "Miscellaneous Puzzle Pieces"
@@ -1125,7 +1125,7 @@ msgctxt "2026960B-123006AA-6A47AC00"
 msgid "All pieces in this section are FLEX and conform to flextrack standards!"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AC00"
+msgctxt "2026960B-123007BB-6A47AC00"
 msgid "RealRailway FLEX Curve Pieces."
 msgstr ""
 
@@ -1133,7 +1133,7 @@ msgctxt "2026960B-123006AA-6A47AC10"
 msgid "All pieces in this section are FLEX and conform to flextrack standards!"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AC10"
+msgctxt "2026960B-123007BB-6A47AC10"
 msgid "RealRailway FLEX Turnout Pieces."
 msgstr ""
 
@@ -1141,7 +1141,7 @@ msgctxt "2026960B-123006AA-6A47AD00"
 msgid "All pieces in this section are FLEX and conform to flextrack and FARR standards!\n"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AD00"
+msgctxt "2026960B-123007BB-6A47AD00"
 msgid "RealRailway FLEX Fractional Angled (FA) Pieces."
 msgstr ""
 
@@ -1152,7 +1152,7 @@ msgid ""
 "Button contains several different Pieces for Dual/Double-Decker Networking."
 msgstr "Bauen von Hochbahn/Landstraße-Doppeldecker-Puzzleteilen."
 
-msgctxt "2026960B-123006BB-6A47B03A"
+msgctxt "2026960B-123007BB-6A47B03A"
 msgid "ElevatedRail Dual/Double-Decker Network Pieces"
 msgstr "Hochbahn/Landstraße-Doppeldecker-Puzzleteile"
 
@@ -1160,7 +1160,7 @@ msgctxt "2026960B-123006AA-6A47B049"
 msgid "These puzzle pieces are to allow you to cross NWM networks with ElRail over Road."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47B049"
+msgctxt "2026960B-123007BB-6A47B049"
 msgid "ElRail over Road NWM Intersections"
 msgstr ""
 
@@ -1174,7 +1174,7 @@ msgstr ""
 "\n"
 "Das Baustellenstück verschwindet automatisch nach dem Bauen. Verwende das Landstraßenwerkzeug, um das Netzwerk zu verbinden und um Kreuzungen zu bauen."
 
-msgctxt "2026960B-123006BB-6A47B060"
+msgctxt "2026960B-123007BB-6A47B060"
 msgid "ElevatedRail over Avenue/Road-4 Puzzle Pieces"
 msgstr "Puzzleteile zum Bauen von erhöhtem Schienenverkehr über Allee oder Road-4"
 
@@ -1182,7 +1182,7 @@ msgctxt "2026960B-123006AA-6A47B10F"
 msgid "Puzzle Pieces to build a ground level extension of the Elevated Rail network for Light Rail/Trams."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47B10F"
+msgctxt "2026960B-123007BB-6A47B10F"
 msgid "Ground Light Rail (Tram)"
 msgstr "Straßenbahn-Puzzleteile"
 
@@ -1196,7 +1196,7 @@ msgstr ""
 "\n"
 "Benutze das Hochbahnwerkzeug, um von diesen Start-Puzzleteilen Straßenbahnschienen zu ziehen. Die Hochbahngleise verwandeln sich automatisch in ebenerdige Straßenbahngleise."
 
-msgctxt "2026960B-123006BB-6A47B3FF"
+msgctxt "2026960B-123007BB-6A47B3FF"
 msgid "Draggable Ground Light Rail (Tram)"
 msgstr "Ziehbare Straßenbahngleise"
 
@@ -1204,7 +1204,7 @@ msgctxt "2026960B-123006AA-6A47B42A"
 msgid "For building Tram-Avenue (= GroundLightRail / Avenue) - Dual Network Pieces."
 msgstr "Bauen von Alleen mit integrierten Straßenbahngleisen."
 
-msgctxt "2026960B-123006BB-6A47B42A"
+msgctxt "2026960B-123007BB-6A47B42A"
 msgid "Tram-Avenue (GroundLightRail / Avenue) - Dual Network Pieces"
 msgstr "Alleen mit integrierten Straßenbahngleisen"
 
@@ -1215,7 +1215,7 @@ msgid ""
 "These puzzle pieces are designed so that you may plop them first or you may plop them on existing networks."
 msgstr "Bauen von erhöhten Hochbahn-Überführungen über erhöhte Autobahnen, Hochbahnen und Viadukte."
 
-msgctxt "2026960B-123006BB-6A47B900"
+msgctxt "2026960B-123007BB-6A47B900"
 msgid "High Elevated Rail Puzzle Pieces"
 msgstr "Erhöhte Hochbahn-Puzzleteile"
 
@@ -1226,7 +1226,7 @@ msgid ""
 "Button contains Tram-in-Road Puzzle Pieces"
 msgstr "Bauen von Puzzleteilen der Tram-in-Hauptstraße."
 
-msgctxt "2026960B-123006BB-6A47BA00"
+msgctxt "2026960B-123007BB-6A47BA00"
 msgid "Tram-in-Road"
 msgstr "Tram-in-Hauptstraße"
 
@@ -1234,7 +1234,7 @@ msgctxt "2026960B-123006AA-6A47BBA0"
 msgid "For utilizing the Tram Puzzle Pieces"
 msgstr "Bauen von Tram-Puzzleteilen."
 
-msgctxt "2026960B-123006BB-6A47BBA0"
+msgctxt "2026960B-123007BB-6A47BBA0"
 msgid "Tram-on-Road & texture variations"
 msgstr "Tram-auf-Hauptstraße & Texturvariationen"
 
@@ -1242,7 +1242,7 @@ msgctxt "2026960B-123006AA-6A47BC60"
 msgid "For utilizing the Tram Puzzle Pieces"
 msgstr "Bauen von Puzzleteilen der Tram-auf-Nebenstraße"
 
-msgctxt "2026960B-123006BB-6A47BC60"
+msgctxt "2026960B-123007BB-6A47BC60"
 msgid "Tram-on-Street"
 msgstr "Tram auf Nebenstraße"
 
@@ -1256,7 +1256,7 @@ msgstr ""
 "\n"
 "Benutze das Hochbahnwerkzeug, um von diesen Start-Puzzleteilen Straßenbahnschienen zu ziehen. Die Hochbahngleise verwandeln sich automatisch in ebenerdige Straßenbahngleise."
 
-msgctxt "2026960B-123006BB-6A47BD00"
+msgctxt "2026960B-123007BB-6A47BD00"
 msgid "Draggable Ground Light Rail (Tram)--Additional Styles"
 msgstr "Ziehbare Straßenbahngleise - Alternativer Stil"
 
@@ -1267,7 +1267,7 @@ msgid ""
 "Button contains Starter, Filler and Overpass Puzzle Pieces for High Speed Rail (HSR)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47C000"
+msgctxt "2026960B-123007BB-6A47C000"
 msgid "High Speed Rail (HSR)"
 msgstr ""
 
@@ -1280,11 +1280,11 @@ msgid ""
 "GHSR is a ground level extension of High Speed Rail (HSR)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47C200"
+msgctxt "2026960B-123007BB-6A47C200"
 msgid "Ground High Speed Rail (GHSR)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47C700"
+msgctxt "2026960B-123007BB-6A47C700"
 msgid "Monorail Wide Radius Curve Puzzle Pieces"
 msgstr "Sanfte Monorail-Kurvenpuzzleteile"
 
@@ -1302,7 +1302,7 @@ msgid ""
 "These puzzle pieces are designed so that you may plop them first or you may plop them on existing networks."
 msgstr "Bauen von erhöhten Monorail-Überführungen über erhöhte Autobahnen, Hochbahnen und Viadukte."
 
-msgctxt "2026960B-123006BB-6A47C900"
+msgctxt "2026960B-123007BB-6A47C900"
 msgid "High Monorail Puzzle Pieces"
 msgstr "Erhöhte Monorail-Puzzleteile"
 
@@ -1310,7 +1310,7 @@ msgctxt "2026960B-123006AA-6A47CA00"
 msgid "For building Hybrid Railway straight track sections.  Hybrid Railway carries both normal Rail traffic and High Speed Rail (Monorail) traffic."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47CA00"
+msgctxt "2026960B-123007BB-6A47CA00"
 msgid "Hybrid Railway (Rail-High Speed Rail) Straight Sections"
 msgstr ""
 
@@ -1318,7 +1318,7 @@ msgctxt "2026960B-123006AA-6A47CB00"
 msgid "For building Hybrid Railway curves.  Hybrid Railway carries both normal Rail traffic and High Speed Rail (Monorail) traffic."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47CB00"
+msgctxt "2026960B-123007BB-6A47CB00"
 msgid "Hybrid Railway (Rail-High Speed Rail) Curves"
 msgstr ""
 
@@ -1329,7 +1329,7 @@ msgid ""
 "Hybrid Railway carries both normal Rail traffic and High Speed Rail (Monorail) traffic."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47CD00"
+msgctxt "2026960B-123007BB-6A47CD00"
 msgid "Hybrid Railway (Rail-High Speed Rail) Switches"
 msgstr ""
 
@@ -1340,7 +1340,7 @@ msgid ""
 "Use ground-level Hybrid Railway segments, and connect to the elevated end of the transitions (or to other already elevated sections) to elevate them."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47CE00"
+msgctxt "2026960B-123007BB-6A47CE00"
 msgid "Hybrid Railway (Rail-High Speed Rail) Height Transitions"
 msgstr ""
 
@@ -1348,7 +1348,7 @@ msgctxt "2026960B-123006AA-6A47DC00"
 msgid "Button contains Ground Highway Puzzle Pieces"
 msgstr "Bauen von ebenerdigen Autobahn-Puzzleteilen"
 
-msgctxt "2026960B-123006BB-6A47DC00"
+msgctxt "2026960B-123007BB-6A47DC00"
 msgid "Ground Highway Puzzle Pieces"
 msgstr "Ebenerdige Autobahn-Puzzleteile"
 
@@ -1359,7 +1359,7 @@ msgid ""
 "Button contains Single-Sided Perpendicular Ramps for Elevated Highway"
 msgstr "Bauen von einseitigen Autobahnauffahrten für erhöhte Autobahnen"
 
-msgctxt "2026960B-123006BB-6A47E010"
+msgctxt "2026960B-123007BB-6A47E010"
 msgid ""
 "Single-Sided Perpendicular Ramps\n"
 "\n"
@@ -1373,7 +1373,7 @@ msgid ""
 "Button contains Single-Sided Parallel Ramps for both Ground Highway and Elevated Highway"
 msgstr "Bauen von seitlichen Autobahnauffahrten für ebenerdige und erhöhte Autobahnen"
 
-msgctxt "2026960B-123006BB-6A47E050"
+msgctxt "2026960B-123007BB-6A47E050"
 msgid ""
 "Single-Sided Parallel Ramps\n"
 "\n"
@@ -1384,15 +1384,15 @@ msgctxt "2026960B-123006AA-6A47E100"
 msgid "Button contains Custom Interchanges"
 msgstr "Bauen von zusätzlichen Autobahnkreuzen für erhöhte Autobahnen"
 
-msgctxt "2026960B-123006BB-6A47E100"
+msgctxt "2026960B-123007BB-6A47E100"
 msgid "Custom Interchanges"
 msgstr "Zusätzliche Autobahnkreuze"
 
-msgctxt "2026960B-123006BB-6A47FFFF"
+msgctxt "2026960B-123007BB-6A47FFFF"
 msgid "Network Addon Mod Controller"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A476200"
+msgctxt "2026960B-123007BB-6A476200"
 msgid "Draggable Pedmalls"
 msgstr "Ziehbare Fußgängerzonen"
 

--- a/ltext/es/buttons.po
+++ b/ltext/es/buttons.po
@@ -36,7 +36,7 @@ msgid ""
 "Button contains Parallel Ramps for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-52001000"
+msgctxt "2026960B-123007BB-52001000"
 msgid ""
 "Parallel Ramps\n"
 "\n"
@@ -50,7 +50,7 @@ msgid ""
 "Button contains Overpass/Perpendicular Ramps for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-52001010"
+msgctxt "2026960B-123007BB-52001010"
 msgid ""
 "Overpass/Perpendicular Ramps\n"
 "\n"
@@ -64,7 +64,7 @@ msgid ""
 "Button contains Cloverleaves for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-52001020"
+msgctxt "2026960B-123007BB-52001020"
 msgid ""
 "Cloverleaf\n"
 "\n"
@@ -78,7 +78,7 @@ msgid ""
 "Button contains T-Intersections for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-52002000"
+msgctxt "2026960B-123007BB-52002000"
 msgid ""
 "T-Intersections\n"
 "\n"
@@ -89,7 +89,7 @@ msgctxt "2026960B-123006AA-6A470100"
 msgid "With the Canal Addon Mod you can build functional canals"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A470100"
+msgctxt "2026960B-123007BB-6A470100"
 msgid "Canal Addon Mod"
 msgstr ""
 
@@ -101,7 +101,7 @@ msgid ""
 "Drag the listed network through the FLEX/Starter Piece to construct the turn lane."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A470460"
+msgctxt "2026960B-123007BB-6A470460"
 msgid "FLEX Turn Lanes (FTLs)"
 msgstr ""
 
@@ -112,7 +112,7 @@ msgid ""
 "Button contains QuickTurn setups, which are FLEX intersections with turn lanes"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A4704A0"
+msgctxt "2026960B-123007BB-6A4704A0"
 msgid "QuickTurn (Pre-Built FLEX Turn Lane Setups)"
 msgstr ""
 
@@ -123,7 +123,7 @@ msgid ""
 "Button contains Turn Lane and Slip Lane Puzzle Pieces for various networks and configurations"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A4704E0"
+msgctxt "2026960B-123007BB-6A4704E0"
 msgid "TuLEPs (Turn Lane Extension Pieces) (OLD)"
 msgstr ""
 
@@ -134,7 +134,7 @@ msgid ""
 "Button contains Turn Lane puzzle pieces for 7-lane Turning Lane Avenue (TLA-7) and 6-lane Avenue (AVE-6) networks"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A470600"
+msgctxt "2026960B-123007BB-6A470600"
 msgid "Network Widening Mod (NWM) Triple-Tile Network Turn Lane Extension Pieces (TuLEPs)"
 msgstr ""
 
@@ -145,7 +145,7 @@ msgid ""
 "Button contains components for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A473141"
+msgctxt "2026960B-123007BB-6A473141"
 msgid ""
 "Symphony Prefab Interchange Components\n"
 "\n"
@@ -159,7 +159,7 @@ msgid ""
 "Button contains components for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A473143"
+msgctxt "2026960B-123007BB-6A473143"
 msgid ""
 "Symphony Ramp Interfaces\n"
 "\n"
@@ -173,7 +173,7 @@ msgid ""
 "The first item is the starter piece."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A474000"
+msgctxt "2026960B-123007BB-6A474000"
 msgid "Single-Track Rail (STR)"
 msgstr ""
 
@@ -185,7 +185,7 @@ msgid ""
 "Drag the RealHighway (RHW-2) network tool through the Starter Piece to construct the desired override network."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475000"
+msgctxt "2026960B-123007BB-6A475000"
 msgid "RealHighway (RHW) Starter Pieces"
 msgstr ""
 
@@ -205,7 +205,7 @@ msgstr ""
 "\n"
 "Es requisito para construir rampas RHW internas trazadas"
 
-msgctxt "2026960B-123006BB-6A475024"
+msgctxt "2026960B-123007BB-6A475024"
 msgid "Network Eraser"
 msgstr "Borra-redes"
 
@@ -216,7 +216,7 @@ msgid ""
 "Button contains Filler Pieces to build RHW networks in smaller chunks, in unstable situations"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475050"
+msgctxt "2026960B-123007BB-6A475050"
 msgid "RealHighway Filler Pieces"
 msgstr ""
 
@@ -229,7 +229,7 @@ msgid ""
 "These items are DEPRECATED, and the use of the FLEX Neighbor Connections is recommended instead."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47508C"
+msgctxt "2026960B-123007BB-6A47508C"
 msgid "Old RealHighway Neighbor Connector Puzzle Pieces  - DEPRECATED"
 msgstr ""
 
@@ -242,7 +242,7 @@ msgid ""
 "NOTE: ALL REALHIGHWAY NEIGHBOR CONNECTIONS (EXCEPT RHW-2) ARE REQUIRED TO USE NEIGHBOR CONNECTOR PIECES TO ENSURE PROPERLY FUNCTIONING NEIGHBOR CONNECTIONS--OTHERWISE ONLY FREIGHT TRUCKS WILL USE THE RHW"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475090"
+msgctxt "2026960B-123007BB-6A475090"
 msgid "RealHighway FLEX Neighbor Connector Pieces (FLEX-NC)"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgctxt "2026960B-123006AA-6A475100"
 msgid "For building DEPRECATED RealHighway Ramp Interfaces.  All of the functionality of the 47 pieces contained and many more are covered by the FLEXRamp system."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475100"
+msgctxt "2026960B-123007BB-6A475100"
 msgid "OBSOLETE RealHighway Ramp Interfaces (Static Puzzle-Based)"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgid ""
 "Button contains Type B Ramp Interface Pieces for building interchanges with the RHW"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475104"
+msgctxt "2026960B-123007BB-6A475104"
 msgid "RealHighway Type B Ramp Interfaces"
 msgstr ""
 
@@ -272,7 +272,7 @@ msgid ""
 "Button contains Type E Ramp Interface Pieces for building interchanges with the RHW"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475109"
+msgctxt "2026960B-123007BB-6A475109"
 msgid "RealHighway Type E Ramp Interfaces"
 msgstr ""
 
@@ -283,7 +283,7 @@ msgid ""
 "Button contains Type D Ramp Interface Pieces for building interchanges with the RHW"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47510A"
+msgctxt "2026960B-123007BB-6A47510A"
 msgid "RealHighway Type D Ramp Interfaces"
 msgstr ""
 
@@ -294,7 +294,7 @@ msgid ""
 "Deprecated puzzle piece ramps follow Volleyball pieces - use of the FLEXRamps or Draggable Ramp Interfaces (DRIs) is recommended instead of using the deprecated puzzle pieces."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475118"
+msgctxt "2026960B-123007BB-6A475118"
 msgid "Specialized and Deprecated RealHighway Ramp Interfaces and Volleyball Crossings (Static Puzzle-Based)"
 msgstr ""
 
@@ -305,7 +305,7 @@ msgid ""
 "Button contains FLEX pieces for different overrideable ramp interfaces.  Drag appropriate networks through to convert base ramp to match."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A4751F0"
+msgctxt "2026960B-123007BB-6A4751F0"
 msgid "RealHighway FLEXRamps"
 msgstr ""
 
@@ -316,7 +316,7 @@ msgid ""
 "Button contains pieces to build Wide Curves for the RHW networks"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475220"
+msgctxt "2026960B-123007BB-6A475220"
 msgid "RealHighway Wide-Radius and Multi-Radius (Smooth) Curves"
 msgstr ""
 
@@ -329,7 +329,7 @@ msgid ""
 "These items are DEPRECATED and use of the FLEX Width Transitions (FLEX-WT) is recommended instead."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475300"
+msgctxt "2026960B-123007BB-6A475300"
 msgid "Old RealHighway Width Transition Puzzle Pieces - DEPRECATED"
 msgstr ""
 
@@ -342,7 +342,7 @@ msgid ""
 "All functionality here has been duplicated with the FLEX Height Transitions, and as such, this button is DEPRECATED."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475312"
+msgctxt "2026960B-123007BB-6A475312"
 msgid "Old RealHighway Height Transition Puzzle Pieces  - DEPRECATED"
 msgstr ""
 
@@ -358,7 +358,7 @@ msgstr ""
 "\n"
 "Las piezas se giran usando las teclas Inicio y Fin; las teclas Tab y Shift+Tab (o Ctrl+Tab y Ctrl+Shift+Tab en macOS) cambian la pieza a usar. Cuando el cursor esté en verde, se puede colocar haciendo clic."
 
-msgctxt "2026960B-123006BB-6A475330"
+msgctxt "2026960B-123007BB-6A475330"
 msgid "RealHighway FLEX Height Transitions (FLEX-HT)"
 msgstr "Transiciones de altura flexibles de RealHighway (FLEX-HT)"
 
@@ -369,7 +369,7 @@ msgid ""
 "Button contains pieces to transition between RHW networks of different widths.  Dragging another RHW network into them will convert them to fit."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475336"
+msgctxt "2026960B-123007BB-6A475336"
 msgid "RealHighway FLEX Width Transitions (FLEX-WT)"
 msgstr ""
 
@@ -380,7 +380,7 @@ msgid ""
 "Button contains components for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475350"
+msgctxt "2026960B-123007BB-6A475350"
 msgid ""
 "Symphony Transitions\n"
 "\n"
@@ -394,7 +394,7 @@ msgid ""
 "Button contains components for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475366"
+msgctxt "2026960B-123007BB-6A475366"
 msgid ""
 "Symphony Smooth Curves\n"
 "\n"
@@ -410,7 +410,7 @@ msgid ""
 "NOTE: These pieces should NOT be confused with TuLEPs."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475400"
+msgctxt "2026960B-123007BB-6A475400"
 msgid "RealHighway Cosmetic Puzzle Pieces (for 1-Tile Networks)"
 msgstr ""
 
@@ -423,7 +423,7 @@ msgid ""
 "NOTE: These pieces should NOT be confused with TuLEPs."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475410"
+msgctxt "2026960B-123007BB-6A475410"
 msgid "RealHighway Cosmetic Piece Transitions"
 msgstr ""
 
@@ -436,7 +436,7 @@ msgid ""
 "NOTE: These pieces should NOT be confused with TuLEPs."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475440"
+msgctxt "2026960B-123007BB-6A475440"
 msgid "RealHighway Cosmetic Puzzle Pieces (for 2-Tile Networks)"
 msgstr ""
 
@@ -449,7 +449,7 @@ msgid ""
 "NOTE: These pieces should NOT be confused with TuLEPs."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475471"
+msgctxt "2026960B-123007BB-6A475471"
 msgid "RealHighway Cosmetic Puzzle Pieces (for 3-Tile Networks)"
 msgstr ""
 
@@ -462,7 +462,7 @@ msgid ""
 "<DEPRECATED>"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475500"
+msgctxt "2026960B-123007BB-6A475500"
 msgid "ERHW-over-RHW Diagonal Overpass Puzzle Pieces<DEPRECATED>"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgid ""
 "Place overcrossing pieces on top of underground roadways whenever a surface network crosses over, to allow traffic to pass underground."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475600"
+msgctxt "2026960B-123007BB-6A475600"
 msgid "RHW Flexible Underpasses (FLUPs), Draggable Underground Roads (URoads), and Overcrossings"
 msgstr ""
 
@@ -486,7 +486,7 @@ msgid ""
 "Button contains flexible RHW interchange segments.  Drag appropriate networks through to convert base ramp to match, and combine to easily create a full interchange."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475700"
+msgctxt "2026960B-123007BB-6A475700"
 msgid "RealHighway QuickChanges"
 msgstr ""
 
@@ -497,7 +497,7 @@ msgid ""
 "Button contains starter/transition FLEX pieces for different RHW turn lane setups"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475900"
+msgctxt "2026960B-123007BB-6A475900"
 msgid "RealHighway FLEX Turn Lanes (FTLs)"
 msgstr ""
 
@@ -508,7 +508,7 @@ msgid ""
 "Button contains pieces to build FLEXFly Pieces"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475AF3"
+msgctxt "2026960B-123007BB-6A475AF3"
 msgid "RealHighway FLEXFly (LEGACY/DEPRECATED)"
 msgstr ""
 
@@ -519,7 +519,7 @@ msgid ""
 "Button contains pieces to build 3-Level Crossings"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475AF6"
+msgctxt "2026960B-123007BB-6A475AF6"
 msgid "RealHighway 3-Level Crossings"
 msgstr ""
 
@@ -530,7 +530,7 @@ msgid ""
 "Button contains pieces to build FLEXFly Pieces"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475B00"
+msgctxt "2026960B-123007BB-6A475B00"
 msgid "RealHighway FLEXFly"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgid ""
 "NOTE: Most intersections require the use of TuLEPs."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475F00"
+msgctxt "2026960B-123007BB-6A475F00"
 msgid "Fractionally Angled RealHighway Intersections and Transitions"
 msgstr ""
 
@@ -554,7 +554,7 @@ msgid ""
 "Button contains straight pieces and curves to pieces to build Fractionally Angled RealHighway (FARHWs)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475F20"
+msgctxt "2026960B-123007BB-6A475F20"
 msgid "Fractionally Angled RealHighway"
 msgstr ""
 
@@ -565,7 +565,7 @@ msgid ""
 "Button contains pieces to build different FARHW Ramp Interfaces: The C1, F1, C2, F2, and C3 Ramp Interfaces"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475F30"
+msgctxt "2026960B-123007BB-6A475F30"
 msgid "Fractionally Angled RealHighway Ramp Interfaces"
 msgstr ""
 
@@ -576,7 +576,7 @@ msgid ""
 "Button contains Type C Ramp Interface Pieces for building interchanges with the RHW"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475F70"
+msgctxt "2026960B-123007BB-6A475F70"
 msgid "RealHighway Type C Ramp Interfaces"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgid ""
 "Button contains Type F Ramp Interface Pieces for building interchanges with the RHW"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475F71"
+msgctxt "2026960B-123007BB-6A475F71"
 msgid "RealHighway Type F Ramp Interfaces"
 msgstr ""
 
@@ -607,7 +607,7 @@ msgstr ""
 "\n"
 "Nota: Los lotes residenciales necesitan una conexión vehicular en su fachada, las piezas de paseo peatonal no las reemplazan."
 
-msgctxt "2026960B-123006BB-6A476005"
+msgctxt "2026960B-123007BB-6A476005"
 msgid "Pedestrian Mall Tiles"
 msgstr "Piezas de paseo peatonal"
 
@@ -615,7 +615,7 @@ msgctxt "2026960B-123006AA-6A476100"
 msgid "A collection of pedestrian crossing FLEX pieces. Use them on their own at crossing locations, or as part of pedmall corridors."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A476100"
+msgctxt "2026960B-123007BB-6A476100"
 msgid "Pedestrian Revolution Mod (PRM) FLEX Crossings"
 msgstr ""
 
@@ -631,7 +631,7 @@ msgstr ""
 "\n"
 "Las piezas se giran usando las teclas Inicio y Fin; las teclas Tab y Shift+Tab (o Ctrl+Tab y Ctrl+Shift+Tab en macOS) cambian la pieza a usar. Cuando el cursor esté en verde, se puede colocar haciendo clic"
 
-msgctxt "2026960B-123006BB-6A476525"
+msgctxt "2026960B-123007BB-6A476525"
 msgid "Diagonal Street Helper Pieces"
 msgstr "Piezas asistentes para calles diagonales"
 
@@ -642,7 +642,7 @@ msgid ""
 "Button contains Starter Pieces for Street Addon Mod (SAM)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A476700"
+msgctxt "2026960B-123007BB-6A476700"
 msgid "Street Addon Mod (SAM)"
 msgstr ""
 
@@ -650,7 +650,7 @@ msgctxt "2026960B-123006AA-6A476905"
 msgid "Plop one of these pieces on a flat area. It will raise or lower the terrain, and then destroy itself, providing a level area for a raised network of your choice. This is fully compatible with all slope mods."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A476905"
+msgctxt "2026960B-123007BB-6A476905"
 msgid "Hole Digger and Raiser Lots"
 msgstr ""
 
@@ -666,7 +666,7 @@ msgstr ""
 "\n"
 "Las piezas se giran usando las teclas Inicio y Fin; las teclas Tab y Shift+Tab (o Ctrl+Tab y Ctrl+Shift+Tab en macOS) cambian la pieza a usar. Cuando el cursor esté en verde, se puede colocar haciendo clic"
 
-msgctxt "2026960B-123006BB-6A476A00"
+msgctxt "2026960B-123007BB-6A476A00"
 msgid "Avenue Intersections"
 msgstr "Intersecciones de avenida"
 
@@ -682,7 +682,7 @@ msgstr ""
 "\n"
 "Las piezas se giran usando las teclas Inicio y Fin; las teclas Tab y Shift+Tab (o Ctrl+Tab y Ctrl+Shift+Tab en macOS) cambian la pieza a usar. Cuando el cursor esté en verde, se puede colocar haciendo clic"
 
-msgctxt "2026960B-123006BB-6A477000"
+msgctxt "2026960B-123007BB-6A477000"
 msgid "Road Overpasses"
 msgstr "Pasos sobre nivel para carretera"
 
@@ -693,7 +693,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Road"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477005"
+msgctxt "2026960B-123007BB-6A477005"
 msgid "7.5m Elevated Road Viaducts"
 msgstr ""
 
@@ -704,7 +704,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Road"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477200"
+msgctxt "2026960B-123007BB-6A477200"
 msgid "15m Elevated Road Viaducts"
 msgstr ""
 
@@ -715,7 +715,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Road, One-Way Road, or Avenue"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477500"
+msgctxt "2026960B-123007BB-6A477500"
 msgid "Wide Radius Curves (for Road, One-Way Road, Avenue, and Street) (Puzzle Pieces)"
 msgstr ""
 
@@ -726,7 +726,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Road, One-Way Road, and Avenue"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477600"
+msgctxt "2026960B-123007BB-6A477600"
 msgid "Fractionally-Angled Networks (for Road, One-Way Road, and Avenue)"
 msgstr ""
 
@@ -737,7 +737,7 @@ msgid ""
 "Once a puzzle piece is selected, use the [Home] and [End] keys to cycle through the various puzzle piece orientations"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477700"
+msgctxt "2026960B-123007BB-6A477700"
 msgid "Rural Road Puzzle Pieces"
 msgstr ""
 
@@ -748,7 +748,7 @@ msgid ""
 "Button contains pieces to interface between the NAM Elevated Road Puzzle Pieces and RHW networks, including overpasses and intersections"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477800"
+msgctxt "2026960B-123007BB-6A477800"
 msgid "Road/RHW Overpass and Interface Puzzle Pieces (DEPRECATED)"
 msgstr ""
 
@@ -759,7 +759,7 @@ msgid ""
 "Button contains several different FLEX Pieces for various networks"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477900"
+msgctxt "2026960B-123007BB-6A477900"
 msgid "Multi-Radius Curve (MRC) FLEX Pieces for Surface Networks"
 msgstr ""
 
@@ -789,7 +789,7 @@ msgstr ""
 "\n"
 "El nuevo sistema de pasos bajo nivel FLUP basado en la herramienta metro está en el menú de autopistas."
 
-msgctxt "2026960B-123006BB-6A477A00"
+msgctxt "2026960B-123007BB-6A477A00"
 msgid "Flexible Underpasses (FLUPs)"
 msgstr "Pasos bajo nivel flexibles (FLUPs)"
 
@@ -800,7 +800,7 @@ msgid ""
 "Button contains Starter Pieces for the 3, 5 and 7-lane Turning Lane Avenues (TLA-3,5,7), 2 and 6-lane Avenues (AVE-2,6), 3-lane Asymmetrical Road (ARD-3), 4 and 6-lane Roads RD-4,6) and 1, 3, 4 and 5-lane One-Way Roads (OWR-1,3,4,5)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477B00"
+msgctxt "2026960B-123007BB-6A477B00"
 msgid "Network Widening Mod (NWM) Starter Pieces"
 msgstr ""
 
@@ -811,7 +811,7 @@ msgid ""
 "Button contains Wide-Radius Curve Pieces for the single-tile NWM networks"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477B30"
+msgctxt "2026960B-123007BB-6A477B30"
 msgid "Network Widening Mod (NWM) Curve Pieces"
 msgstr ""
 
@@ -824,7 +824,7 @@ msgid ""
 "Note that most transitions involving single and dual-tile networks can be built using draggable means instead (such as direct connections or using the stub-to-stub method)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477B50"
+msgctxt "2026960B-123007BB-6A477B50"
 msgid "Network Widening Mod (NWM) Transition Pieces"
 msgstr ""
 
@@ -835,7 +835,7 @@ msgid ""
 "Button contains Neighbor Connector Pieces for the TLA-5, RD-4 and RD-6"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477BF0"
+msgctxt "2026960B-123007BB-6A477BF0"
 msgid "Network Widening Mod (NWM) Neighbor Connector Pieces"
 msgstr ""
 
@@ -846,7 +846,7 @@ msgid ""
 "Button contains FLEX Single Tile Roundabouts intersections for various road networks"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477C00"
+msgctxt "2026960B-123007BB-6A477C00"
 msgid "Single Tile Roundabouts"
 msgstr ""
 
@@ -859,7 +859,7 @@ msgid ""
 "Button contains OnSlope Transitions to start Alternate Style Road and Street Viaducts"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477E00"
+msgctxt "2026960B-123007BB-6A477E00"
 msgid "Road Viaduct Alternate Styles"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgid ""
 "Button contains several different Starter and FLEX Pieces for Draggable Elevated Road Viaducts"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477F00"
+msgctxt "2026960B-123007BB-6A477F00"
 msgid "Draggable Elevated Road Viaducts"
 msgstr ""
 
@@ -883,7 +883,7 @@ msgid ""
 "Drag networks under (or over) the mid-section of the overpass to build the crossing.  Most networks and FLEX-based dual-networks are supported."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477F30"
+msgctxt "2026960B-123007BB-6A477F30"
 msgid "FLEX Overpasses"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgid ""
 "Button contains several different overpasses for One-Way Road"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A478000"
+msgctxt "2026960B-123007BB-6A478000"
 msgid "One-Way Road Overpasses"
 msgstr ""
 
@@ -905,7 +905,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for One-Way Road"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A478005"
+msgctxt "2026960B-123007BB-6A478005"
 msgid "15m Elevated One-Way Road Viaducts"
 msgstr ""
 
@@ -916,7 +916,7 @@ msgid ""
 "Button contains pieces to interface between the NAM Elevated One-Way Road Puzzle Pieces and RHW networks, including overpasses and intersections"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A478800"
+msgctxt "2026960B-123007BB-6A478800"
 msgid "One-Way Road/RHW Overpass and Interface Puzzle Pieces (DEPRECATED)"
 msgstr ""
 
@@ -924,7 +924,7 @@ msgctxt "2026960B-123006AA-6A478900"
 msgid "For use of the curved pieces for the Real Expressway Network. Use the Home/End key to rotate the FLEX Piece & use TAB/Shift-TAB (Ctrl-TAB/Ctrl-Shift-TAB on macOS) to cycle through the different types of REW Straights and Curves."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A478900"
+msgctxt "2026960B-123007BB-6A478900"
 msgid "Real Expressway FLEX Piece network tool and Curves."
 msgstr ""
 
@@ -935,7 +935,7 @@ msgid ""
 "Button contains FLEX pieces for different overrideable ramp interfaces.  Drag appropriate networks through to convert base ramp to match."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A478B00"
+msgctxt "2026960B-123007BB-6A478B00"
 msgid "RealExpressway (REW) One-Way Road FLEXRamps"
 msgstr ""
 
@@ -946,7 +946,7 @@ msgid ""
 "Button contains several different overpasses for Avenue"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A479000"
+msgctxt "2026960B-123007BB-6A479000"
 msgid "Avenue Overpasses"
 msgstr ""
 
@@ -957,7 +957,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Avenue"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A479005"
+msgctxt "2026960B-123007BB-6A479005"
 msgid "7.5m Elevated Avenue Viaducts"
 msgstr ""
 
@@ -968,7 +968,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Avenue"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A479200"
+msgctxt "2026960B-123007BB-6A479200"
 msgid "15m Elevated Avenue Viaducts"
 msgstr ""
 
@@ -979,7 +979,7 @@ msgid ""
 "Button contains pieces to interface between the NAM Elevated Avenue Puzzle Pieces and RHW networks, including overpasses and intersections"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A479900"
+msgctxt "2026960B-123007BB-6A479900"
 msgid "Avenue/RHW Overpass and Interface Puzzle Pieces (DEPRECATED)"
 msgstr ""
 
@@ -992,7 +992,7 @@ msgid ""
 "FlexSPUI and Flex Diverging Diamond (FlexDDI) pieces are found under this button"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47991A"
+msgctxt "2026960B-123007BB-6A47991A"
 msgid "Specialized RHW x Surface Intersections"
 msgstr ""
 
@@ -1003,7 +1003,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Rail."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47A005"
+msgctxt "2026960B-123007BB-6A47A005"
 msgid "Rail Puzzle Pieces"
 msgstr ""
 
@@ -1011,7 +1011,7 @@ msgctxt "2026960B-123006AA-6A47A130"
 msgid "Button contains FLEX pieces to elevated the Rail network to viaduct level (using the RealRailway (RRW) standard)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47A130"
+msgctxt "2026960B-123007BB-6A47A130"
 msgid "Draggable Elevated Railways (ERRW)"
 msgstr ""
 
@@ -1022,7 +1022,7 @@ msgid ""
 "Once a puzzle piece is selected, use the [Home] and [End] keys to cycle through the various puzzle piece orientations"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47A358"
+msgctxt "2026960B-123007BB-6A47A358"
 msgid "Wide Radius Railroad Curve and Double Track Rail Switch Puzzle Pieces"
 msgstr ""
 
@@ -1033,7 +1033,7 @@ msgid ""
 "Once a puzzle piece is selected, use the [Home] and [End] keys to cycle through the various puzzle piece orientations"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47A368"
+msgctxt "2026960B-123007BB-6A47A368"
 msgid "Fractional Angle Railroad (FARR) Puzzle Pieces"
 msgstr ""
 
@@ -1044,7 +1044,7 @@ msgid ""
 "Button contains pieces to interface between the NAM Elevated Rail Viaduct Puzzle Pieces and RHW networks, including overpasses and intersections"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47A800"
+msgctxt "2026960B-123007BB-6A47A800"
 msgid "Rail Viaduct/RHW Overpass and Interface Puzzle Pieces"
 msgstr ""
 
@@ -1055,7 +1055,7 @@ msgid ""
 "Once a puzzle piece is selected, use the [Home] and [End] keys to cycle through the various puzzle piece orientations"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47A900"
+msgctxt "2026960B-123007BB-6A47A900"
 msgid "Wide Radius Railroad Curve and Double Track Rail Switch Puzzle Pieces"
 msgstr ""
 
@@ -1066,7 +1066,7 @@ msgid ""
 "Button contains several different Pieces for Dual/Double-Decker Networking."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AA0F"
+msgctxt "2026960B-123007BB-6A47AA0F"
 msgid ""
 "Underground Rail\n"
 "Rail Tunnel under Roads Dual Networking Puzzle Pieces"
@@ -1082,7 +1082,7 @@ msgid ""
 "Button contains several different Pieces for Dual/Double-Decker Networking."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AA10"
+msgctxt "2026960B-123007BB-6A47AA10"
 msgid ""
 "Underground Rail\n"
 "Rail Tunnel under Ped Malls Dual Networking Puzzle Pieces"
@@ -1098,7 +1098,7 @@ msgid ""
 "Button contains several different Pieces for Maxis Roadways."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AA11"
+msgctxt "2026960B-123007BB-6A47AA11"
 msgid ""
 "Underground Rail\n"
 "Maxis Roadway Intersection Pieces"
@@ -1114,7 +1114,7 @@ msgid ""
 "Button contains several different Pieces for Railways."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AA12"
+msgctxt "2026960B-123007BB-6A47AA12"
 msgid ""
 "Underground Rail\n"
 "Railway Intersection Pieces"
@@ -1130,7 +1130,7 @@ msgid ""
 "Button contains several different Pieces for Tramways."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AA13"
+msgctxt "2026960B-123007BB-6A47AA13"
 msgid ""
 "Underground Rail\n"
 "Tramway Intersection Pieces"
@@ -1146,7 +1146,7 @@ msgid ""
 "Button contains several different Pieces for Dual/Double-Decker Networking."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AA8A"
+msgctxt "2026960B-123007BB-6A47AA8A"
 msgid ""
 "Underground Rail\n"
 "Miscellaneous Puzzle Pieces"
@@ -1159,7 +1159,7 @@ msgctxt "2026960B-123006AA-6A47AC00"
 msgid "All pieces in this section are FLEX and conform to flextrack standards!"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AC00"
+msgctxt "2026960B-123007BB-6A47AC00"
 msgid "RealRailway FLEX Curve Pieces."
 msgstr ""
 
@@ -1167,7 +1167,7 @@ msgctxt "2026960B-123006AA-6A47AC10"
 msgid "All pieces in this section are FLEX and conform to flextrack standards!"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AC10"
+msgctxt "2026960B-123007BB-6A47AC10"
 msgid "RealRailway FLEX Turnout Pieces."
 msgstr ""
 
@@ -1175,7 +1175,7 @@ msgctxt "2026960B-123006AA-6A47AD00"
 msgid "All pieces in this section are FLEX and conform to flextrack and FARR standards!\n"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AD00"
+msgctxt "2026960B-123007BB-6A47AD00"
 msgid "RealRailway FLEX Fractional Angled (FA) Pieces."
 msgstr ""
 
@@ -1186,7 +1186,7 @@ msgid ""
 "Button contains several different Pieces for Dual/Double-Decker Networking."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47B03A"
+msgctxt "2026960B-123007BB-6A47B03A"
 msgid "ElevatedRail Dual/Double-Decker Network Pieces"
 msgstr ""
 
@@ -1194,7 +1194,7 @@ msgctxt "2026960B-123006AA-6A47B049"
 msgid "These puzzle pieces are to allow you to cross NWM networks with ElRail over Road."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47B049"
+msgctxt "2026960B-123007BB-6A47B049"
 msgid "ElRail over Road NWM Intersections"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgid ""
 "The construction lot vanishes automatically. Use the Road Tool to connect the network and to build intersections."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47B060"
+msgctxt "2026960B-123007BB-6A47B060"
 msgid "ElevatedRail over Avenue/Road-4 Puzzle Pieces"
 msgstr ""
 
@@ -1213,7 +1213,7 @@ msgctxt "2026960B-123006AA-6A47B10F"
 msgid "Puzzle Pieces to build a ground level extension of the Elevated Rail network for Light Rail/Trams."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47B10F"
+msgctxt "2026960B-123007BB-6A47B10F"
 msgid "Ground Light Rail (Tram)"
 msgstr ""
 
@@ -1224,7 +1224,7 @@ msgid ""
 "Connect the Elevated Rail network with the Starter Piece. The Elevated Rail will turn into a Ground Light Rail track."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47B3FF"
+msgctxt "2026960B-123007BB-6A47B3FF"
 msgid "Draggable Ground Light Rail (Tram)"
 msgstr ""
 
@@ -1232,7 +1232,7 @@ msgctxt "2026960B-123006AA-6A47B42A"
 msgid "For building Tram-Avenue (= GroundLightRail / Avenue) - Dual Network Pieces."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47B42A"
+msgctxt "2026960B-123007BB-6A47B42A"
 msgid "Tram-Avenue (GroundLightRail / Avenue) - Dual Network Pieces"
 msgstr ""
 
@@ -1243,7 +1243,7 @@ msgid ""
 "These puzzle pieces are designed so that you may plop them first or you may plop them on existing networks."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47B900"
+msgctxt "2026960B-123007BB-6A47B900"
 msgid "High Elevated Rail Puzzle Pieces"
 msgstr ""
 
@@ -1254,7 +1254,7 @@ msgid ""
 "Button contains Tram-in-Road Puzzle Pieces"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47BA00"
+msgctxt "2026960B-123007BB-6A47BA00"
 msgid "Tram-in-Road"
 msgstr ""
 
@@ -1262,7 +1262,7 @@ msgctxt "2026960B-123006AA-6A47BBA0"
 msgid "For utilizing the Tram Puzzle Pieces"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47BBA0"
+msgctxt "2026960B-123007BB-6A47BBA0"
 msgid "Tram-on-Road & texture variations"
 msgstr ""
 
@@ -1270,7 +1270,7 @@ msgctxt "2026960B-123006AA-6A47BC60"
 msgid "For utilizing the Tram Puzzle Pieces"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47BC60"
+msgctxt "2026960B-123007BB-6A47BC60"
 msgid "Tram-on-Street"
 msgstr ""
 
@@ -1281,7 +1281,7 @@ msgid ""
 "Button contains starters for two additional Ground Light Rail styles, plus filler pieces."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47BD00"
+msgctxt "2026960B-123007BB-6A47BD00"
 msgid "Draggable Ground Light Rail (Tram)--Additional Styles"
 msgstr ""
 
@@ -1292,7 +1292,7 @@ msgid ""
 "Button contains Starter, Filler and Overpass Puzzle Pieces for High Speed Rail (HSR)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47C000"
+msgctxt "2026960B-123007BB-6A47C000"
 msgid "High Speed Rail (HSR)"
 msgstr ""
 
@@ -1305,11 +1305,11 @@ msgid ""
 "GHSR is a ground level extension of High Speed Rail (HSR)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47C200"
+msgctxt "2026960B-123007BB-6A47C200"
 msgid "Ground High Speed Rail (GHSR)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47C700"
+msgctxt "2026960B-123007BB-6A47C700"
 msgid "Monorail Wide Radius Curve Puzzle Pieces"
 msgstr ""
 
@@ -1327,7 +1327,7 @@ msgid ""
 "These puzzle pieces are designed so that you may plop them first or you may plop them on existing networks."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47C900"
+msgctxt "2026960B-123007BB-6A47C900"
 msgid "High Monorail Puzzle Pieces"
 msgstr ""
 
@@ -1335,7 +1335,7 @@ msgctxt "2026960B-123006AA-6A47CA00"
 msgid "For building Hybrid Railway straight track sections.  Hybrid Railway carries both normal Rail traffic and High Speed Rail (Monorail) traffic."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47CA00"
+msgctxt "2026960B-123007BB-6A47CA00"
 msgid "Hybrid Railway (Rail-High Speed Rail) Straight Sections"
 msgstr ""
 
@@ -1343,7 +1343,7 @@ msgctxt "2026960B-123006AA-6A47CB00"
 msgid "For building Hybrid Railway curves.  Hybrid Railway carries both normal Rail traffic and High Speed Rail (Monorail) traffic."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47CB00"
+msgctxt "2026960B-123007BB-6A47CB00"
 msgid "Hybrid Railway (Rail-High Speed Rail) Curves"
 msgstr ""
 
@@ -1354,7 +1354,7 @@ msgid ""
 "Hybrid Railway carries both normal Rail traffic and High Speed Rail (Monorail) traffic."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47CD00"
+msgctxt "2026960B-123007BB-6A47CD00"
 msgid "Hybrid Railway (Rail-High Speed Rail) Switches"
 msgstr ""
 
@@ -1370,7 +1370,7 @@ msgstr ""
 "\n"
 "Las piezas se giran usando las teclas Inicio y Fin; las teclas Tab y Shift+Tab (o Ctrl+Tab y Ctrl+Shift+Tab en macOS) cambian la pieza a usar. Cuando el cursor esté en verde, se puede colocar haciendo clic."
 
-msgctxt "2026960B-123006BB-6A47CE00"
+msgctxt "2026960B-123007BB-6A47CE00"
 msgid "Hybrid Railway (Rail-High Speed Rail) Height Transitions"
 msgstr "Transiciones de altura para Ferrocarril Híbrido (HRW)"
 
@@ -1378,7 +1378,7 @@ msgctxt "2026960B-123006AA-6A47DC00"
 msgid "Button contains Ground Highway Puzzle Pieces"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47DC00"
+msgctxt "2026960B-123007BB-6A47DC00"
 msgid "Ground Highway Puzzle Pieces"
 msgstr ""
 
@@ -1389,7 +1389,7 @@ msgid ""
 "Button contains Single-Sided Perpendicular Ramps for Elevated Highway"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47E010"
+msgctxt "2026960B-123007BB-6A47E010"
 msgid ""
 "Single-Sided Perpendicular Ramps\n"
 "\n"
@@ -1403,7 +1403,7 @@ msgid ""
 "Button contains Single-Sided Parallel Ramps for both Ground Highway and Elevated Highway"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47E050"
+msgctxt "2026960B-123007BB-6A47E050"
 msgid ""
 "Single-Sided Parallel Ramps\n"
 "\n"
@@ -1414,15 +1414,15 @@ msgctxt "2026960B-123006AA-6A47E100"
 msgid "Button contains Custom Interchanges"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47E100"
+msgctxt "2026960B-123007BB-6A47E100"
 msgid "Custom Interchanges"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47FFFF"
+msgctxt "2026960B-123007BB-6A47FFFF"
 msgid "Network Addon Mod Controller"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A476200"
+msgctxt "2026960B-123007BB-6A476200"
 msgid "Draggable Pedmalls"
 msgstr "Plazas Peatonales Trazables"
 

--- a/ltext/fr/buttons.po
+++ b/ltext/fr/buttons.po
@@ -34,7 +34,7 @@ msgid ""
 "Button contains Parallel Ramps for both Ground Highway and Elevated Highway."
 msgstr "L'outil permet de construire des bretelles parallèles pour les autoroutes de sol ou surélevées."
 
-msgctxt "2026960B-123006BB-52001000"
+msgctxt "2026960B-123007BB-52001000"
 msgid ""
 "Parallel Ramps\n"
 "\n"
@@ -48,7 +48,7 @@ msgid ""
 "Button contains Overpass/Perpendicular Ramps for both Ground Highway and Elevated Highway."
 msgstr "L'outil permet de construire des passages supérieurs et ponts orthogonaux pour autoroutes de sol et surélevées."
 
-msgctxt "2026960B-123006BB-52001010"
+msgctxt "2026960B-123007BB-52001010"
 msgid ""
 "Overpass/Perpendicular Ramps\n"
 "\n"
@@ -62,7 +62,7 @@ msgid ""
 "Button contains Cloverleaves for both Ground Highway and Elevated Highway."
 msgstr "Cet outil contient les éléments pour construire des échangeurs en trèfle, pour autoroutes de sol et surélevées."
 
-msgctxt "2026960B-123006BB-52001020"
+msgctxt "2026960B-123007BB-52001020"
 msgid ""
 "Cloverleaf\n"
 "\n"
@@ -76,7 +76,7 @@ msgid ""
 "Button contains T-Intersections for both Ground Highway and Elevated Highway."
 msgstr "L'outil contient les éléments pour construire des échangeurs en T pour les autoroutes de sol et surélevées."
 
-msgctxt "2026960B-123006BB-52002000"
+msgctxt "2026960B-123007BB-52002000"
 msgid ""
 "T-Intersections\n"
 "\n"
@@ -87,7 +87,7 @@ msgctxt "2026960B-123006AA-6A470100"
 msgid "With the Canal Addon Mod you can build functional canals"
 msgstr "Le Canal Addon Mod vous permet de construire des canaux fonctionnels. "
 
-msgctxt "2026960B-123006BB-6A470100"
+msgctxt "2026960B-123007BB-6A470100"
 msgid "Canal Addon Mod"
 msgstr "Canal Addon Mod (CAN-AM)"
 
@@ -102,7 +102,7 @@ msgstr ""
 "Cet outil contient les Pièces-Initiales pour construire des voies médianes et intersections FLEX pour les diverses Routes.\n"
 "Glissez l'outil de route adapté à travers la Pièce-Initiale correspondante pour construire la chaussée."
 
-msgctxt "2026960B-123006BB-6A470460"
+msgctxt "2026960B-123007BB-6A470460"
 msgid "FLEX Turn Lanes (FTLs)"
 msgstr "Voies médianes et intersections FLEX (FTLs)"
 
@@ -113,7 +113,7 @@ msgid ""
 "Button contains QuickTurn setups, which are FLEX intersections with turn lanes"
 msgstr "L'outil contient des configurations d'intersections préfabriquées FLEX (dynamiques) avec voies médianes."
 
-msgctxt "2026960B-123006BB-6A4704A0"
+msgctxt "2026960B-123007BB-6A4704A0"
 msgid "QuickTurn (Pre-Built FLEX Turn Lane Setups)"
 msgstr "Intersections préfabriquées (Configurations FLEX)"
 
@@ -124,7 +124,7 @@ msgid ""
 "Button contains Turn Lane and Slip Lane Puzzle Pieces for various networks and configurations"
 msgstr "L'outil contient les anciennes Pièces-Puzzles (TuLEPs) pour établir des voies médianes et intersections de différentes chaussées et configurations."
 
-msgctxt "2026960B-123006BB-6A4704E0"
+msgctxt "2026960B-123007BB-6A4704E0"
 msgid "TuLEPs (Turn Lane Extension Pieces) (OLD)"
 msgstr "Voies médianes et intersections (Anciennes pièces TuLEPs)"
 
@@ -138,7 +138,7 @@ msgstr ""
 "L'outil propose les Pièces-Puzzles pour les chaussées à 7 voies (TLA-7) et à 6 voies (AVE-6).\n"
 "Pièces TuLEPs."
 
-msgctxt "2026960B-123006BB-6A470600"
+msgctxt "2026960B-123007BB-6A470600"
 msgid "Network Widening Mod (NWM) Triple-Tile Network Turn Lane Extension Pieces (TuLEPs)"
 msgstr "Voies médianes et intersections de triple-carreaux (NWM)"
 
@@ -149,7 +149,7 @@ msgid ""
 "Button contains components for both Ground Highway and Elevated Highway."
 msgstr "L'outil contient des éléments préfabriqués pour les autoroutes de sol et surélevées."
 
-msgctxt "2026960B-123006BB-6A473141"
+msgctxt "2026960B-123007BB-6A473141"
 msgid ""
 "Symphony Prefab Interchange Components\n"
 "\n"
@@ -163,7 +163,7 @@ msgid ""
 "Button contains components for both Ground Highway and Elevated Highway."
 msgstr "Cet outil contient des éléments pour les autoroutes de sol et surélevées."
 
-msgctxt "2026960B-123006BB-6A473143"
+msgctxt "2026960B-123007BB-6A473143"
 msgid ""
 "Symphony Ramp Interfaces\n"
 "\n"
@@ -179,7 +179,7 @@ msgstr ""
 "Utilisez ces éléments pour construire des Rails à voie unique (STR)\n"
 "Le premier élément est une Pièces-Initiales."
 
-msgctxt "2026960B-123006BB-6A474000"
+msgctxt "2026960B-123007BB-6A474000"
 msgid "Single-Track Rail (STR)"
 msgstr "Voie ferrée unique (STR)"
 
@@ -195,7 +195,7 @@ msgstr ""
 "\n"
 "Faites glisser l'outil de réseau Autoroute (RHW-2) à travers la Pièce-Initiale pour construire la chaussée."
 
-msgctxt "2026960B-123006BB-6A475000"
+msgctxt "2026960B-123007BB-6A475000"
 msgid "RealHighway (RHW) Starter Pieces"
 msgstr "Autoroutes (RHW), Pièces-Initiales"
 
@@ -217,7 +217,7 @@ msgstr ""
 "\n"
 "Placez la gomme sur le carreau souhaitée et redessinez si nécessaire."
 
-msgctxt "2026960B-123006BB-6A475024"
+msgctxt "2026960B-123007BB-6A475024"
 msgid "Network Eraser"
 msgstr "Gomme de segment de réseau"
 
@@ -228,7 +228,7 @@ msgid ""
 "Button contains Filler Pieces to build RHW networks in smaller chunks, in unstable situations"
 msgstr "L'outil contient des pièces de remplissage pour construire des autoroutes (RHW) par petits morceaux, dans des situations instables."
 
-msgctxt "2026960B-123006BB-6A475050"
+msgctxt "2026960B-123007BB-6A475050"
 msgid "RealHighway Filler Pieces"
 msgstr "Autoroutes (RHW), Pièces de Remplissage"
 
@@ -244,7 +244,7 @@ msgstr ""
 "\n"
 "Ces éléments sont OBSOLÈTES et il est recommandé d'utiliser les connecteurs de voisinage FLEX."
 
-msgctxt "2026960B-123006BB-6A47508C"
+msgctxt "2026960B-123007BB-6A47508C"
 msgid "Old RealHighway Neighbor Connector Puzzle Pieces  - DEPRECATED"
 msgstr "Connecteur d'autoroute (RHW), Pièce-Puzzle de liaison de voisinage - OBSOLÈTE"
 
@@ -260,7 +260,7 @@ msgstr ""
 "\n"
 "NOTE : Toutes les  LIAISONS DE VOISINAGE D'AUTOROUTES (sauf RHW-2) doivent utiliser CES CONNECTEURS DE VOISINAGE pour garantir le bon fonctionnement des liaisons, faute de quoi seuls les camions de marchandises utiliseront l'autoroute (RHW)."
 
-msgctxt "2026960B-123006BB-6A475090"
+msgctxt "2026960B-123007BB-6A475090"
 msgid "RealHighway FLEX Neighbor Connector Pieces (FLEX-NC)"
 msgstr "Connecteurs de Voisinage FLEX pour autoroute (FLEX-NC)"
 
@@ -269,7 +269,7 @@ msgid ""
 "For building DEPRECATED RealHighway Ramp Interfaces.  All of the functionality of the 47 pieces contained and many more are covered by the FLEXRamp system."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475100"
+msgctxt "2026960B-123007BB-6A475100"
 msgid "OBSOLETE RealHighway Ramp Interfaces (Static Puzzle-Based)"
 msgstr "Bretelles d'autoroutes - OBSOLÈTE (Pièces-Puzzle statiques)"
 
@@ -280,7 +280,7 @@ msgid ""
 "Button contains Type B Ramp Interface Pieces for building interchanges with the RHW"
 msgstr "L'outil contient des pièces d'interface de bretelles de type B (voie en biseau) pour la construction d'échangeurs d'autoroutes (RHW)."
 
-msgctxt "2026960B-123006BB-6A475104"
+msgctxt "2026960B-123007BB-6A475104"
 msgid "RealHighway Type B Ramp Interfaces"
 msgstr "Bretelles Type B d'autoroutes (RHW)"
 
@@ -291,7 +291,7 @@ msgid ""
 "Button contains Type E Ramp Interface Pieces for building interchanges with the RHW"
 msgstr "L'outil contient des pièces de bretelles de type E (voie oblique de sortie uniquement) pour la construction d'échangeurs d'autoroutes (RHW)."
 
-msgctxt "2026960B-123006BB-6A475109"
+msgctxt "2026960B-123007BB-6A475109"
 msgid "RealHighway Type E Ramp Interfaces"
 msgstr "Bretelles Type E d'autoroutes (RHW)"
 
@@ -302,7 +302,7 @@ msgid ""
 "Button contains Type D Ramp Interface Pieces for building interchanges with the RHW"
 msgstr "L'outil contient des pièces de bretelles de type D (voie parallèle de sortie uniquement) pour la construction d'échangeurs d'autoroutes (RHW)."
 
-msgctxt "2026960B-123006BB-6A47510A"
+msgctxt "2026960B-123007BB-6A47510A"
 msgid "RealHighway Type D Ramp Interfaces"
 msgstr "Bretelles Type D d'autoroutes (RHW)"
 
@@ -316,7 +316,7 @@ msgstr ""
 "\n"
 "Les éléments de bretelles, Pièces-Puzzles dépréciées, suivent les pièces de Diamant-3-niveaux. Il est recommandé d'utiliser les bretelles FLEX ou les bretelles d'accès étirables (DRIs) plutôt que les Pièces-Puzzles dépréciées."
 
-msgctxt "2026960B-123006BB-6A475118"
+msgctxt "2026960B-123007BB-6A475118"
 msgid "Specialized and Deprecated RealHighway Ramp Interfaces and Volleyball Crossings (Static Puzzle-Based)"
 msgstr "Bretelles d'accès spéciales et échangeurs Diamant-3-niveaux (Pièces-Puzzles statiques) - OBSOLÈTES"
 
@@ -327,7 +327,7 @@ msgid ""
 "Button contains FLEX pieces for different overrideable ramp interfaces.  Drag appropriate networks through to convert base ramp to match."
 msgstr "L'outil contient des éléments sur-chargeables de bretelles FLEX. Faites glisser l'outil du réseau approprié pour convertir la pièce de base."
 
-msgctxt "2026960B-123006BB-6A4751F0"
+msgctxt "2026960B-123007BB-6A4751F0"
 msgid "RealHighway FLEXRamps"
 msgstr "Bretelles d'accès FLEX (RHW)"
 
@@ -338,7 +338,7 @@ msgid ""
 "Button contains pieces to build Wide Curves for the RHW networks"
 msgstr "L'outil contient des pièces à diverses courbures pour le réseau autoroutier (RHW)."
 
-msgctxt "2026960B-123006BB-6A475220"
+msgctxt "2026960B-123007BB-6A475220"
 msgid "RealHighway Wide-Radius and Multi-Radius (Smooth) Curves"
 msgstr "Virages d'autoroutes à multiples rayons."
 
@@ -354,7 +354,7 @@ msgstr ""
 "\n"
 "Ces éléments sont OBSOLÈTES et il est recommandé d'utiliser les transitions de largeur FLEX (FLEX-WT) à la place."
 
-msgctxt "2026960B-123006BB-6A475300"
+msgctxt "2026960B-123007BB-6A475300"
 msgid "Old RealHighway Width Transition Puzzle Pieces - DEPRECATED"
 msgstr "Pièces de transitions de largeurs (Pièces-Puzzles OBSOLÈTES)"
 
@@ -370,7 +370,7 @@ msgstr ""
 "\n"
 "Les fonctionnalités de ce bouton ont été dupliquées avec les transitions de hauteurs FLEX et, par conséquent, cet outil est OBSOLÈTE."
 
-msgctxt "2026960B-123006BB-6A475312"
+msgctxt "2026960B-123007BB-6A475312"
 msgid "Old RealHighway Height Transition Puzzle Pieces  - DEPRECATED"
 msgstr "Transitions de hauteurs pour autoroutes, Pièces-Puzzles - OBSOLÈTES"
 
@@ -381,7 +381,7 @@ msgid ""
 "Button contains pieces to transition between RHW networks of different heights.  Pieces begin as RHW-2 transitions, and dragging another RHW network into them will convert them to fit."
 msgstr "L'outil contient des pièces (FLEX) permettant d'effectuer des transitions entre des voies autoroutières de différentes hauteurs.  Les pièces commencent par des transitions RHW-2, et le fait de glisser l'outil réseau RHW dans ces pièces les convertira pour qu'elles s'adaptent."
 
-msgctxt "2026960B-123006BB-6A475330"
+msgctxt "2026960B-123007BB-6A475330"
 msgid "RealHighway FLEX Height Transitions (FLEX-HT)"
 msgstr "Transitions de hauteurs d'autoroutes (FLEX-HT)"
 
@@ -392,7 +392,7 @@ msgid ""
 "Button contains pieces to transition between RHW networks of different widths.  Dragging another RHW network into them will convert them to fit."
 msgstr "L'outil contient des pièces (FLEX) permettant d'assurer la transition entre des chaussées RHW de largeurs différentes.  Le fait de faire glisser l'outil réseau RHW dans ces pièces les convertira pour qu'elles s'adaptent."
 
-msgctxt "2026960B-123006BB-6A475336"
+msgctxt "2026960B-123007BB-6A475336"
 msgid "RealHighway FLEX Width Transitions (FLEX-WT)"
 msgstr "Transitions de largeurs d'autoroutes (FLEX-WT)"
 
@@ -403,7 +403,7 @@ msgid ""
 "Button contains components for both Ground Highway and Elevated Highway."
 msgstr "L'outil contient des composants de transitions entre les différents réseaux et de hauteurs variables pour les autoroutes de sol et surélevées."
 
-msgctxt "2026960B-123006BB-6A475350"
+msgctxt "2026960B-123007BB-6A475350"
 msgid ""
 "Symphony Transitions\n"
 "\n"
@@ -417,7 +417,7 @@ msgid ""
 "Button contains components for both Ground Highway and Elevated Highway."
 msgstr "L'outil contient les éléments de virages à courbes douces et chaussées à angles fractionnaires pour les autoroutes de sol et surélevées."
 
-msgctxt "2026960B-123006BB-6A475366"
+msgctxt "2026960B-123007BB-6A475366"
 msgid ""
 "Symphony Smooth Curves\n"
 "\n"
@@ -436,7 +436,7 @@ msgstr ""
 "RHW-2, RHW-3 et RHW-4\n"
 "NOTE : ne pas confondre avec les pièces TuLEPs."
 
-msgctxt "2026960B-123006BB-6A475400"
+msgctxt "2026960B-123007BB-6A475400"
 msgid "RealHighway Cosmetic Puzzle Pieces (for 1-Tile Networks)"
 msgstr ""
 "Habillage de voie d'autoroute\n"
@@ -453,7 +453,7 @@ msgstr ""
 "Pièces d'habillages de transitions pour différentes largeurs de chaussées.\n"
 "NOTE : ne pas confondre avec les pièces TuLEPs."
 
-msgctxt "2026960B-123006BB-6A475410"
+msgctxt "2026960B-123007BB-6A475410"
 msgid "RealHighway Cosmetic Piece Transitions"
 msgstr "Habillage de Transitions d'autoroutes"
 
@@ -469,7 +469,7 @@ msgstr ""
 "RHW-8S | RHW-10S et RHW-6S\n"
 "NOTE : ne pas confondre avec les pièces TuLEPs."
 
-msgctxt "2026960B-123006BB-6A475440"
+msgctxt "2026960B-123007BB-6A475440"
 msgid "RealHighway Cosmetic Puzzle Pieces (for 2-Tile Networks)"
 msgstr ""
 "Habillage de voie d'autoroute\n"
@@ -487,7 +487,7 @@ msgstr ""
 "RHW-6C | RHW-8C\n"
 "NOTE : ne pas confondre avec les pièces TuLEPs."
 
-msgctxt "2026960B-123006BB-6A475471"
+msgctxt "2026960B-123007BB-6A475471"
 msgid "RealHighway Cosmetic Puzzle Pieces (for 3-Tile Networks)"
 msgstr ""
 "Habillage de voie d'autoroute\n"
@@ -504,7 +504,7 @@ msgstr ""
 "L'outil contient des pièces diagonales de viaduc autoroutier en surplomb d'autoroutes. Lorsque ce n'est pas possible sur chaussées étirables.\n"
 "OBSOLÈTES"
 
-msgctxt "2026960B-123006BB-6A475500"
+msgctxt "2026960B-123007BB-6A475500"
 msgid "ERHW-over-RHW Diagonal Overpass Puzzle Pieces<DEPRECATED>"
 msgstr ""
 "Viaduc d'autoroutes sur diagonales d'autoroutes\n"
@@ -524,7 +524,7 @@ msgstr ""
 "\n"
 "Placez les pièces de franchissement au-dessus du tracé souterrain chaque fois qu'un réseau de surface se croise, afin de permettre au trafic souterrain de passer."
 
-msgctxt "2026960B-123006BB-6A475600"
+msgctxt "2026960B-123007BB-6A475600"
 msgid "RHW Flexible Underpasses (FLUPs), Draggable Underground Roads (URoads), and Overcrossings"
 msgstr "Passages souterrains modulables (FLUPs) pour autoroutes (RHW), routes souterraines étirables (URoads), et croisements en dénivelés"
 
@@ -535,7 +535,7 @@ msgid ""
 "Button contains flexible RHW interchange segments.  Drag appropriate networks through to convert base ramp to match, and combine to easily create a full interchange."
 msgstr "Cet outil contient des éléments d'échangeurs (RHW) modulables.  Faites glisser l'outil de réseau approprié pour convertir la bretelle de base et combinez-les pour créer facilement un échangeur complet."
 
-msgctxt "2026960B-123006BB-6A475700"
+msgctxt "2026960B-123007BB-6A475700"
 msgid "RealHighway QuickChanges"
 msgstr "Échangeurs d'autoroutes préfabriqués"
 
@@ -546,7 +546,7 @@ msgid ""
 "Button contains starter/transition FLEX pieces for different RHW turn lane setups"
 msgstr "L'outil contient des Pièces-Initiales et des transitions FLEX pour diverses configurations de voies médianes (FTLs)."
 
-msgctxt "2026960B-123006BB-6A475900"
+msgctxt "2026960B-123007BB-6A475900"
 msgid "RealHighway FLEX Turn Lanes (FTLs)"
 msgstr "Voies médianes et intersections pour autoroutes (FTLs)"
 
@@ -557,7 +557,7 @@ msgid ""
 "Button contains pieces to build FLEXFly Pieces"
 msgstr "Pour la construction de systèmes par surcharge étirable FLEXFly, hérités ou obsolètes."
 
-msgctxt "2026960B-123006BB-6A475AF3"
+msgctxt "2026960B-123007BB-6A475AF3"
 msgid "RealHighway FLEXFly (LEGACY/DEPRECATED)"
 msgstr "Éléments FLEXFly pour autoroutes (hérités et obsolètes)."
 
@@ -568,7 +568,7 @@ msgid ""
 "Button contains pieces to build 3-Level Crossings"
 msgstr "Guides FLEX pour la construction d'échangeurs en diamant-3-niveaux (RHW)."
 
-msgctxt "2026960B-123006BB-6A475AF6"
+msgctxt "2026960B-123007BB-6A475AF6"
 msgid "RealHighway 3-Level Crossings"
 msgstr "Échangeur d'autoroute en Diamant-3-niveaux"
 
@@ -579,7 +579,7 @@ msgid ""
 "Button contains pieces to build FLEXFly Pieces"
 msgstr "L'outil contient des éléments du Système des Pièces de Surcharge FLEXFly. "
 
-msgctxt "2026960B-123006BB-6A475B00"
+msgctxt "2026960B-123007BB-6A475B00"
 msgid "RealHighway FLEXFly"
 msgstr "Autoroutes, pièces FLEXFly"
 
@@ -595,7 +595,7 @@ msgstr ""
 "\n"
 "NOTE : La plupart des intersections nécessitent l'utilisation de pièces TuLEPs."
 
-msgctxt "2026960B-123006BB-6A475F00"
+msgctxt "2026960B-123007BB-6A475F00"
 msgid "Fractionally Angled RealHighway Intersections and Transitions"
 msgstr "Intersections et transitions à angles fractionnaires pour autoroutes (FA-RHW)"
 
@@ -606,7 +606,7 @@ msgid ""
 "Button contains straight pieces and curves to pieces to build Fractionally Angled RealHighway (FARHWs)"
 msgstr "L'outil contient des pièces droites et courbes pour construire des autoroutes à angles fractionnaires (FARHWs)."
 
-msgctxt "2026960B-123006BB-6A475F20"
+msgctxt "2026960B-123007BB-6A475F20"
 msgid "Fractionally Angled RealHighway"
 msgstr "Autoroutes à angles fractionnaires (FA)"
 
@@ -617,7 +617,7 @@ msgid ""
 "Button contains pieces to build different FARHW Ramp Interfaces: The C1, F1, C2, F2, and C3 Ramp Interfaces"
 msgstr "L'outil contient les éléments permettant de construire différentes bretelles d'accès (FARHW) type : C1 | F1 | C2 | F2 et C3"
 
-msgctxt "2026960B-123006BB-6A475F30"
+msgctxt "2026960B-123007BB-6A475F30"
 msgid "Fractionally Angled RealHighway Ramp Interfaces"
 msgstr "Bretelles d'accès pour autoroutes (RHW) à angles fractionnaires."
 
@@ -628,7 +628,7 @@ msgid ""
 "Button contains Type C Ramp Interface Pieces for building interchanges with the RHW"
 msgstr "L'outil contient des éléments de bretelles de type C (nouvelle voie à angle fractionnaire) pour la construction d'échangeurs d'autoroutes (RHW)."
 
-msgctxt "2026960B-123006BB-6A475F70"
+msgctxt "2026960B-123007BB-6A475F70"
 msgid "RealHighway Type C Ramp Interfaces"
 msgstr "Bretelles d'accès type C pour autoroutes (RHW)"
 
@@ -639,7 +639,7 @@ msgid ""
 "Button contains Type F Ramp Interface Pieces for building interchanges with the RHW"
 msgstr "L'outil contient des éléments de bretelles de type F (voie de sortie à angle fractionnaire) pour la construction d'échangeurs d'autoroutes (RHW)."
 
-msgctxt "2026960B-123006BB-6A475F71"
+msgctxt "2026960B-123007BB-6A475F71"
 msgid "RealHighway Type F Ramp Interfaces"
 msgstr "Bretelles d'accès type F pour autoroutes (RHW)"
 
@@ -655,7 +655,7 @@ msgstr ""
 "\n"
 "NOTE : Ces voies piétonnes ne doivent pas être utilisées directement devant les zones résidentielles (voir flèche de zone)."
 
-msgctxt "2026960B-123006BB-6A476005"
+msgctxt "2026960B-123007BB-6A476005"
 msgid "Pedestrian Mall Tiles"
 msgstr "Voies piétonnes (par carreau)"
 
@@ -663,7 +663,7 @@ msgctxt "2026960B-123006AA-6A476100"
 msgid "A collection of pedestrian crossing FLEX pieces. Use them on their own at crossing locations, or as part of pedmall corridors."
 msgstr "Une collection d'éléments FLEX de Passages Piétons. Utilisez-les seuls aux points de passages souhaités ou dans le cadre de rues piétonnes."
 
-msgctxt "2026960B-123006BB-6A476100"
+msgctxt "2026960B-123007BB-6A476100"
 msgid "Pedestrian Revolution Mod (PRM) FLEX Crossings"
 msgstr "Passages Piétons FLEX (Pedestrian Revolution Mod)"
 
@@ -677,7 +677,7 @@ msgstr ""
 "\n"
 "L'outil contient plusieurs longueurs de rue et des Pièces-Puzzles."
 
-msgctxt "2026960B-123006BB-6A476525"
+msgctxt "2026960B-123007BB-6A476525"
 msgid "Diagonal Street Helper Pieces"
 msgstr "Rues diagonales"
 
@@ -688,7 +688,7 @@ msgid ""
 "Button contains Starter Pieces for Street Addon Mod (SAM)"
 msgstr "L'outil contient les Pièces-Initiales des rues additionnelles (SAM)"
 
-msgctxt "2026960B-123006BB-6A476700"
+msgctxt "2026960B-123007BB-6A476700"
 msgid "Street Addon Mod (SAM)"
 msgstr "Rues additionnelles - Street Addon Mod (SAM)"
 
@@ -696,7 +696,7 @@ msgctxt "2026960B-123006AA-6A476905"
 msgid "Plop one of these pieces on a flat area. It will raise or lower the terrain, and then destroy itself, providing a level area for a raised network of your choice. This is fully compatible with all slope mods."
 msgstr "Placez l'outil sur le terrain. À chaque clic il soulèvera ou abaissera (rotation [Home] [End]) ce dernier selon la hauteur/profondeur [tab] choisie, fournissant une zone plane pour tout type de réseau. Ce système est également compatible avec tous les Mods de pentes."
 
-msgctxt "2026960B-123006BB-6A476905"
+msgctxt "2026960B-123007BB-6A476905"
 msgid "Hole Digger and Raiser Lots"
 msgstr "Outil d'excavation et d'élévation de terrain"
 
@@ -707,7 +707,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Avenues"
 msgstr "L'outil contient des Pièces-Puzzles pour avenues, ronds-points, franchissement en Y, et autres intersections Tram, ..."
 
-msgctxt "2026960B-123006BB-6A476A00"
+msgctxt "2026960B-123007BB-6A476A00"
 msgid "Avenue Intersections"
 msgstr "Ronds-Points et Intersections d'avenue"
 
@@ -718,7 +718,7 @@ msgid ""
 "Button contains several different overpasses for Road"
 msgstr "L'outil contient plusieurs passages supérieurs pour Route."
 
-msgctxt "2026960B-123006BB-6A477000"
+msgctxt "2026960B-123007BB-6A477000"
 msgid "Road Overpasses"
 msgstr "Ponts Routiers"
 
@@ -729,7 +729,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Road"
 msgstr "L'outil contient diverses Pièces-Puzzles de viaducs de route d'une hauteur de 7,5 m."
 
-msgctxt "2026960B-123006BB-6A477005"
+msgctxt "2026960B-123007BB-6A477005"
 msgid "7.5m Elevated Road Viaducts"
 msgstr "Viaduc de Route de 7,5 m"
 
@@ -740,7 +740,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Road"
 msgstr "L'outil contient diverses Pièces-Puzzles de viaducs de route d'une hauteur de 15 m."
 
-msgctxt "2026960B-123006BB-6A477200"
+msgctxt "2026960B-123007BB-6A477200"
 msgid "15m Elevated Road Viaducts"
 msgstr "Viaduc de Route de 15 m"
 
@@ -751,7 +751,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Road, One-Way Road, or Avenue"
 msgstr "L'outil contient des segments Pièces-Puzzles de courbes (S, 90°, grand rayon)"
 
-msgctxt "2026960B-123006BB-6A477500"
+msgctxt "2026960B-123007BB-6A477500"
 msgid "Wide Radius Curves (for Road, One-Way Road, Avenue, and Street) (Puzzle Pieces)"
 msgstr "Courbes variables pour Route, Sens-unique, Avenue et Rue"
 
@@ -762,7 +762,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Road, One-Way Road, and Avenue"
 msgstr "L'outil contient diverses Pièces-Puzzles pour réseaux à angles fractionnaires (FAR3), segments droits, courbes et intersections."
 
-msgctxt "2026960B-123006BB-6A477600"
+msgctxt "2026960B-123007BB-6A477600"
 msgid "Fractionally-Angled Networks (for Road, One-Way Road, and Avenue)"
 msgstr "Chaussées à angles fractionnaires (Route, Sens-unique et Avenue)"
 
@@ -777,7 +777,7 @@ msgstr ""
 "Utilisez la touche [tab] - ou [maj]+[tab] - pour sélectionner l'une des pièces.\n"
 "Puis orientez la pièce avec les touches [Home] et [End] - ([début] [fin])."
 
-msgctxt "2026960B-123006BB-6A477700"
+msgctxt "2026960B-123007BB-6A477700"
 msgid "Rural Road Puzzle Pieces"
 msgstr "Route rurale (Pièces-Puzzles)"
 
@@ -790,7 +790,7 @@ msgstr ""
 "L'outil contient des pièces de liaison entre les réseaux routiers surélevés et les réseaux d'autoroutes (RHW), y compris les viaducs et les intersections.\n"
 "OBSOLÈTES"
 
-msgctxt "2026960B-123006BB-6A477800"
+msgctxt "2026960B-123007BB-6A477800"
 msgid "Road/RHW Overpass and Interface Puzzle Pieces (DEPRECATED)"
 msgstr "Passage supérieur Route/Autoroute et Pièces-Puzzles de liaison"
 
@@ -801,7 +801,7 @@ msgid ""
 "Button contains several different FLEX Pieces for various networks"
 msgstr "Outil contenant des pièces FLEX à rayons de courbure multiples (MRC) pour les réseaux de surface : routes, sens unique, avenues et routes élargies (NWM)."
 
-msgctxt "2026960B-123006BB-6A477900"
+msgctxt "2026960B-123007BB-6A477900"
 msgid "Multi-Radius Curve (MRC) FLEX Pieces for Surface Networks"
 msgstr "Courbes FLEX pour réseaux de surface"
 
@@ -823,7 +823,7 @@ msgstr ""
 "\n"
 "Le nouveau système FLUPs basé sur le métro se trouve dans le menu Autoroutes."
 
-msgctxt "2026960B-123006BB-6A477A00"
+msgctxt "2026960B-123007BB-6A477A00"
 msgid "Flexible Underpasses (FLUPs)"
 msgstr "Passages souterrains modulables (FLUPs)"
 
@@ -840,7 +840,7 @@ msgstr ""
 "Routes à 4 et 6 voies (RD-4 | 6).\n"
 "Routes à sens unique à 1, 3, 4 et 5 voies (OWR-1 | 3 | 4 | 5)."
 
-msgctxt "2026960B-123006BB-6A477B00"
+msgctxt "2026960B-123007BB-6A477B00"
 msgid "Network Widening Mod (NWM) Starter Pieces"
 msgstr "Mod Routes Élargies (NWM) - Pièces-Initiales"
 
@@ -851,7 +851,7 @@ msgid ""
 "Button contains Wide-Radius Curve Pieces for the single-tile NWM networks"
 msgstr "L'outil contient les pièces de courbes à rayon large pour les réseaux NWM à un seul carreau."
 
-msgctxt "2026960B-123006BB-6A477B30"
+msgctxt "2026960B-123007BB-6A477B30"
 msgid "Network Widening Mod (NWM) Curve Pieces"
 msgstr "Mod Routes Élargies (NWM) - Courbes"
 
@@ -866,7 +866,7 @@ msgstr ""
 "Pièces-Puzzles de transitions entres les différentes largeurs de Routes Élargies (NWM).\n"
 "Notez que la plupart des transitions impliquant des chaussées à un ou deux carreaux peuvent se faire en utilisant l'outil étirable d'un des réseaux (route, avenue, ...) par connexion directe !"
 
-msgctxt "2026960B-123006BB-6A477B50"
+msgctxt "2026960B-123007BB-6A477B50"
 msgid "Network Widening Mod (NWM) Transition Pieces"
 msgstr "Mod Routes Élargies (NWM) - Transitions"
 
@@ -879,7 +879,7 @@ msgstr ""
 "L'outil permet la construction de connecteurs de voisinage pour les chaussées (NWM) de type :\n"
 "TLA-5 | RD-4 | RD-6 | TLA-7 | AVE-6"
 
-msgctxt "2026960B-123006BB-6A477BF0"
+msgctxt "2026960B-123007BB-6A477BF0"
 msgid "Network Widening Mod (NWM) Neighbor Connector Pieces"
 msgstr "Mod Routes Élargies (NWM) - Connecteurs de voisinage"
 
@@ -890,7 +890,7 @@ msgid ""
 "Button contains FLEX Single Tile Roundabouts intersections for various road networks"
 msgstr "L'outil propose des ronds-points (3 branches) d'un seul carreau."
 
-msgctxt "2026960B-123006BB-6A477C00"
+msgctxt "2026960B-123007BB-6A477C00"
 msgid "Single Tile Roundabouts"
 msgstr "Ronds-points 1 carreau"
 
@@ -903,7 +903,7 @@ msgid ""
 "Button contains OnSlope Transitions to start Alternate Style Road and Street Viaducts"
 msgstr "L'outil propose des pièces de transitions sur versant, sans des styles alternatifs. Pour des franchissements courts et de réseaux orthogonaux. Pas de support diagonal."
 
-msgctxt "2026960B-123006BB-6A477E00"
+msgctxt "2026960B-123007BB-6A477E00"
 msgid "Road Viaduct Alternate Styles"
 msgstr "Viaduc routier - Styles alternatifs"
 
@@ -917,7 +917,7 @@ msgstr ""
 "Pour route, sens unique et avenue, de 7,5 et 15 m.\n"
 "Orthogonal et diagonal."
 
-msgctxt "2026960B-123006BB-6A477F00"
+msgctxt "2026960B-123007BB-6A477F00"
 msgid "Draggable Elevated Road Viaducts"
 msgstr "Viaducs routiers étirables"
 
@@ -932,7 +932,7 @@ msgstr ""
 "Permet la construction de passages supérieurs de routes, sens uniques et d'avenues FLEX de différentes longueurs.\n"
 "Faire glisser les réseaux sous la section centrale du pont pour construire le franchissement.  La plupart des réseaux et les réseaux doubles basés sur FLEX sont pris en charge."
 
-msgctxt "2026960B-123006BB-6A477F30"
+msgctxt "2026960B-123007BB-6A477F30"
 msgid "FLEX Overpasses"
 msgstr "Passages supérieurs FLEX"
 
@@ -943,7 +943,7 @@ msgid ""
 "Button contains several different overpasses for One-Way Road"
 msgstr "Permet de créer des ponts à sens unique, hauteur 15 m, pour passages sur divers réseaux : avenue, route, rue, rail ..."
 
-msgctxt "2026960B-123006BB-6A478000"
+msgctxt "2026960B-123007BB-6A478000"
 msgid "One-Way Road Overpasses"
 msgstr "Pont routier à sens unique"
 
@@ -954,7 +954,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for One-Way Road"
 msgstr "L'outil contient des Pièces-Puzzles, rampes, virages, pour viaduc de 15 m. Franchissement de divers réseaux."
 
-msgctxt "2026960B-123006BB-6A478005"
+msgctxt "2026960B-123007BB-6A478005"
 msgid "15m Elevated One-Way Road Viaducts"
 msgstr "Viaducs de route à sens unique - 15 m"
 
@@ -967,7 +967,7 @@ msgstr ""
 "L'outil contient des Pièces-Puzzles de ponts et de liaisons de routes à sens uniques, surélevées, vers autoroutes (RHW).\n"
 "OBSOLÈTES"
 
-msgctxt "2026960B-123006BB-6A478800"
+msgctxt "2026960B-123007BB-6A478800"
 msgid "One-Way Road/RHW Overpass and Interface Puzzle Pieces (DEPRECATED)"
 msgstr "Pont et liaisons Route sens unique et autoroute"
 
@@ -975,7 +975,7 @@ msgctxt "2026960B-123006AA-6A478900"
 msgid "For use of the curved pieces for the Real Expressway Network. Use the Home/End key to rotate the FLEX Piece & use TAB/Shift-TAB (Ctrl-TAB/Ctrl-Shift-TAB on macOS) to cycle through the different types of REW Straights and Curves."
 msgstr "Pour l'utilisation des pièces courbes des voies rapides. Utilisez la touche Home/End (début/fin) pour faire pivoter la pièce FLEX et utilisez [tab] | [maj+tab] ([Ctrl-tab] | [Ctrl-maj-tab] sur macOS) pour faire défiler les différents types de droites et de courbes REW."
 
-msgctxt "2026960B-123006BB-6A478900"
+msgctxt "2026960B-123007BB-6A478900"
 msgid "Real Expressway FLEX Piece network tool and Curves."
 msgstr "Voies Rapides FLEX, segments et courbes."
 
@@ -988,7 +988,7 @@ msgstr ""
 "L'outil contient plusieurs pièces FLEX (modifiables) accès, sortie et transitions de Voie Rapide - Sens unique à 2 ou 3 voies (OWR-2|3). Ortho et diagonales.\n"
 "Faites glisser l'outil de réseau approprié pour convertir la rampe de base."
 
-msgctxt "2026960B-123006BB-6A478B00"
+msgctxt "2026960B-123007BB-6A478B00"
 msgid "RealExpressway (REW) One-Way Road FLEXRamps"
 msgstr "Bretelles d'accès pour Voies Rapides - Sens unique 2|3 voies (REW)"
 
@@ -999,7 +999,7 @@ msgid ""
 "Button contains several different overpasses for Avenue"
 msgstr "L'outil propose un pont d'avenue en franchissement de divers réseaux. Orthogonal - 15 m."
 
-msgctxt "2026960B-123006BB-6A479000"
+msgctxt "2026960B-123007BB-6A479000"
 msgid "Avenue Overpasses"
 msgstr "Pont d'avenues"
 
@@ -1010,7 +1010,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Avenue"
 msgstr "Cet outil contient des Pièces-Puzzles, rampes, virages, pour viaduc de 7,5 m. Franchissement de divers réseaux."
 
-msgctxt "2026960B-123006BB-6A479005"
+msgctxt "2026960B-123007BB-6A479005"
 msgid "7.5m Elevated Avenue Viaducts"
 msgstr "Viaduc pour avenue - 7,5 m"
 
@@ -1021,7 +1021,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Avenue"
 msgstr "L'outil contient des Pièces-Puzzles, rampes, virages, pour viaduc de 15 m. Franchissement de divers réseaux."
 
-msgctxt "2026960B-123006BB-6A479200"
+msgctxt "2026960B-123007BB-6A479200"
 msgid "15m Elevated Avenue Viaducts"
 msgstr "Viaduc pour avenue - 15 m"
 
@@ -1034,7 +1034,7 @@ msgstr ""
 "L'outil fournit des Pièces-Puzzles de liaisons d'avenues surélevées avec les autoroutes (RHW). Inclus des ponts et intersections.\n"
 "OBSOLÈTES"
 
-msgctxt "2026960B-123006BB-6A479900"
+msgctxt "2026960B-123007BB-6A479900"
 msgid "Avenue/RHW Overpass and Interface Puzzle Pieces (DEPRECATED)"
 msgstr "Avenue/RHW franchissement et liaisons"
 
@@ -1051,7 +1051,7 @@ msgstr ""
 "FlexSPUI - échangeur urbain à point unique.\n"
 "FlexDDI - échangeur diamant-divergent."
 
-msgctxt "2026960B-123006BB-6A47991A"
+msgctxt "2026960B-123007BB-6A47991A"
 msgid "Specialized RHW x Surface Intersections"
 msgstr "Intersections Spéciales -  autoroutes et autres réseaux"
 
@@ -1064,7 +1064,7 @@ msgstr ""
 "L'outil fournit diverses pièces, rampes, courbes, segments ainsi que des franchissements sur divers réseaux.\n"
 "Orthogonal et diagonal."
 
-msgctxt "2026960B-123006BB-6A47A005"
+msgctxt "2026960B-123007BB-6A47A005"
 msgid "Rail Puzzle Pieces"
 msgstr "Viaduc ferroviaire - Pièces-Puzzles"
 
@@ -1072,7 +1072,7 @@ msgctxt "2026960B-123006AA-6A47A130"
 msgid "Button contains FLEX pieces to elevated the Rail network to viaduct level (using the RealRailway (RRW) standard)"
 msgstr "L'outil propose les pièces initiales FLEX sur versant ainsi que les rampes de niveau 1 et 2 pour construire des viaducs ferroviaires étirables (RRW)."
 
-msgctxt "2026960B-123006BB-6A47A130"
+msgctxt "2026960B-123007BB-6A47A130"
 msgid "Draggable Elevated Railways (ERRW)"
 msgstr "Viaduc férroviaire étirable (ERRW)"
 
@@ -1085,7 +1085,7 @@ msgstr ""
 "L'outil propose diverses Pièces-Puzzles de courbes, S, aiguillages et déviations de voies. Orthogonales et diagonales.\n"
 "Utilisez [tab] ([maj][tab]) pour faire défiler les éléments, ainsi que les touches [home] et [end] pour la rotation des pièces."
 
-msgctxt "2026960B-123006BB-6A47A358"
+msgctxt "2026960B-123007BB-6A47A358"
 msgid "Wide Radius Railroad Curve and Double Track Rail Switch Puzzle Pieces"
 msgstr "Rails courbes et aiguillages"
 
@@ -1098,7 +1098,7 @@ msgstr ""
 "L'outil contient des Pièces-Puzzles d'aiguillages, segments, transitions ortho-fract ... de voies ferrées fractionnaires.\n"
 "Utilisez [tab] ([shift][tab]) pour faire défiler les éléments et [home], [end] pour tourner les pièces."
 
-msgctxt "2026960B-123006BB-6A47A368"
+msgctxt "2026960B-123007BB-6A47A368"
 msgid "Fractional Angle Railroad (FARR) Puzzle Pieces"
 msgstr "Rails à angles fractionnaires (FARR)"
 
@@ -1109,7 +1109,7 @@ msgid ""
 "Button contains pieces to interface between the NAM Elevated Rail Viaduct Puzzle Pieces and RHW networks, including overpasses and intersections"
 msgstr "L'outil contient des pièces de franchissement entre les Pièces-Puzzles de viaduc ferroviaire surélevé NAM et les réseaux RHW, y compris les ponts et les intersections."
 
-msgctxt "2026960B-123006BB-6A47A800"
+msgctxt "2026960B-123007BB-6A47A800"
 msgid "Rail Viaduct/RHW Overpass and Interface Puzzle Pieces"
 msgstr "Viaduc ferroviaire/Autoroutes, ponts et Pièces-puzzles"
 
@@ -1122,7 +1122,7 @@ msgstr ""
 "Utilisez [tab] ([maj][tab]) pour faire défiler les éléments, ainsi que les touches [home] et [end] pour la rotation des pièces.\n"
 "Pièces-Puzzles."
 
-msgctxt "2026960B-123006BB-6A47A900"
+msgctxt "2026960B-123007BB-6A47A900"
 msgid "Wide Radius Railroad Curve and Double Track Rail Switch Puzzle Pieces"
 msgstr "Rails courbes à grand rayon, S, aiguillages"
 
@@ -1135,7 +1135,7 @@ msgstr ""
 "Outil permettant de placer les voies souterraines, sous divers segments de route. Droite, courbe, carrefours, ortho et diagonale, rampe d'accès et double réseau.\n"
 "Pièces-Puzzles."
 
-msgctxt "2026960B-123006BB-6A47AA0F"
+msgctxt "2026960B-123007BB-6A47AA0F"
 msgid ""
 "Underground Rail\n"
 "Rail Tunnel under Roads Dual Networking Puzzle Pieces"
@@ -1150,7 +1150,7 @@ msgstr ""
 "Outil permettant de placer les voies souterraines avec des rues piétonnes en surplomb. + double réseau de surface.\n"
 "Pièces-Puzzles."
 
-msgctxt "2026960B-123006BB-6A47AA10"
+msgctxt "2026960B-123007BB-6A47AA10"
 msgid ""
 "Underground Rail\n"
 "Rail Tunnel under Ped Malls Dual Networking Puzzle Pieces"
@@ -1165,7 +1165,7 @@ msgstr ""
 "Outil permettant de placer des voies souterraines sous divers segments de routes, sens uniques, rues, avenues et autoroutes Maxis.\n"
 "Pièces-Puzzles."
 
-msgctxt "2026960B-123006BB-6A47AA11"
+msgctxt "2026960B-123007BB-6A47AA11"
 msgid ""
 "Underground Rail\n"
 "Maxis Roadway Intersection Pieces"
@@ -1180,7 +1180,7 @@ msgstr ""
 "Outil permettant de placer des voies souterraines sous divers segments de rails.\n"
 "Pièces-Puzzles"
 
-msgctxt "2026960B-123006BB-6A47AA12"
+msgctxt "2026960B-123007BB-6A47AA12"
 msgid ""
 "Underground Rail\n"
 "Railway Intersection Pieces"
@@ -1195,7 +1195,7 @@ msgstr ""
 "Outil permettant de placer des voies souterraines sous divers segments de Tram (unique ; partagée en rue, en route ou avenue).\n"
 "Pièces-Puzzles."
 
-msgctxt "2026960B-123006BB-6A47AA13"
+msgctxt "2026960B-123007BB-6A47AA13"
 msgid ""
 "Underground Rail\n"
 "Tramway Intersection Pieces"
@@ -1210,7 +1210,7 @@ msgstr ""
 "L'outil permet de placer des croisements (X) de voies ferrées sous des segments de routes ou de voies piétonnes.\n"
 "Pièces-Puzzles."
 
-msgctxt "2026960B-123006BB-6A47AA8A"
+msgctxt "2026960B-123007BB-6A47AA8A"
 msgid ""
 "Underground Rail\n"
 "Miscellaneous Puzzle Pieces"
@@ -1220,7 +1220,7 @@ msgctxt "2026960B-123006AA-6A47AC00"
 msgid "All pieces in this section are FLEX and conform to flextrack standards!"
 msgstr "L'outil contient les pièces courbes à grand rayon (R3, R4 et R5), peuvent être converties (FLEX) en voie unique (STR) ou élevées."
 
-msgctxt "2026960B-123006BB-6A47AC00"
+msgctxt "2026960B-123007BB-6A47AC00"
 msgid "RealRailway FLEX Curve Pieces."
 msgstr "Rails courbes (RRW) - pièces FLEX"
 
@@ -1230,7 +1230,7 @@ msgstr ""
 "L'outil contient de multiples aiguillages, bretelles, divisions Y, courbes, croisements ... voie double et unique (DTR | STR) ortho et diagonale.\n"
 "Pièces FLEX."
 
-msgctxt "2026960B-123006BB-6A47AC10"
+msgctxt "2026960B-123007BB-6A47AC10"
 msgid "RealRailway FLEX Turnout Pieces."
 msgstr "Aiguillages et bretelles ferroviaires (RRW) - FLEX"
 
@@ -1240,7 +1240,7 @@ msgstr ""
 "Cet outil contient divers segments de voie ortho et diagonales vers FARR 1,5 | 2 | 3 et 6.\n"
 "Pièces FLEX."
 
-msgctxt "2026960B-123006BB-6A47AD00"
+msgctxt "2026960B-123007BB-6A47AD00"
 msgid "RealRailway FLEX Fractional Angled (FA) Pieces."
 msgstr "Voies ferroviaires (RRW) à angles fractionnaires (FA) - FLEX"
 
@@ -1253,7 +1253,7 @@ msgstr ""
 "L'outil contient des segments (droite et courbe) de Tram surélevée en surplomb et croisement de routes, rues et avenues ainsi qu'en surplomb de voies piétonnes.\n"
 "Pièces-Puzzles."
 
-msgctxt "2026960B-123006BB-6A47B03A"
+msgctxt "2026960B-123007BB-6A47B03A"
 msgid "ElevatedRail Dual/Double-Decker Network Pieces"
 msgstr "Tram surélevé - Double réseaux"
 
@@ -1261,7 +1261,7 @@ msgctxt "2026960B-123006AA-6A47B049"
 msgid "These puzzle pieces are to allow you to cross NWM networks with ElRail over Road."
 msgstr "Pièces-Puzzles de segments de Tram surélevée croisant les réseaux routiers élargis : AVE-2 | TLA-3 | ARD-3 | NRD-4 | RD-6 ..."
 
-msgctxt "2026960B-123006BB-6A47B049"
+msgctxt "2026960B-123007BB-6A47B049"
 msgid "ElRail over Road NWM Intersections"
 msgstr "Tram surélevé - Intersections du réseau élargi (NWM)"
 
@@ -1272,7 +1272,7 @@ msgid ""
 "The construction lot vanishes automatically. Use the Road Tool to connect the network and to build intersections."
 msgstr "Cet outil contient des Pièces-Puzzles de segments de Tram en surplomb de 4-voies et d'avenues + Rampe Tram (GLR) vers Tram surélevé."
 
-msgctxt "2026960B-123006BB-6A47B060"
+msgctxt "2026960B-123007BB-6A47B060"
 msgid "ElevatedRail over Avenue/Road-4 Puzzle Pieces"
 msgstr "Tram surélevé - Route 4 voies et avenue"
 
@@ -1280,7 +1280,7 @@ msgctxt "2026960B-123006AA-6A47B10F"
 msgid "Puzzle Pieces to build a ground level extension of the Elevated Rail network for Light Rail/Trams."
 msgstr "Pièces-Puzzles pour établir un réseau de Tramway. Ortho et diagonale, boucle, courbe, carrefour, jonction, variantes de sol et croisement avec les réseaux routiers standards."
 
-msgctxt "2026960B-123006BB-6A47B10F"
+msgctxt "2026960B-123007BB-6A47B10F"
 msgid "Ground Light Rail (Tram)"
 msgstr "Tram (GLR)"
 
@@ -1291,7 +1291,7 @@ msgid ""
 "Connect the Elevated Rail network with the Starter Piece. The Elevated Rail will turn into a Ground Light Rail track."
 msgstr "L'outil propose les pièces-initiales ortho et diagonale (+ version rurale), Rampe depuis réseau Tram surélevé, boucle."
 
-msgctxt "2026960B-123006BB-6A47B3FF"
+msgctxt "2026960B-123007BB-6A47B3FF"
 msgid "Draggable Ground Light Rail (Tram)"
 msgstr "Tram (GLR) - Pièces-Initiales étirables"
 
@@ -1299,7 +1299,7 @@ msgctxt "2026960B-123006AA-6A47B42A"
 msgid "For building Tram-Avenue (= GroundLightRail / Avenue) - Dual Network Pieces."
 msgstr "Pièces-Puzzles de segments de Tram sur avenues en double réseau. Ortho et diagonales. Croisement et liaisons avec les réseaux de bases, de sol et surélevés, boucles."
 
-msgctxt "2026960B-123006BB-6A47B42A"
+msgctxt "2026960B-123007BB-6A47B42A"
 msgid "Tram-Avenue (GroundLightRail / Avenue) - Dual Network Pieces"
 msgstr "Tram sur Avenue (GLR)"
 
@@ -1310,7 +1310,7 @@ msgid ""
 "These puzzle pieces are designed so that you may plop them first or you may plop them on existing networks."
 msgstr "L'outil fournit divers segments de Tram archi-surélevés (30m) de franchissement des réseaux de bases (Maxis) surélevés ou non, plus une rampe : surélevés vers archi-surélevés."
 
-msgctxt "2026960B-123006BB-6A47B900"
+msgctxt "2026960B-123007BB-6A47B900"
 msgid "High Elevated Rail Puzzle Pieces"
 msgstr "Tram archi-surélevé ! "
 
@@ -1321,7 +1321,7 @@ msgid ""
 "Button contains Tram-in-Road Puzzle Pieces"
 msgstr "L'outil propose divers segments (pièces-puzzles) de tram sur route en double réseau. Ortho et diagonales. Croisements et liaisons avec les réseaux de bases, boucles et transition avec le Tram surélevé."
 
-msgctxt "2026960B-123006BB-6A47BA00"
+msgctxt "2026960B-123007BB-6A47BA00"
 msgid "Tram-in-Road"
 msgstr "Tram sur Route"
 
@@ -1331,7 +1331,7 @@ msgstr ""
 "L'outil fournit plusieurs pièces-puzzles de Tram sur route et sur avenue (en double réseau) en texture tout goudron.\n"
 "Plus voie de Tram sur herbe pour route (ortho) et avenue (ortho et diagonales)."
 
-msgctxt "2026960B-123006BB-6A47BBA0"
+msgctxt "2026960B-123007BB-6A47BBA0"
 msgid "Tram-on-Road & texture variations"
 msgstr "Tram sur route et avenue - Styles additionnelles"
 
@@ -1339,7 +1339,7 @@ msgctxt "2026960B-123006AA-6A47BC60"
 msgid "For utilizing the Tram Puzzle Pieces"
 msgstr "L'outil propose divers segments (Pièces-Puzzles) de Tram sur Rue (voies partagées). Ortho et diagonales, Croisement et liaisons avec les autres réseaux, boucles."
 
-msgctxt "2026960B-123006BB-6A47BC60"
+msgctxt "2026960B-123007BB-6A47BC60"
 msgid "Tram-on-Street"
 msgstr "Tram sur Rue"
 
@@ -1350,7 +1350,7 @@ msgid ""
 "Button contains starters for two additional Ground Light Rail styles, plus filler pieces."
 msgstr "L'outil contient les pièces-initiales dans 2 styles additionnels."
 
-msgctxt "2026960B-123006BB-6A47BD00"
+msgctxt "2026960B-123007BB-6A47BD00"
 msgid "Draggable Ground Light Rail (Tram)--Additional Styles"
 msgstr "Tram (GLR) Étirable - Styles additionnels"
 
@@ -1363,7 +1363,7 @@ msgstr ""
 "Pièce-Initiale du réseau Grande Vitesse (HSR project).\n"
 "Contient aussi des segments en surplomb des réseaux de bases."
 
-msgctxt "2026960B-123006BB-6A47C000"
+msgctxt "2026960B-123007BB-6A47C000"
 msgid "High Speed Rail (HSR)"
 msgstr "Voie à grande vitesse (HSR) - Surélevé"
 
@@ -1376,11 +1376,11 @@ msgid ""
 "GHSR is a ground level extension of High Speed Rail (HSR)"
 msgstr "Pièce-initiale du réseau Grande Vitesse ainsi que les segments de franchissement des réseaux de bases, une rampe vers le réseau surélevé, S, ..."
 
-msgctxt "2026960B-123006BB-6A47C200"
+msgctxt "2026960B-123007BB-6A47C200"
 msgid "Ground High Speed Rail (GHSR)"
 msgstr "Voie à Grande Vitesse de sol (GHSR)"
 
-msgctxt "2026960B-123006BB-6A47C700"
+msgctxt "2026960B-123007BB-6A47C700"
 msgid "Monorail Wide Radius Curve Puzzle Pieces"
 msgstr "Monorail - Grandes Courbes"
 
@@ -1398,7 +1398,7 @@ msgid ""
 "These puzzle pieces are designed so that you may plop them first or you may plop them on existing networks."
 msgstr "Pièces-puzzles de segments en surplomb des réseaux de bases (Maxis). + rampe de 15 à 30 m"
 
-msgctxt "2026960B-123006BB-6A47C900"
+msgctxt "2026960B-123007BB-6A47C900"
 msgid "High Monorail Puzzle Pieces"
 msgstr "Monorail - Haute Élévation"
 
@@ -1408,7 +1408,7 @@ msgstr ""
 "Segments de voies ferrées hybrides en ligne droite (ortho et diagonale). \n"
 "Le chemin de fer hybride supporte à la fois le trafic ferroviaire normal et le trafic ferroviaire à grande vitesse (monorail)."
 
-msgctxt "2026960B-123006BB-6A47CA00"
+msgctxt "2026960B-123007BB-6A47CA00"
 msgid "Hybrid Railway (Rail-High Speed Rail) Straight Sections"
 msgstr "Chemin de fer hybride (Rail ordinaire - Grande Vitesse) - Droites"
 
@@ -1418,7 +1418,7 @@ msgstr ""
 "L'outil contient des segments de voies ferrées hybrides en courbes à grands rayons et S. \n"
 "Le chemin de fer hybride supporte à la fois le trafic ferroviaire normal et le trafic ferroviaire à grande vitesse (monorail)."
 
-msgctxt "2026960B-123006BB-6A47CB00"
+msgctxt "2026960B-123007BB-6A47CB00"
 msgid "Hybrid Railway (Rail-High Speed Rail) Curves"
 msgstr "Chemin de fer hybride (Rail ordinaire - Grande Vitesse) - Courbes"
 
@@ -1429,7 +1429,7 @@ msgid ""
 "Hybrid Railway carries both normal Rail traffic and High Speed Rail (Monorail) traffic."
 msgstr "L'outil contient divers aiguillages, droit, en courbe, croisement."
 
-msgctxt "2026960B-123006BB-6A47CD00"
+msgctxt "2026960B-123007BB-6A47CD00"
 msgid "Hybrid Railway (Rail-High Speed Rail) Switches"
 msgstr "Chemin de fer hybride (Rail ordinaire - Grande Vitesse) - Aiguillages"
 
@@ -1443,7 +1443,7 @@ msgstr ""
 "Le chemin de fer hybride supporte à la fois le trafic ferroviaire normal et le trafic ferroviaire à grande vitesse (monorail).\n"
 "Utilisez des tronçons de chemin de fer hybride au niveau du sol et reliez les à l'extrémité surélevée des transitions (ou à d'autres tronçons déjà surélevés) pour les surélever."
 
-msgctxt "2026960B-123006BB-6A47CE00"
+msgctxt "2026960B-123007BB-6A47CE00"
 msgid "Hybrid Railway (Rail-High Speed Rail) Height Transitions"
 msgstr "Chemin de fer Hybride (Rail ordinaire - Grande Vitesse) - Transitions vers viaduc."
 
@@ -1451,7 +1451,7 @@ msgctxt "2026960B-123006AA-6A47DC00"
 msgid "Button contains Ground Highway Puzzle Pieces"
 msgstr "L'outil contient de segments d'autoroutes."
 
-msgctxt "2026960B-123006BB-6A47DC00"
+msgctxt "2026960B-123007BB-6A47DC00"
 msgid "Ground Highway Puzzle Pieces"
 msgstr "Autoroute de sol -  Pièces-puzzles"
 
@@ -1462,7 +1462,7 @@ msgid ""
 "Button contains Single-Sided Perpendicular Ramps for Elevated Highway"
 msgstr "L'outil contient des bretelles perpendiculaires surélevées."
 
-msgctxt "2026960B-123006BB-6A47E010"
+msgctxt "2026960B-123007BB-6A47E010"
 msgid ""
 "Single-Sided Perpendicular Ramps\n"
 "\n"
@@ -1476,7 +1476,7 @@ msgid ""
 "Button contains Single-Sided Parallel Ramps for both Ground Highway and Elevated Highway"
 msgstr "L'outil propose des bretelles parallèles d'autoroute de sol et surlélevé."
 
-msgctxt "2026960B-123006BB-6A47E050"
+msgctxt "2026960B-123007BB-6A47E050"
 msgid ""
 "Single-Sided Parallel Ramps\n"
 "\n"
@@ -1487,15 +1487,15 @@ msgctxt "2026960B-123006AA-6A47E100"
 msgid "Button contains Custom Interchanges"
 msgstr "Échangeurs ..."
 
-msgctxt "2026960B-123006BB-6A47E100"
+msgctxt "2026960B-123007BB-6A47E100"
 msgid "Custom Interchanges"
 msgstr "Échangeurs sur mesures"
 
-msgctxt "2026960B-123006BB-6A47FFFF"
+msgctxt "2026960B-123007BB-6A47FFFF"
 msgid "Network Addon Mod Controller"
 msgstr "Network Addon Mod - Version Controlleur"
 
-msgctxt "2026960B-123006BB-6A476200"
+msgctxt "2026960B-123007BB-6A476200"
 msgid "Draggable Pedmalls"
 msgstr "Voies piétonnes étirables"
 

--- a/ltext/it/buttons.po
+++ b/ltext/it/buttons.po
@@ -40,7 +40,7 @@ msgstr ""
 "\n"
 "Il pulsante contiene rampe parallele sia per l'autostrada che per l'autostrada sopraelevata."
 
-msgctxt "2026960B-123006BB-52001000"
+msgctxt "2026960B-123007BB-52001000"
 msgid ""
 "Parallel Ramps\n"
 "\n"
@@ -60,7 +60,7 @@ msgstr ""
 "\n"
 "Il pulsante contiene le rampe di scavalcamento/perpendicolari sia per l'autostrada che per l'autostrada sopraelevata."
 
-msgctxt "2026960B-123006BB-52001010"
+msgctxt "2026960B-123007BB-52001010"
 msgid ""
 "Overpass/Perpendicular Ramps\n"
 "\n"
@@ -80,7 +80,7 @@ msgstr ""
 "\n"
 "Il pulsante contiene quadrifogli sia per l'autostrada che per l'autostrada sopraelevata."
 
-msgctxt "2026960B-123006BB-52001020"
+msgctxt "2026960B-123007BB-52001020"
 msgid ""
 "Cloverleaf\n"
 "\n"
@@ -97,7 +97,7 @@ msgstr ""
 "\n"
 "Il pulsante contiene le intersezioni a T sia per l'autostrada che per l'autostrada sopraelevata."
 
-msgctxt "2026960B-123006BB-52002000"
+msgctxt "2026960B-123007BB-52002000"
 msgid ""
 "T-Intersections\n"
 "\n"
@@ -108,7 +108,7 @@ msgctxt "2026960B-123006AA-6A470100"
 msgid "With the Canal Addon Mod you can build functional canals"
 msgstr "Con il Canale Addon Mod è possibile costruire canali funzionali"
 
-msgctxt "2026960B-123006BB-6A470100"
+msgctxt "2026960B-123007BB-6A470100"
 msgid "Canal Addon Mod"
 msgstr "Canale Addon Mod"
 
@@ -124,7 +124,7 @@ msgstr ""
 "Il pulsante contiene gli starter delle corsie di svolta FLEX e le intersezioni FLEX per varie reti stradali.\n"
 "Trascinare la rete elencata attraverso il pezzo FLEX/Starter per costruire la corsia di svolta."
 
-msgctxt "2026960B-123006BB-6A470460"
+msgctxt "2026960B-123007BB-6A470460"
 msgid "FLEX Turn Lanes (FTLs)"
 msgstr "Corsie di svolta FLEX (FTL)"
 
@@ -135,7 +135,7 @@ msgid ""
 "Button contains QuickTurn setups, which are FLEX intersections with turn lanes"
 msgstr "Per la costruzione di intersezioni QuickTurn\\"
 
-msgctxt "2026960B-123006BB-6A4704A0"
+msgctxt "2026960B-123007BB-6A4704A0"
 msgid "QuickTurn (Pre-Built FLEX Turn Lane Setups)"
 msgstr "QuickTurn (Configurazione preconfezionata della corsia di svolta FLEX)"
 
@@ -146,7 +146,7 @@ msgid ""
 "Button contains Turn Lane and Slip Lane Puzzle Pieces for various networks and configurations"
 msgstr "Per la costruzione di vecchi pezzi di estensione della corsia di svolta (TuLEP)\\"
 
-msgctxt "2026960B-123006BB-6A4704E0"
+msgctxt "2026960B-123007BB-6A4704E0"
 msgid "TuLEPs (Turn Lane Extension Pieces) (OLD)"
 msgstr "TuLEP (Pezzi di estensione della corsia di svolta) (VECCHIO)"
 
@@ -157,7 +157,7 @@ msgid ""
 "Button contains Turn Lane puzzle pieces for 7-lane Turning Lane Avenue (TLA-7) and 6-lane Avenue (AVE-6) networks"
 msgstr "Per la costruzione di pezzi di corsie di svolta per la rete a tre piastrelle Network Widening Mod (NWM)\\"
 
-msgctxt "2026960B-123006BB-6A470600"
+msgctxt "2026960B-123007BB-6A470600"
 msgid "Network Widening Mod (NWM) Triple-Tile Network Turn Lane Extension Pieces (TuLEPs)"
 msgstr "Modello di allargamento della rete (NWM) Pezzi di estensione della corsia di svolta della rete a tre piastrelle (TuLEPs)"
 
@@ -171,7 +171,7 @@ msgstr ""
 "\n"
 "Il pulsante contiene componenti per l'autostrada e l'autostrada sopraelevata."
 
-msgctxt "2026960B-123006BB-6A473141"
+msgctxt "2026960B-123007BB-6A473141"
 msgid ""
 "Symphony Prefab Interchange Components\n"
 "\n"
@@ -188,7 +188,7 @@ msgstr ""
 "\n"
 "Il pulsante contiene componenti per l'autostrada e l'autostrada sopraelevata."
 
-msgctxt "2026960B-123006BB-6A473143"
+msgctxt "2026960B-123007BB-6A473143"
 msgid ""
 "Symphony Ramp Interfaces\n"
 "\n"
@@ -205,7 +205,7 @@ msgstr ""
 "\n"
 "Il primo oggetto è il pezzo iniziale."
 
-msgctxt "2026960B-123006BB-6A474000"
+msgctxt "2026960B-123007BB-6A474000"
 msgid "Single-Track Rail (STR)"
 msgstr "RAM Fase 1 - Binario unico"
 
@@ -221,7 +221,7 @@ msgstr ""
 "Il pulsante contiene gli Pezzi Iniziali per costruire reti RHW di varie larghezze e altezze, fino a 12 corsie (RHW-12S) e, per alcune reti, fino a 30 metri di altezza (L4).\n"
 "Trascinare lo strumento di rete RealHighway (RHW-2) attraverso gli Pezzi Iniziali per costruire la rete di scavalcamento desiderata."
 
-msgctxt "2026960B-123006BB-6A475000"
+msgctxt "2026960B-123007BB-6A475000"
 msgid "RealHighway (RHW) Starter Pieces"
 msgstr "Pezzi iniziali RealHighway (RHW)"
 
@@ -236,7 +236,7 @@ msgid ""
 "Place down Eraser onto desired tile and redraw anything if needed"
 msgstr "Usare questa piastrella per cancellare sezioni 1x1 di reti da pezzi FLEX, starter, incroci o altre sezioni di rete trascinabili senza influenzare le piastrelle vicine, compresi altri starter, pezzi FLEX o incroci.\\"
 
-msgctxt "2026960B-123006BB-6A475024"
+msgctxt "2026960B-123007BB-6A475024"
 msgid "Network Eraser"
 msgstr "Cancellazione della rete"
 
@@ -247,7 +247,7 @@ msgid ""
 "Button contains Filler Pieces to build RHW networks in smaller chunks, in unstable situations"
 msgstr "Per costruire pezzi di riempimento RealHighway\\"
 
-msgctxt "2026960B-123006BB-6A475050"
+msgctxt "2026960B-123007BB-6A475050"
 msgid "RealHighway Filler Pieces"
 msgstr "Pezzi di riempimento RealHighway"
 
@@ -265,7 +265,7 @@ msgstr ""
 "\n"
 "Questi elementi sono DEPRECATI e si raccomanda l'uso delle Connessioni di Vicinato FLEX."
 
-msgctxt "2026960B-123006BB-6A47508C"
+msgctxt "2026960B-123007BB-6A47508C"
 msgid "Old RealHighway Neighbor Connector Puzzle Pieces  - DEPRECATED"
 msgstr "Vecchi pezzi del puzzle del connettore di vicinato RealHighway - DEPRECATO"
 
@@ -278,7 +278,7 @@ msgid ""
 "NOTE: ALL REALHIGHWAY NEIGHBOR CONNECTIONS (EXCEPT RHW-2) ARE REQUIRED TO USE NEIGHBOR CONNECTOR PIECES TO ENSURE PROPERLY FUNCTIONING NEIGHBOR CONNECTIONS--OTHERWISE ONLY FREIGHT TRUCKS WILL USE THE RHW"
 msgstr "Per costruire i connettori di vicinato RealHighway FLEX (FLEX-NC)\\"
 
-msgctxt "2026960B-123006BB-6A475090"
+msgctxt "2026960B-123007BB-6A475090"
 msgid "RealHighway FLEX Neighbor Connector Pieces (FLEX-NC)"
 msgstr "RealHighway FLEX Neighbor Connector Pieces (FLEX-NC)"
 
@@ -286,7 +286,7 @@ msgctxt "2026960B-123006AA-6A475100"
 msgid "For building DEPRECATED RealHighway Ramp Interfaces.  All of the functionality of the 47 pieces contained and many more are covered by the FLEXRamp system."
 msgstr "Per la costruzione di interfacce di rampa RealHighway DEPRECATE.  Tutte le funzionalità dei 47 pezzi contenuti e molte altre sono coperte dal sistema FLEXRamp."
 
-msgctxt "2026960B-123006BB-6A475100"
+msgctxt "2026960B-123007BB-6A475100"
 msgid "OBSOLETE RealHighway Ramp Interfaces (Static Puzzle-Based)"
 msgstr "OBSOLETO Interfacce di rampe di autostrade reali (basate su puzzle statici)"
 
@@ -297,7 +297,7 @@ msgid ""
 "Button contains Type B Ramp Interface Pieces for building interchanges with the RHW"
 msgstr "Per la costruzione di interfacce di rampa di tipo B RHW (diramazione diagonale, nuova corsia) \\"
 
-msgctxt "2026960B-123006BB-6A475104"
+msgctxt "2026960B-123007BB-6A475104"
 msgid "RealHighway Type B Ramp Interfaces"
 msgstr "Interfacce di rampa RealHighway di tipo B"
 
@@ -308,7 +308,7 @@ msgid ""
 "Button contains Type E Ramp Interface Pieces for building interchanges with the RHW"
 msgstr "Per la costruzione di interfacce di rampa di tipo E RHW (ramo diagonale, corsia di sola uscita) \\"
 
-msgctxt "2026960B-123006BB-6A475109"
+msgctxt "2026960B-123007BB-6A475109"
 msgid "RealHighway Type E Ramp Interfaces"
 msgstr "Interfacce per rampe di tipo E di RealHighway"
 
@@ -319,7 +319,7 @@ msgid ""
 "Button contains Type D Ramp Interface Pieces for building interchanges with the RHW"
 msgstr "Per la costruzione di interfacce di rampa di tipo D RHW (ramo parallelo, corsia di sola uscita) \\"
 
-msgctxt "2026960B-123006BB-6A47510A"
+msgctxt "2026960B-123007BB-6A47510A"
 msgid "RealHighway Type D Ramp Interfaces"
 msgstr "Interfacce per rampe di tipo D di RealHighway"
 
@@ -333,7 +333,7 @@ msgstr ""
 "\n"
 "Le rampe di pezzi di puzzle deprecati seguono i pezzi di Volleyball - si raccomanda l'uso delle FLEXRamps o delle Draggable Ramp Interfaces (DRI) invece di usare i pezzi di puzzle deprecati."
 
-msgctxt "2026960B-123006BB-6A475118"
+msgctxt "2026960B-123007BB-6A475118"
 msgid "Specialized and Deprecated RealHighway Ramp Interfaces and Volleyball Crossings (Static Puzzle-Based)"
 msgstr "Interfacce di rampe autostradali specializzate e deprecate e attraversamenti di pallavolo (basati su puzzle statici)"
 
@@ -347,7 +347,7 @@ msgstr ""
 "\n"
 "Il pulsante contiene pezzi FLEX per diverse interfacce di rampa modificabili.  Trascinare le reti appropriate per convertire la rampa di base in modo che corrisponda."
 
-msgctxt "2026960B-123006BB-6A4751F0"
+msgctxt "2026960B-123007BB-6A4751F0"
 msgid "RealHighway FLEXRamps"
 msgstr "Rampe RealHighway FLEX"
 
@@ -358,7 +358,7 @@ msgid ""
 "Button contains pieces to build Wide Curves for the RHW networks"
 msgstr "Per costruire pezzi di curve larghe RealHighway\\"
 
-msgctxt "2026960B-123006BB-6A475220"
+msgctxt "2026960B-123007BB-6A475220"
 msgid "RealHighway Wide-Radius and Multi-Radius (Smooth) Curves"
 msgstr "RealHighway Curve a raggio largo e a raggio multiplo (lisce)"
 
@@ -376,7 +376,7 @@ msgstr ""
 "\n"
 "Questi elementi sono DEPRECATI e si raccomanda l'uso delle transizioni di larghezza FLEX (FLEX-WT)."
 
-msgctxt "2026960B-123006BB-6A475300"
+msgctxt "2026960B-123007BB-6A475300"
 msgid "Old RealHighway Width Transition Puzzle Pieces - DEPRECATED"
 msgstr "Vecchi pezzi del puzzle di transizione in larghezza di RealHighway - DEPRECATI"
 
@@ -394,7 +394,7 @@ msgstr ""
 "\n"
 "Tutte le funzionalità sono state duplicate con le transizioni di altezza FLEX e pertanto questo pulsante è DEPRECATO."
 
-msgctxt "2026960B-123006BB-6A475312"
+msgctxt "2026960B-123007BB-6A475312"
 msgid "Old RealHighway Height Transition Puzzle Pieces  - DEPRECATED"
 msgstr "Vecchi pezzi del puzzle di transizione di altezza RealHighway - DEPRECATO"
 
@@ -408,7 +408,7 @@ msgstr ""
 "\n"
 "Il pulsante contiene pezzi di transizione tra reti RHW di altezze diverse.  I pezzi iniziano come transizioni RHW-2 e, trascinando un'altra rete RHW, vengono convertiti per adattarsi."
 
-msgctxt "2026960B-123006BB-6A475330"
+msgctxt "2026960B-123007BB-6A475330"
 msgid "RealHighway FLEX Height Transitions (FLEX-HT)"
 msgstr "Transizioni in altezza RealHighway FLEX (FLEX-HT)"
 
@@ -422,7 +422,7 @@ msgstr ""
 "\n"
 "Il pulsante contiene pezzi di transizione tra reti RHW di diversa larghezza.  Trascinando un'altra rete RHW al loro interno, si convertiranno per adattarsi."
 
-msgctxt "2026960B-123006BB-6A475336"
+msgctxt "2026960B-123007BB-6A475336"
 msgid "RealHighway FLEX Width Transitions (FLEX-WT)"
 msgstr "Transizioni di larghezza RealHighway FLEX (FLEX-WT)"
 
@@ -436,7 +436,7 @@ msgstr ""
 "\n"
 "Il pulsante contiene componenti per autostrade terrestri e sopraelevate."
 
-msgctxt "2026960B-123006BB-6A475350"
+msgctxt "2026960B-123007BB-6A475350"
 msgid ""
 "Symphony Transitions\n"
 "\n"
@@ -453,7 +453,7 @@ msgstr ""
 "\n"
 "Il pulsante contiene componenti per autostrade terrestri e sopraelevate."
 
-msgctxt "2026960B-123006BB-6A475366"
+msgctxt "2026960B-123007BB-6A475366"
 msgid ""
 "Symphony Smooth Curves\n"
 "\n"
@@ -474,7 +474,7 @@ msgstr ""
 "\n"
 "NOTA: questi pezzi non devono essere confusi con i TuLEP."
 
-msgctxt "2026960B-123006BB-6A475400"
+msgctxt "2026960B-123007BB-6A475400"
 msgid "RealHighway Cosmetic Puzzle Pieces (for 1-Tile Networks)"
 msgstr "Pezzi di puzzle cosmetici RealHighway (per reti a 1 tessera)"
 
@@ -492,7 +492,7 @@ msgstr ""
 "\n"
 "NOTA: questi pezzi non devono essere confusi con i TuLEP."
 
-msgctxt "2026960B-123006BB-6A475410"
+msgctxt "2026960B-123007BB-6A475410"
 msgid "RealHighway Cosmetic Piece Transitions"
 msgstr "RealHighway Transizioni di pezzi cosmetici"
 
@@ -510,7 +510,7 @@ msgstr ""
 "\n"
 "NOTA: questi pezzi non devono essere confusi con i TuLEP."
 
-msgctxt "2026960B-123006BB-6A475440"
+msgctxt "2026960B-123007BB-6A475440"
 msgid "RealHighway Cosmetic Puzzle Pieces (for 2-Tile Networks)"
 msgstr "Pezzi di puzzle cosmetici RealHighway (per reti a 2 piastrelle)"
 
@@ -528,7 +528,7 @@ msgstr ""
 "\n"
 "NOTA: questi pezzi non devono essere confusi con i TuLEP."
 
-msgctxt "2026960B-123006BB-6A475471"
+msgctxt "2026960B-123007BB-6A475471"
 msgid "RealHighway Cosmetic Puzzle Pieces (for 3-Tile Networks)"
 msgstr "Pezzi di puzzle cosmetici RealHighway (per reti a 3 piastrelle)"
 
@@ -541,7 +541,7 @@ msgid ""
 "<DEPRECATED>"
 msgstr "Per la costruzione di cavalcavia diagonali ERHW-over-RHW DEPRECATI\\"
 
-msgctxt "2026960B-123006BB-6A475500"
+msgctxt "2026960B-123007BB-6A475500"
 msgid "ERHW-over-RHW Diagonal Overpass Puzzle Pieces<DEPRECATED>"
 msgstr "Pezzi del puzzle di sovrappasso diagonale ERHW-over-RHW<DEPRECATO>"
 
@@ -559,7 +559,7 @@ msgstr ""
 "\n"
 "Posizionare i pezzi di attraversamento sopra le strade sotterranee ogni volta che una rete di superficie si incrocia, per consentire al traffico di passare nel sottosuolo."
 
-msgctxt "2026960B-123006BB-6A475600"
+msgctxt "2026960B-123007BB-6A475600"
 msgid "RHW Flexible Underpasses (FLUPs), Draggable Underground Roads (URoads), and Overcrossings"
 msgstr "Sottopassi flessibili RHW (FLUP), strade sotterranee trascinabili (URoad) e attraversamenti"
 
@@ -573,7 +573,7 @@ msgstr ""
 "\n"
 "Il pulsante contiene segmenti di interscambio RHW flessibili.  Trascinare le reti appropriate per convertire la rampa di base e combinarle per creare facilmente uno svincolo completo."
 
-msgctxt "2026960B-123006BB-6A475700"
+msgctxt "2026960B-123007BB-6A475700"
 msgid "RealHighway QuickChanges"
 msgstr "Cambi rapidi di RealHighway"
 
@@ -584,7 +584,7 @@ msgid ""
 "Button contains starter/transition FLEX pieces for different RHW turn lane setups"
 msgstr "Per la costruzione di corsie di svolta RealHighway FLEX (FTL)\\"
 
-msgctxt "2026960B-123006BB-6A475900"
+msgctxt "2026960B-123007BB-6A475900"
 msgid "RealHighway FLEX Turn Lanes (FTLs)"
 msgstr "Corsie di svolta FLEX di RealHighway (FTL)"
 
@@ -595,7 +595,7 @@ msgid ""
 "Button contains pieces to build FLEXFly Pieces"
 msgstr "Per la costruzione di sistemi FLEXFly Flyover e Flyunder legacy/deprecati\\"
 
-msgctxt "2026960B-123006BB-6A475AF3"
+msgctxt "2026960B-123007BB-6A475AF3"
 msgid "RealHighway FLEXFly (LEGACY/DEPRECATED)"
 msgstr "RealHighway FLEXFly (LEGACY/DEPRECATO)"
 
@@ -606,7 +606,7 @@ msgid ""
 "Button contains pieces to build 3-Level Crossings"
 msgstr "Per la costruzione di FLEX/Helper Pezzi per la costruzione di incroci a 3 livelli RHW\\"
 
-msgctxt "2026960B-123006BB-6A475AF6"
+msgctxt "2026960B-123007BB-6A475AF6"
 msgid "RealHighway 3-Level Crossings"
 msgstr "RealHighway Attraversamenti a 3 livelli"
 
@@ -617,7 +617,7 @@ msgid ""
 "Button contains pieces to build FLEXFly Pieces"
 msgstr "Per costruire i sistemi FLEXFly Flyover e Flyunder\\"
 
-msgctxt "2026960B-123006BB-6A475B00"
+msgctxt "2026960B-123007BB-6A475B00"
 msgid "RealHighway FLEXFly"
 msgstr "RealHighway FLEXFly"
 
@@ -635,7 +635,7 @@ msgstr ""
 "\n"
 "NOTA: la maggior parte delle intersezioni richiede l'uso di TuLEP."
 
-msgctxt "2026960B-123006BB-6A475F00"
+msgctxt "2026960B-123007BB-6A475F00"
 msgid "Fractionally Angled RealHighway Intersections and Transitions"
 msgstr "Intersezioni e transizioni di autostrade reali angolate in modo frazionario"
 
@@ -646,7 +646,7 @@ msgid ""
 "Button contains straight pieces and curves to pieces to build Fractionally Angled RealHighway (FARHWs)"
 msgstr "Per costruire pezzi di autostrade reali frazionatamente angolate\\"
 
-msgctxt "2026960B-123006BB-6A475F20"
+msgctxt "2026960B-123007BB-6A475F20"
 msgid "Fractionally Angled RealHighway"
 msgstr "Autostrada reale ad angolo frazionato"
 
@@ -657,7 +657,7 @@ msgid ""
 "Button contains pieces to build different FARHW Ramp Interfaces: The C1, F1, C2, F2, and C3 Ramp Interfaces"
 msgstr "Per la costruzione di interfacce di rampa Fractionally Angled RealHighway\\"
 
-msgctxt "2026960B-123006BB-6A475F30"
+msgctxt "2026960B-123007BB-6A475F30"
 msgid "Fractionally Angled RealHighway Ramp Interfaces"
 msgstr "Interfacce per rampe autostradali ad angolo frazionato"
 
@@ -668,7 +668,7 @@ msgid ""
 "Button contains Type C Ramp Interface Pieces for building interchanges with the RHW"
 msgstr "Per la costruzione di interfacce di rampa di tipo C RHW (diramazione ad angolo frazionario, nuova corsia) \\"
 
-msgctxt "2026960B-123006BB-6A475F70"
+msgctxt "2026960B-123007BB-6A475F70"
 msgid "RealHighway Type C Ramp Interfaces"
 msgstr "Interfacce di rampa RealHighway di tipo C"
 
@@ -679,7 +679,7 @@ msgid ""
 "Button contains Type F Ramp Interface Pieces for building interchanges with the RHW"
 msgstr "Per la costruzione di interfacce di rampa RHW di tipo F (ramo ad angolo frazionario, corsia di sola uscita) \\"
 
-msgctxt "2026960B-123006BB-6A475F71"
+msgctxt "2026960B-123007BB-6A475F71"
 msgid "RealHighway Type F Ramp Interfaces"
 msgstr "Interfacce di rampa RealHighway di tipo F"
 
@@ -697,7 +697,7 @@ msgstr ""
 "\n"
 "NOTA: le tessere centro commerciale pedonale non devono essere utilizzate direttamente davanti alle zone residenziali, dove si trova la loro freccia di zonizzazione."
 
-msgctxt "2026960B-123006BB-6A476005"
+msgctxt "2026960B-123007BB-6A476005"
 msgid "Pedestrian Mall Tiles"
 msgstr "Piastrelle per centri commerciali pedonali"
 
@@ -705,7 +705,7 @@ msgctxt "2026960B-123006AA-6A476100"
 msgid "A collection of pedestrian crossing FLEX pieces. Use them on their own at crossing locations, or as part of pedmall corridors."
 msgstr "Una collezione di pezzi FLEX per attraversamenti pedonali. Si possono usare da soli nei punti di attraversamento o come parte di corridoi pedonali."
 
-msgctxt "2026960B-123006BB-6A476100"
+msgctxt "2026960B-123007BB-6A476100"
 msgid "Pedestrian Revolution Mod (PRM) FLEX Crossings"
 msgstr "Attraversamenti pedonali FLEX (Pedestrian Revolution Mod, PRM)"
 
@@ -716,7 +716,7 @@ msgid ""
 "Button contains several different Puzzle and Helper Pieces for Street"
 msgstr "Per la costruzione di strade diagonali su terreni inclinati o intersezioni\\"
 
-msgctxt "2026960B-123006BB-6A476525"
+msgctxt "2026960B-123007BB-6A476525"
 msgid "Diagonal Street Helper Pieces"
 msgstr "Pezzi di aiuto per la via diagonale"
 
@@ -727,7 +727,7 @@ msgid ""
 "Button contains Starter Pieces for Street Addon Mod (SAM)"
 msgstr "Per l'utilizzo di Street Addon Mod (SAM)\\"
 
-msgctxt "2026960B-123006BB-6A476700"
+msgctxt "2026960B-123007BB-6A476700"
 msgid "Street Addon Mod (SAM)"
 msgstr "Street Addon Mod (SAM)"
 
@@ -735,7 +735,7 @@ msgctxt "2026960B-123006AA-6A476905"
 msgid "Plop one of these pieces on a flat area. It will raise or lower the terrain, and then destroy itself, providing a level area for a raised network of your choice. This is fully compatible with all slope mods."
 msgstr "Posizionate uno di questi pezzi su un'area piana. Il pezzo alzerà o abbasserà il terreno e poi si autodistruggerà, fornendo un'area pianeggiante per una rete rialzata a scelta. È pienamente compatibile con tutti i mod di pendenza."
 
-msgctxt "2026960B-123006BB-6A476905"
+msgctxt "2026960B-123007BB-6A476905"
 msgid "Hole Digger and Raiser Lots"
 msgstr "Lotti di scavatori e sollevatori di buche"
 
@@ -746,7 +746,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Avenues"
 msgstr "Per la costruzione di rotatorie di strade, di pilastri a Y e di altre intersezioni di strade\\"
 
-msgctxt "2026960B-123006BB-6A476A00"
+msgctxt "2026960B-123007BB-6A476A00"
 msgid "Avenue Intersections"
 msgstr "Intersezioni del viale"
 
@@ -757,7 +757,7 @@ msgid ""
 "Button contains several different overpasses for Road"
 msgstr "Per la creazione di sovrappassi stradali\\"
 
-msgctxt "2026960B-123006BB-6A477000"
+msgctxt "2026960B-123007BB-6A477000"
 msgid "Road Overpasses"
 msgstr "Cavalcavia stradali"
 
@@ -768,7 +768,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Road"
 msgstr "Per la costruzione di viadotti stradali sopraelevati alti 7,5 metri\\"
 
-msgctxt "2026960B-123006BB-6A477005"
+msgctxt "2026960B-123007BB-6A477005"
 msgid "7.5m Elevated Road Viaducts"
 msgstr "Viadotti stradali sopraelevati da 7,5 m"
 
@@ -779,7 +779,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Road"
 msgstr "Per la costruzione di viadotti stradali sopraelevati alti 15 metri\\"
 
-msgctxt "2026960B-123006BB-6A477200"
+msgctxt "2026960B-123007BB-6A477200"
 msgid "15m Elevated Road Viaducts"
 msgstr "Viadotti stradali sopraelevati di 15 m"
 
@@ -790,7 +790,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Road, One-Way Road, or Avenue"
 msgstr "Per costruire curve ad ampio raggio\\"
 
-msgctxt "2026960B-123006BB-6A477500"
+msgctxt "2026960B-123007BB-6A477500"
 msgid "Wide Radius Curves (for Road, One-Way Road, Avenue, and Street) (Puzzle Pieces)"
 msgstr "Curve ad ampio raggio (per strada, strada a senso unico, viale e strada) (Puzzle)"
 
@@ -801,7 +801,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Road, One-Way Road, and Avenue"
 msgstr "Per costruire reti frazionatamente angolate\\"
 
-msgctxt "2026960B-123006BB-6A477600"
+msgctxt "2026960B-123007BB-6A477600"
 msgid "Fractionally-Angled Networks (for Road, One-Way Road, and Avenue)"
 msgstr "Reti ad angoli frazionati (per strada, strada a senso unico e viale)"
 
@@ -812,7 +812,7 @@ msgid ""
 "Once a puzzle piece is selected, use the [Home] and [End] keys to cycle through the various puzzle piece orientations"
 msgstr "Utilizzare il tasto [Tab] per spostarsi verso il basso tra i pezzi del puzzle e i tasti [Shift] + [Tab] per spostarsi verso l'alto.\\"
 
-msgctxt "2026960B-123006BB-6A477700"
+msgctxt "2026960B-123007BB-6A477700"
 msgid "Rural Road Puzzle Pieces"
 msgstr "Pezzi di puzzle di strade rurali"
 
@@ -823,7 +823,7 @@ msgid ""
 "Button contains pieces to interface between the NAM Elevated Road Puzzle Pieces and RHW networks, including overpasses and intersections"
 msgstr "Per la costruzione di pezzi di puzzle stradali che si interfacciano con l'RHW (DEPRECATO)\\"
 
-msgctxt "2026960B-123006BB-6A477800"
+msgctxt "2026960B-123007BB-6A477800"
 msgid "Road/RHW Overpass and Interface Puzzle Pieces (DEPRECATED)"
 msgstr "Pezzi del puzzle del cavalcavia e dell'interfaccia della strada/RHW (DEPRECATO)"
 
@@ -834,7 +834,7 @@ msgid ""
 "Button contains several different FLEX Pieces for various networks"
 msgstr "Per la costruzione di pezzi FLEX con curve a raggio multiplo (MRC) per le reti di superficie, comprese le reti stradali, le strade a senso unico, i viali e i moduli di allargamento della rete (NWM).\\"
 
-msgctxt "2026960B-123006BB-6A477900"
+msgctxt "2026960B-123007BB-6A477900"
 msgid "Multi-Radius Curve (MRC) FLEX Pieces for Surface Networks"
 msgstr "Curva a più raggi (MRC) Pezzi FLEX per reti di superficie"
 
@@ -860,7 +860,7 @@ msgstr ""
 "\n"
 "Il nuovo sistema di FLUP basato sulle metropolitane si trova nel menu Autostrade."
 
-msgctxt "2026960B-123006BB-6A477A00"
+msgctxt "2026960B-123007BB-6A477A00"
 msgid "Flexible Underpasses (FLUPs)"
 msgstr "Sottopassi flessibili (FLUP)"
 
@@ -871,7 +871,7 @@ msgid ""
 "Button contains Starter Pieces for the 3, 5 and 7-lane Turning Lane Avenues (TLA-3,5,7), 2 and 6-lane Avenues (AVE-2,6), 3-lane Asymmetrical Road (ARD-3), 4 and 6-lane Roads RD-4,6) and 1, 3, 4 and 5-lane One-Way Roads (OWR-1,3,4,5)"
 msgstr "Per la costruzione dei pezzi iniziali del Network Widening Mod (NWM)\\"
 
-msgctxt "2026960B-123006BB-6A477B00"
+msgctxt "2026960B-123007BB-6A477B00"
 msgid "Network Widening Mod (NWM) Starter Pieces"
 msgstr "Pezzi iniziali del modulo di allargamento della rete (NWM)"
 
@@ -882,7 +882,7 @@ msgid ""
 "Button contains Wide-Radius Curve Pieces for the single-tile NWM networks"
 msgstr "Per la costruzione di pezzi di curva Network Widening Mod (NWM)\\"
 
-msgctxt "2026960B-123006BB-6A477B30"
+msgctxt "2026960B-123007BB-6A477B30"
 msgid "Network Widening Mod (NWM) Curve Pieces"
 msgstr "Mod di allargamento della rete (NWM) Pezzi di curva"
 
@@ -895,7 +895,7 @@ msgid ""
 "Note that most transitions involving single and dual-tile networks can be built using draggable means instead (such as direct connections or using the stub-to-stub method)"
 msgstr "Per la costruzione di pezzi di puzzle di transizione per il Network Widening Mod (NWM)\\"
 
-msgctxt "2026960B-123006BB-6A477B50"
+msgctxt "2026960B-123007BB-6A477B50"
 msgid "Network Widening Mod (NWM) Transition Pieces"
 msgstr "Mod di ampliamento della rete (NWM) Pezzi di transizione"
 
@@ -906,7 +906,7 @@ msgid ""
 "Button contains Neighbor Connector Pieces for the TLA-5, RD-4 and RD-6"
 msgstr "Per la costruzione di pezzi di connettori di prossimità per il modulo di allargamento della rete (NWM)\\"
 
-msgctxt "2026960B-123006BB-6A477BF0"
+msgctxt "2026960B-123007BB-6A477BF0"
 msgid "Network Widening Mod (NWM) Neighbor Connector Pieces"
 msgstr "Modello di allargamento della rete (NWM) Pezzi di collegamento di prossimità"
 
@@ -917,7 +917,7 @@ msgid ""
 "Button contains FLEX Single Tile Roundabouts intersections for various road networks"
 msgstr "Per la costruzione di rotatorie FLEX a piastrella singola\\"
 
-msgctxt "2026960B-123006BB-6A477C00"
+msgctxt "2026960B-123007BB-6A477C00"
 msgid "Single Tile Roundabouts"
 msgstr "Rotatorie a una piastrella"
 
@@ -930,7 +930,7 @@ msgid ""
 "Button contains OnSlope Transitions to start Alternate Style Road and Street Viaducts"
 msgstr "Per la costruzione di viadotti stradali e viadotti stradali di tipo alternativo\\"
 
-msgctxt "2026960B-123006BB-6A477E00"
+msgctxt "2026960B-123007BB-6A477E00"
 msgid "Road Viaduct Alternate Styles"
 msgstr "Viadotto stradale Stili alternativi"
 
@@ -941,7 +941,7 @@ msgid ""
 "Button contains several different Starter and FLEX Pieces for Draggable Elevated Road Viaducts"
 msgstr "Per la costruzione di viadotti stradali sopraelevati trascinabili\\"
 
-msgctxt "2026960B-123006BB-6A477F00"
+msgctxt "2026960B-123007BB-6A477F00"
 msgid "Draggable Elevated Road Viaducts"
 msgstr "Viadotti stradali sopraelevati trascinabili"
 
@@ -959,7 +959,7 @@ msgstr ""
 "\n"
 "Trascinare le reti sotto (o sopra) la sezione centrale del cavalcavia per costruire l'attraversamento.  Sono supportate la maggior parte delle reti e le reti doppie basate su FLEX."
 
-msgctxt "2026960B-123006BB-6A477F30"
+msgctxt "2026960B-123007BB-6A477F30"
 msgid "FLEX Overpasses"
 msgstr "Cavalcavia FLEX"
 
@@ -970,7 +970,7 @@ msgid ""
 "Button contains several different overpasses for One-Way Road"
 msgstr "Per creare cavalcavia per strade a senso unico\\"
 
-msgctxt "2026960B-123006BB-6A478000"
+msgctxt "2026960B-123007BB-6A478000"
 msgid "One-Way Road Overpasses"
 msgstr "Cavalcavia a senso unico"
 
@@ -981,7 +981,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for One-Way Road"
 msgstr "Per la costruzione di viadotti stradali a senso unico alti 15 metri\\"
 
-msgctxt "2026960B-123006BB-6A478005"
+msgctxt "2026960B-123007BB-6A478005"
 msgid "15m Elevated One-Way Road Viaducts"
 msgstr "Viadotti stradali a senso unico sopraelevati di 15 m"
 
@@ -992,7 +992,7 @@ msgid ""
 "Button contains pieces to interface between the NAM Elevated One-Way Road Puzzle Pieces and RHW networks, including overpasses and intersections"
 msgstr "Per la costruzione di pezzi di puzzle di strade a senso unico che si interfacciano con l'RHW (DEPRECATO)\\"
 
-msgctxt "2026960B-123006BB-6A478800"
+msgctxt "2026960B-123007BB-6A478800"
 msgid "One-Way Road/RHW Overpass and Interface Puzzle Pieces (DEPRECATED)"
 msgstr "Strada a senso unico/sovrappasso AV e pezzi del puzzle di interfaccia (DEPRECATO)"
 
@@ -1000,7 +1000,7 @@ msgctxt "2026960B-123006AA-6A478900"
 msgid "For use of the curved pieces for the Real Expressway Network. Use the Home/End key to rotate the FLEX Piece & use TAB/Shift-TAB (Ctrl-TAB/Ctrl-Shift-TAB on macOS) to cycle through the different types of REW Straights and Curves."
 msgstr "Per l'uso dei pezzi curvi per la rete di superstrade reali. Usare il tasto Home/Fine per ruotare il pezzo FLEX e usare TAB/Shift-TAB (Ctrl-TAB/Ctrl-Shift-TAB su macOS) per scorrere i diversi tipi di rette e curve REW."
 
-msgctxt "2026960B-123006BB-6A478900"
+msgctxt "2026960B-123007BB-6A478900"
 msgid "Real Expressway FLEX Piece network tool and Curves."
 msgstr "Strumento di rete di pezzi FLEX Real Expressway e Curve."
 
@@ -1014,7 +1014,7 @@ msgstr ""
 "\n"
 "Il pulsante contiene pezzi FLEX per diverse interfacce di rampa modificabili.  Trascinare le reti appropriate per convertire la rampa di base in modo che corrisponda."
 
-msgctxt "2026960B-123006BB-6A478B00"
+msgctxt "2026960B-123007BB-6A478B00"
 msgid "RealExpressway (REW) One-Way Road FLEXRamps"
 msgstr "RealExpressway (REW) Strada a senso unico FLEXRamps"
 
@@ -1025,7 +1025,7 @@ msgid ""
 "Button contains several different overpasses for Avenue"
 msgstr "Per creare i cavalcavia di Viale\\"
 
-msgctxt "2026960B-123006BB-6A479000"
+msgctxt "2026960B-123007BB-6A479000"
 msgid "Avenue Overpasses"
 msgstr "Cavalcavia del viale"
 
@@ -1036,7 +1036,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Avenue"
 msgstr "Per la costruzione di viadotti sopraelevati alti 7,5 metri\\"
 
-msgctxt "2026960B-123006BB-6A479005"
+msgctxt "2026960B-123007BB-6A479005"
 msgid "7.5m Elevated Avenue Viaducts"
 msgstr "Viadotti di 7,5 m per il viale sopraelevato"
 
@@ -1047,7 +1047,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Avenue"
 msgstr "Per costruire viadotti sopraelevati di 15 metri di altezza\\"
 
-msgctxt "2026960B-123006BB-6A479200"
+msgctxt "2026960B-123007BB-6A479200"
 msgid "15m Elevated Avenue Viaducts"
 msgstr "Viadotti di viale sopraelevati di 15 m"
 
@@ -1058,7 +1058,7 @@ msgid ""
 "Button contains pieces to interface between the NAM Elevated Avenue Puzzle Pieces and RHW networks, including overpasses and intersections"
 msgstr "Per la costruzione di pezzi di puzzle di strade che si interfacciano con l'RHW (DEPRECATO)\\"
 
-msgctxt "2026960B-123006BB-6A479900"
+msgctxt "2026960B-123007BB-6A479900"
 msgid "Avenue/RHW Overpass and Interface Puzzle Pieces (DEPRECATED)"
 msgstr "Cavalcavia di Avenue/RHW e pezzi di puzzle dell'interfaccia (DEPRECATO)"
 
@@ -1071,7 +1071,7 @@ msgid ""
 "FlexSPUI and Flex Diverging Diamond (FlexDDI) pieces are found under this button"
 msgstr "Per la costruzione di pezzi FLEX in cui le reti di superficie (ad es. viali, reti NWM, ecc.) si intersecano o si incrociano con le reti RHW.\\"
 
-msgctxt "2026960B-123006BB-6A47991A"
+msgctxt "2026960B-123007BB-6A47991A"
 msgid "Specialized RHW x Surface Intersections"
 msgstr "Intersezioni specializzate RHW x Superficie"
 
@@ -1085,7 +1085,7 @@ msgstr ""
 "\n"
 "Il pulsante contiene diversi pezzi di puzzle per rotaie."
 
-msgctxt "2026960B-123006BB-6A47A005"
+msgctxt "2026960B-123007BB-6A47A005"
 msgid "Rail Puzzle Pieces"
 msgstr "Pezzi del puzzle ferroviario"
 
@@ -1093,7 +1093,7 @@ msgctxt "2026960B-123006AA-6A47A130"
 msgid "Button contains FLEX pieces to elevated the Rail network to viaduct level (using the RealRailway (RRW) standard)"
 msgstr "Il pulsante contiene pezzi FLEX per elevare la rete ferroviaria a livello di viadotto (utilizzando lo standard RealRailway (RRW))"
 
-msgctxt "2026960B-123006BB-6A47A130"
+msgctxt "2026960B-123007BB-6A47A130"
 msgid "Draggable Elevated Railways (ERRW)"
 msgstr "Ferrovie Elevate Trascinabili (ERRW)"
 
@@ -1104,7 +1104,7 @@ msgid ""
 "Once a puzzle piece is selected, use the [Home] and [End] keys to cycle through the various puzzle piece orientations"
 msgstr "Utilizzare il tasto [Tab] per spostarsi verso il basso tra i pezzi del puzzle e i tasti [Shift] + [Tab] per spostarsi verso l'alto.\\"
 
-msgctxt "2026960B-123006BB-6A47A358"
+msgctxt "2026960B-123007BB-6A47A358"
 msgid "Wide Radius Railroad Curve and Double Track Rail Switch Puzzle Pieces"
 msgstr "Pezzi di puzzle per interruttori ferroviari a doppio binario e con curve ad ampio raggio"
 
@@ -1115,7 +1115,7 @@ msgid ""
 "Once a puzzle piece is selected, use the [Home] and [End] keys to cycle through the various puzzle piece orientations"
 msgstr "Utilizzare il tasto [Tab] per spostarsi verso il basso tra i pezzi del puzzle e i tasti [Shift] + [Tab] per spostarsi verso l'alto.\\"
 
-msgctxt "2026960B-123006BB-6A47A368"
+msgctxt "2026960B-123007BB-6A47A368"
 msgid "Fractional Angle Railroad (FARR) Puzzle Pieces"
 msgstr "Pezzi del puzzle della ferrovia ad angolo frazionario (FARR)"
 
@@ -1126,7 +1126,7 @@ msgid ""
 "Button contains pieces to interface between the NAM Elevated Rail Viaduct Puzzle Pieces and RHW networks, including overpasses and intersections"
 msgstr "Per la costruzione di pezzi di puzzle ferroviari che si interfacciano con l'RHW\\"
 
-msgctxt "2026960B-123006BB-6A47A800"
+msgctxt "2026960B-123007BB-6A47A800"
 msgid "Rail Viaduct/RHW Overpass and Interface Puzzle Pieces"
 msgstr "Viadotto ferroviario/sovrappasso dell'autostrada e pezzi del puzzle dell'interfaccia"
 
@@ -1137,7 +1137,7 @@ msgid ""
 "Once a puzzle piece is selected, use the [Home] and [End] keys to cycle through the various puzzle piece orientations"
 msgstr "Utilizzare il tasto [Tab] per spostarsi verso il basso tra i pezzi del puzzle e i tasti [Shift] + [Tab] per spostarsi verso l'alto.\\"
 
-msgctxt "2026960B-123006BB-6A47A900"
+msgctxt "2026960B-123007BB-6A47A900"
 msgid "Wide Radius Railroad Curve and Double Track Rail Switch Puzzle Pieces"
 msgstr "Pezzi di puzzle per interruttori ferroviari a doppio binario e con curve ad ampio raggio"
 
@@ -1151,7 +1151,7 @@ msgstr ""
 "\n"
 "Il pulsante contiene diversi pezzi per la rete a due o due piani."
 
-msgctxt "2026960B-123006BB-6A47AA0F"
+msgctxt "2026960B-123007BB-6A47AA0F"
 msgid ""
 "Underground Rail\n"
 "Rail Tunnel under Roads Dual Networking Puzzle Pieces"
@@ -1167,7 +1167,7 @@ msgstr ""
 "\n"
 "Il pulsante contiene diversi pezzi per la rete a due o due piani."
 
-msgctxt "2026960B-123006BB-6A47AA10"
+msgctxt "2026960B-123007BB-6A47AA10"
 msgid ""
 "Underground Rail\n"
 "Rail Tunnel under Ped Malls Dual Networking Puzzle Pieces"
@@ -1183,7 +1183,7 @@ msgstr ""
 "\n"
 "Il pulsante contiene diversi pezzi per le strade Maxis."
 
-msgctxt "2026960B-123006BB-6A47AA11"
+msgctxt "2026960B-123007BB-6A47AA11"
 msgid ""
 "Underground Rail\n"
 "Maxis Roadway Intersection Pieces"
@@ -1199,7 +1199,7 @@ msgstr ""
 "\n"
 "Il pulsante contiene diversi pezzi per le ferrovie."
 
-msgctxt "2026960B-123006BB-6A47AA12"
+msgctxt "2026960B-123007BB-6A47AA12"
 msgid ""
 "Underground Rail\n"
 "Railway Intersection Pieces"
@@ -1215,7 +1215,7 @@ msgstr ""
 "\n"
 "Il pulsante contiene diversi pezzi per le linee tranviarie."
 
-msgctxt "2026960B-123006BB-6A47AA13"
+msgctxt "2026960B-123007BB-6A47AA13"
 msgid ""
 "Underground Rail\n"
 "Tramway Intersection Pieces"
@@ -1231,7 +1231,7 @@ msgstr ""
 "\n"
 "Il pulsante contiene diversi pezzi per la rete a due o due piani."
 
-msgctxt "2026960B-123006BB-6A47AA8A"
+msgctxt "2026960B-123007BB-6A47AA8A"
 msgid ""
 "Underground Rail\n"
 "Miscellaneous Puzzle Pieces"
@@ -1241,7 +1241,7 @@ msgctxt "2026960B-123006AA-6A47AC00"
 msgid "All pieces in this section are FLEX and conform to flextrack standards!"
 msgstr "Tutti i pezzi di questa sezione sono FLEX e conformi agli standard Flextrack!"
 
-msgctxt "2026960B-123006BB-6A47AC00"
+msgctxt "2026960B-123007BB-6A47AC00"
 msgid "RealRailway FLEX Curve Pieces."
 msgstr "Pezzi di curva RealRailway FLEX."
 
@@ -1249,7 +1249,7 @@ msgctxt "2026960B-123006AA-6A47AC10"
 msgid "All pieces in this section are FLEX and conform to flextrack standards!"
 msgstr "Tutti i pezzi di questa sezione sono FLEX e conformi agli standard Flextrack!"
 
-msgctxt "2026960B-123006BB-6A47AC10"
+msgctxt "2026960B-123007BB-6A47AC10"
 msgid "RealRailway FLEX Turnout Pieces."
 msgstr "Pezzi di deviatoio RealRailway FLEX."
 
@@ -1257,7 +1257,7 @@ msgctxt "2026960B-123006AA-6A47AD00"
 msgid "All pieces in this section are FLEX and conform to flextrack and FARR standards!\n"
 msgstr "Tutti i pezzi di questa sezione sono FLEX e conformi agli standard Flextrack e FARR!\n"
 
-msgctxt "2026960B-123006BB-6A47AD00"
+msgctxt "2026960B-123007BB-6A47AD00"
 msgid "RealRailway FLEX Fractional Angled (FA) Pieces."
 msgstr "RealRailway FLEX Fractional Angled (FA) Pieces."
 
@@ -1271,7 +1271,7 @@ msgstr ""
 "\n"
 "Il pulsante contiene diversi pezzi per la costruzione di reti doppie/doppie."
 
-msgctxt "2026960B-123006BB-6A47B03A"
+msgctxt "2026960B-123007BB-6A47B03A"
 msgid "ElevatedRail Dual/Double-Decker Network Pieces"
 msgstr "Ferrovia sopraelevata Pezzi di rete a due/due piani"
 
@@ -1279,7 +1279,7 @@ msgctxt "2026960B-123006AA-6A47B049"
 msgid "These puzzle pieces are to allow you to cross NWM networks with ElRail over Road."
 msgstr "Questi pezzi del puzzle permettono di attraversare le reti NWM con la Ferrovia Sopraelevata su Strada."
 
-msgctxt "2026960B-123006BB-6A47B049"
+msgctxt "2026960B-123007BB-6A47B049"
 msgid "ElRail over Road NWM Intersections"
 msgstr "Intersezioni Ferrovia Sopraelevata su Strada e NWM"
 
@@ -1293,7 +1293,7 @@ msgstr ""
 "\n"
 "Utilizzare i tasti Home/Fine per ruotare il pezzo e il tasto TAB per scorrere i diversi tipi di pezzi ElevatedRail."
 
-msgctxt "2026960B-123006BB-6A47B060"
+msgctxt "2026960B-123007BB-6A47B060"
 msgid "ElevatedRail over Avenue/Road-4 Puzzle Pieces"
 msgstr "Ferrovia sopra viale/strada-4 pezzi di puzzle"
 
@@ -1301,7 +1301,7 @@ msgctxt "2026960B-123006AA-6A47B10F"
 msgid "Puzzle Pieces to build a ground level extension of the Elevated Rail network for Light Rail/Trams."
 msgstr "Pezzi di puzzle per costruire un'estensione a livello del suolo della rete ferroviaria sopraelevata per Light Rail/Trams."
 
-msgctxt "2026960B-123006BB-6A47B10F"
+msgctxt "2026960B-123007BB-6A47B10F"
 msgid "Ground Light Rail (Tram)"
 msgstr "Metropolitana leggera di terra (tram)"
 
@@ -1315,7 +1315,7 @@ msgstr ""
 "\n"
 "Collegare la rete di binari sopraelevati con il pezzo iniziale. La ferrovia sopraelevata si trasformerà in un binario della ferrovia leggera terrestre."
 
-msgctxt "2026960B-123006BB-6A47B3FF"
+msgctxt "2026960B-123007BB-6A47B3FF"
 msgid "Draggable Ground Light Rail (Tram)"
 msgstr "Ferrovia leggera trascinabile (tram)"
 
@@ -1323,7 +1323,7 @@ msgctxt "2026960B-123006AA-6A47B42A"
 msgid "For building Tram-Avenue (= GroundLightRail / Avenue) - Dual Network Pieces."
 msgstr "Per la costruzione di tram-viale (= GroundLightRail / Avenue) - Pezzi di rete doppi."
 
-msgctxt "2026960B-123006BB-6A47B42A"
+msgctxt "2026960B-123007BB-6A47B42A"
 msgid "Tram-Avenue (GroundLightRail / Avenue) - Dual Network Pieces"
 msgstr "Tram - Viale (GroundLightRail / Viale) - Pezzi di rete doppi"
 
@@ -1337,7 +1337,7 @@ msgstr ""
 "\n"
 "Questi pezzi del puzzle sono progettati in modo da poter essere inseriti per primi o da poter essere inseriti nelle reti esistenti."
 
-msgctxt "2026960B-123006BB-6A47B900"
+msgctxt "2026960B-123007BB-6A47B900"
 msgid "High Elevated Rail Puzzle Pieces"
 msgstr "Pezzi di puzzle per binari alti"
 
@@ -1348,7 +1348,7 @@ msgid ""
 "Button contains Tram-in-Road Puzzle Pieces"
 msgstr "Per l'utilizzo del Tram su strada\\"
 
-msgctxt "2026960B-123006BB-6A47BA00"
+msgctxt "2026960B-123007BB-6A47BA00"
 msgid "Tram-in-Road"
 msgstr "Tram in strada"
 
@@ -1356,7 +1356,7 @@ msgctxt "2026960B-123006AA-6A47BBA0"
 msgid "For utilizing the Tram Puzzle Pieces"
 msgstr "Per utilizzare i pezzi del puzzle del tram"
 
-msgctxt "2026960B-123006BB-6A47BBA0"
+msgctxt "2026960B-123007BB-6A47BBA0"
 msgid "Tram-on-Road & texture variations"
 msgstr "Tram su strada e variazioni di texture"
 
@@ -1364,7 +1364,7 @@ msgctxt "2026960B-123006AA-6A47BC60"
 msgid "For utilizing the Tram Puzzle Pieces"
 msgstr "Per utilizzare i pezzi del puzzle del tram"
 
-msgctxt "2026960B-123006BB-6A47BC60"
+msgctxt "2026960B-123007BB-6A47BC60"
 msgid "Tram-on-Street"
 msgstr "Tram su strada"
 
@@ -1378,7 +1378,7 @@ msgstr ""
 "\n"
 "Il pulsante contiene gli elementi di partenza per due stili aggiuntivi di binari leggeri terrestri, oltre a pezzi di riempimento."
 
-msgctxt "2026960B-123006BB-6A47BD00"
+msgctxt "2026960B-123007BB-6A47BD00"
 msgid "Draggable Ground Light Rail (Tram)--Additional Styles"
 msgstr "Metropolitana leggera trascinabile (tram) - Stili aggiuntivi"
 
@@ -1389,7 +1389,7 @@ msgid ""
 "Button contains Starter, Filler and Overpass Puzzle Pieces for High Speed Rail (HSR)"
 msgstr "Per l'utilizzo del Progetto ferroviario ad alta velocità (HSRP)\\"
 
-msgctxt "2026960B-123006BB-6A47C000"
+msgctxt "2026960B-123007BB-6A47C000"
 msgid "High Speed Rail (HSR)"
 msgstr "Ferrovia ad alta velocità (HSR)"
 
@@ -1402,11 +1402,11 @@ msgid ""
 "GHSR is a ground level extension of High Speed Rail (HSR)"
 msgstr "Per l'utilizzo del Progetto ferroviario ad alta velocità (HSRP)\\"
 
-msgctxt "2026960B-123006BB-6A47C200"
+msgctxt "2026960B-123007BB-6A47C200"
 msgid "Ground High Speed Rail (GHSR)"
 msgstr "Ferrovia ad alta velocità terrestre (GHSR)"
 
-msgctxt "2026960B-123006BB-6A47C700"
+msgctxt "2026960B-123007BB-6A47C700"
 msgid "Monorail Wide Radius Curve Puzzle Pieces"
 msgstr "Pezzi del puzzle della Monorotaia con curva ad ampio raggio"
 
@@ -1430,7 +1430,7 @@ msgstr ""
 "\n"
 "Questi pezzi del puzzle sono progettati in modo da poter essere collocati per primi o su reti esistenti."
 
-msgctxt "2026960B-123006BB-6A47C900"
+msgctxt "2026960B-123007BB-6A47C900"
 msgid "High Monorail Puzzle Pieces"
 msgstr "Pezzi del puzzle della monorotaia alta"
 
@@ -1438,7 +1438,7 @@ msgctxt "2026960B-123006AA-6A47CA00"
 msgid "For building Hybrid Railway straight track sections.  Hybrid Railway carries both normal Rail traffic and High Speed Rail (Monorail) traffic."
 msgstr "Per la costruzione di sezioni di binario rettilineo per la Ferrovia Ibrida.  La ferrovia ibrida trasporta sia il traffico ferroviario normale che quello ad alta velocità (monorotaia)."
 
-msgctxt "2026960B-123006BB-6A47CA00"
+msgctxt "2026960B-123007BB-6A47CA00"
 msgid "Hybrid Railway (Rail-High Speed Rail) Straight Sections"
 msgstr "Ferrovia Ibrida (Ferrovia ad Alta Velocità) Tratti rettilinei"
 
@@ -1446,7 +1446,7 @@ msgctxt "2026960B-123006AA-6A47CB00"
 msgid "For building Hybrid Railway curves.  Hybrid Railway carries both normal Rail traffic and High Speed Rail (Monorail) traffic."
 msgstr "Per la costruzione di curve Ferroviarie Ibride.  La Ferrovia Ibrida trasporta sia il traffico ferroviario normale che quello ad alta velocità (monorotaia)."
 
-msgctxt "2026960B-123006BB-6A47CB00"
+msgctxt "2026960B-123007BB-6A47CB00"
 msgid "Hybrid Railway (Rail-High Speed Rail) Curves"
 msgstr "Curve per Ferrovie Ibride (Ferrovie ad Alta Velocità)"
 
@@ -1457,7 +1457,7 @@ msgid ""
 "Hybrid Railway carries both normal Rail traffic and High Speed Rail (Monorail) traffic."
 msgstr "Per la costruzione di scambi ferroviari della Ferrovia Ibrida (Ferrovia ad Alta Velocità)"
 
-msgctxt "2026960B-123006BB-6A47CD00"
+msgctxt "2026960B-123007BB-6A47CD00"
 msgid "Hybrid Railway (Rail-High Speed Rail) Switches"
 msgstr "Scambi Ferroviari per Ferrovie Ibride (Ferrovia ad Alta Velocità)"
 
@@ -1471,7 +1471,7 @@ msgstr ""
 "\n"
 "Utilizzare segmenti di ferrovia ibrida a livello del suolo e collegarli all'estremità sopraelevata delle transizioni (o ad altre sezioni già sopraelevate) per elevarle."
 
-msgctxt "2026960B-123006BB-6A47CE00"
+msgctxt "2026960B-123007BB-6A47CE00"
 msgid "Hybrid Railway (Rail-High Speed Rail) Height Transitions"
 msgstr "Ferrovia Ibrida (ferrovia ad alta velocità) Transizioni in altezza"
 
@@ -1479,7 +1479,7 @@ msgctxt "2026960B-123006AA-6A47DC00"
 msgid "Button contains Ground Highway Puzzle Pieces"
 msgstr "Il pulsante contiene i pezzi del puzzle Autostrada Terrestre"
 
-msgctxt "2026960B-123006BB-6A47DC00"
+msgctxt "2026960B-123007BB-6A47DC00"
 msgid "Ground Highway Puzzle Pieces"
 msgstr "Pezzi del puzzle dell'autostrada terrestre"
 
@@ -1490,7 +1490,7 @@ msgid ""
 "Button contains Single-Sided Perpendicular Ramps for Elevated Highway"
 msgstr "Autostrada sopraelevata\\"
 
-msgctxt "2026960B-123006BB-6A47E010"
+msgctxt "2026960B-123007BB-6A47E010"
 msgid ""
 "Single-Sided Perpendicular Ramps\n"
 "\n"
@@ -1504,7 +1504,7 @@ msgid ""
 "Button contains Single-Sided Parallel Ramps for both Ground Highway and Elevated Highway"
 msgstr "Per la costruzione di rampe parallele monofacciali\\"
 
-msgctxt "2026960B-123006BB-6A47E050"
+msgctxt "2026960B-123007BB-6A47E050"
 msgid ""
 "Single-Sided Parallel Ramps\n"
 "\n"
@@ -1515,15 +1515,15 @@ msgctxt "2026960B-123006AA-6A47E100"
 msgid "Button contains Custom Interchanges"
 msgstr "Il pulsante contiene gli interscambi personalizzati"
 
-msgctxt "2026960B-123006BB-6A47E100"
+msgctxt "2026960B-123007BB-6A47E100"
 msgid "Custom Interchanges"
 msgstr "Interscambi personalizzati"
 
-msgctxt "2026960B-123006BB-6A47FFFF"
+msgctxt "2026960B-123007BB-6A47FFFF"
 msgid "Network Addon Mod Controller"
 msgstr "Controller della Rete Aggiuntiva Mod"
 
-msgctxt "2026960B-123006BB-6A476200"
+msgctxt "2026960B-123007BB-6A476200"
 msgid "Draggable Pedmalls"
 msgstr "Zona Pedonale Trascinabile"
 

--- a/ltext/ja/buttons.po
+++ b/ltext/ja/buttons.po
@@ -31,7 +31,7 @@ msgid ""
 "Button contains Parallel Ramps for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-52001000"
+msgctxt "2026960B-123007BB-52001000"
 msgid ""
 "Parallel Ramps\n"
 "\n"
@@ -45,7 +45,7 @@ msgid ""
 "Button contains Overpass/Perpendicular Ramps for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-52001010"
+msgctxt "2026960B-123007BB-52001010"
 msgid ""
 "Overpass/Perpendicular Ramps\n"
 "\n"
@@ -59,7 +59,7 @@ msgid ""
 "Button contains Cloverleaves for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-52001020"
+msgctxt "2026960B-123007BB-52001020"
 msgid ""
 "Cloverleaf\n"
 "\n"
@@ -73,7 +73,7 @@ msgid ""
 "Button contains T-Intersections for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-52002000"
+msgctxt "2026960B-123007BB-52002000"
 msgid ""
 "T-Intersections\n"
 "\n"
@@ -84,7 +84,7 @@ msgctxt "2026960B-123006AA-6A470100"
 msgid "With the Canal Addon Mod you can build functional canals"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A470100"
+msgctxt "2026960B-123007BB-6A470100"
 msgid "Canal Addon Mod"
 msgstr ""
 
@@ -96,7 +96,7 @@ msgid ""
 "Drag the listed network through the FLEX/Starter Piece to construct the turn lane."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A470460"
+msgctxt "2026960B-123007BB-6A470460"
 msgid "FLEX Turn Lanes (FTLs)"
 msgstr ""
 
@@ -107,7 +107,7 @@ msgid ""
 "Button contains QuickTurn setups, which are FLEX intersections with turn lanes"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A4704A0"
+msgctxt "2026960B-123007BB-6A4704A0"
 msgid "QuickTurn (Pre-Built FLEX Turn Lane Setups)"
 msgstr ""
 
@@ -118,7 +118,7 @@ msgid ""
 "Button contains Turn Lane and Slip Lane Puzzle Pieces for various networks and configurations"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A4704E0"
+msgctxt "2026960B-123007BB-6A4704E0"
 msgid "TuLEPs (Turn Lane Extension Pieces) (OLD)"
 msgstr ""
 
@@ -129,7 +129,7 @@ msgid ""
 "Button contains Turn Lane puzzle pieces for 7-lane Turning Lane Avenue (TLA-7) and 6-lane Avenue (AVE-6) networks"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A470600"
+msgctxt "2026960B-123007BB-6A470600"
 msgid "Network Widening Mod (NWM) Triple-Tile Network Turn Lane Extension Pieces (TuLEPs)"
 msgstr ""
 
@@ -140,7 +140,7 @@ msgid ""
 "Button contains components for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A473141"
+msgctxt "2026960B-123007BB-6A473141"
 msgid ""
 "Symphony Prefab Interchange Components\n"
 "\n"
@@ -154,7 +154,7 @@ msgid ""
 "Button contains components for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A473143"
+msgctxt "2026960B-123007BB-6A473143"
 msgid ""
 "Symphony Ramp Interfaces\n"
 "\n"
@@ -168,7 +168,7 @@ msgid ""
 "The first item is the starter piece."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A474000"
+msgctxt "2026960B-123007BB-6A474000"
 msgid "Single-Track Rail (STR)"
 msgstr ""
 
@@ -180,7 +180,7 @@ msgid ""
 "Drag the RealHighway (RHW-2) network tool through the Starter Piece to construct the desired override network."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475000"
+msgctxt "2026960B-123007BB-6A475000"
 msgid "RealHighway (RHW) Starter Pieces"
 msgstr ""
 
@@ -195,7 +195,7 @@ msgid ""
 "Place down Eraser onto desired tile and redraw anything if needed"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475024"
+msgctxt "2026960B-123007BB-6A475024"
 msgid "Network Eraser"
 msgstr ""
 
@@ -206,7 +206,7 @@ msgid ""
 "Button contains Filler Pieces to build RHW networks in smaller chunks, in unstable situations"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475050"
+msgctxt "2026960B-123007BB-6A475050"
 msgid "RealHighway Filler Pieces"
 msgstr ""
 
@@ -219,7 +219,7 @@ msgid ""
 "These items are DEPRECATED, and the use of the FLEX Neighbor Connections is recommended instead."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47508C"
+msgctxt "2026960B-123007BB-6A47508C"
 msgid "Old RealHighway Neighbor Connector Puzzle Pieces  - DEPRECATED"
 msgstr ""
 
@@ -232,7 +232,7 @@ msgid ""
 "NOTE: ALL REALHIGHWAY NEIGHBOR CONNECTIONS (EXCEPT RHW-2) ARE REQUIRED TO USE NEIGHBOR CONNECTOR PIECES TO ENSURE PROPERLY FUNCTIONING NEIGHBOR CONNECTIONS--OTHERWISE ONLY FREIGHT TRUCKS WILL USE THE RHW"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475090"
+msgctxt "2026960B-123007BB-6A475090"
 msgid "RealHighway FLEX Neighbor Connector Pieces (FLEX-NC)"
 msgstr ""
 
@@ -240,7 +240,7 @@ msgctxt "2026960B-123006AA-6A475100"
 msgid "For building DEPRECATED RealHighway Ramp Interfaces.  All of the functionality of the 47 pieces contained and many more are covered by the FLEXRamp system."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475100"
+msgctxt "2026960B-123007BB-6A475100"
 msgid "OBSOLETE RealHighway Ramp Interfaces (Static Puzzle-Based)"
 msgstr ""
 
@@ -251,7 +251,7 @@ msgid ""
 "Button contains Type B Ramp Interface Pieces for building interchanges with the RHW"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475104"
+msgctxt "2026960B-123007BB-6A475104"
 msgid "RealHighway Type B Ramp Interfaces"
 msgstr ""
 
@@ -262,7 +262,7 @@ msgid ""
 "Button contains Type E Ramp Interface Pieces for building interchanges with the RHW"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475109"
+msgctxt "2026960B-123007BB-6A475109"
 msgid "RealHighway Type E Ramp Interfaces"
 msgstr ""
 
@@ -273,7 +273,7 @@ msgid ""
 "Button contains Type D Ramp Interface Pieces for building interchanges with the RHW"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47510A"
+msgctxt "2026960B-123007BB-6A47510A"
 msgid "RealHighway Type D Ramp Interfaces"
 msgstr ""
 
@@ -284,7 +284,7 @@ msgid ""
 "Deprecated puzzle piece ramps follow Volleyball pieces - use of the FLEXRamps or Draggable Ramp Interfaces (DRIs) is recommended instead of using the deprecated puzzle pieces."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475118"
+msgctxt "2026960B-123007BB-6A475118"
 msgid "Specialized and Deprecated RealHighway Ramp Interfaces and Volleyball Crossings (Static Puzzle-Based)"
 msgstr ""
 
@@ -295,7 +295,7 @@ msgid ""
 "Button contains FLEX pieces for different overrideable ramp interfaces.  Drag appropriate networks through to convert base ramp to match."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A4751F0"
+msgctxt "2026960B-123007BB-6A4751F0"
 msgid "RealHighway FLEXRamps"
 msgstr ""
 
@@ -306,7 +306,7 @@ msgid ""
 "Button contains pieces to build Wide Curves for the RHW networks"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475220"
+msgctxt "2026960B-123007BB-6A475220"
 msgid "RealHighway Wide-Radius and Multi-Radius (Smooth) Curves"
 msgstr ""
 
@@ -319,7 +319,7 @@ msgid ""
 "These items are DEPRECATED and use of the FLEX Width Transitions (FLEX-WT) is recommended instead."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475300"
+msgctxt "2026960B-123007BB-6A475300"
 msgid "Old RealHighway Width Transition Puzzle Pieces - DEPRECATED"
 msgstr ""
 
@@ -332,7 +332,7 @@ msgid ""
 "All functionality here has been duplicated with the FLEX Height Transitions, and as such, this button is DEPRECATED."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475312"
+msgctxt "2026960B-123007BB-6A475312"
 msgid "Old RealHighway Height Transition Puzzle Pieces  - DEPRECATED"
 msgstr ""
 
@@ -343,7 +343,7 @@ msgid ""
 "Button contains pieces to transition between RHW networks of different heights.  Pieces begin as RHW-2 transitions, and dragging another RHW network into them will convert them to fit."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475330"
+msgctxt "2026960B-123007BB-6A475330"
 msgid "RealHighway FLEX Height Transitions (FLEX-HT)"
 msgstr ""
 
@@ -354,7 +354,7 @@ msgid ""
 "Button contains pieces to transition between RHW networks of different widths.  Dragging another RHW network into them will convert them to fit."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475336"
+msgctxt "2026960B-123007BB-6A475336"
 msgid "RealHighway FLEX Width Transitions (FLEX-WT)"
 msgstr ""
 
@@ -365,7 +365,7 @@ msgid ""
 "Button contains components for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475350"
+msgctxt "2026960B-123007BB-6A475350"
 msgid ""
 "Symphony Transitions\n"
 "\n"
@@ -379,7 +379,7 @@ msgid ""
 "Button contains components for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475366"
+msgctxt "2026960B-123007BB-6A475366"
 msgid ""
 "Symphony Smooth Curves\n"
 "\n"
@@ -395,7 +395,7 @@ msgid ""
 "NOTE: These pieces should NOT be confused with TuLEPs."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475400"
+msgctxt "2026960B-123007BB-6A475400"
 msgid "RealHighway Cosmetic Puzzle Pieces (for 1-Tile Networks)"
 msgstr ""
 
@@ -408,7 +408,7 @@ msgid ""
 "NOTE: These pieces should NOT be confused with TuLEPs."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475410"
+msgctxt "2026960B-123007BB-6A475410"
 msgid "RealHighway Cosmetic Piece Transitions"
 msgstr ""
 
@@ -421,7 +421,7 @@ msgid ""
 "NOTE: These pieces should NOT be confused with TuLEPs."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475440"
+msgctxt "2026960B-123007BB-6A475440"
 msgid "RealHighway Cosmetic Puzzle Pieces (for 2-Tile Networks)"
 msgstr ""
 
@@ -434,7 +434,7 @@ msgid ""
 "NOTE: These pieces should NOT be confused with TuLEPs."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475471"
+msgctxt "2026960B-123007BB-6A475471"
 msgid "RealHighway Cosmetic Puzzle Pieces (for 3-Tile Networks)"
 msgstr ""
 
@@ -447,7 +447,7 @@ msgid ""
 "<DEPRECATED>"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475500"
+msgctxt "2026960B-123007BB-6A475500"
 msgid "ERHW-over-RHW Diagonal Overpass Puzzle Pieces<DEPRECATED>"
 msgstr ""
 
@@ -460,7 +460,7 @@ msgid ""
 "Place overcrossing pieces on top of underground roadways whenever a surface network crosses over, to allow traffic to pass underground."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475600"
+msgctxt "2026960B-123007BB-6A475600"
 msgid "RHW Flexible Underpasses (FLUPs), Draggable Underground Roads (URoads), and Overcrossings"
 msgstr ""
 
@@ -471,7 +471,7 @@ msgid ""
 "Button contains flexible RHW interchange segments.  Drag appropriate networks through to convert base ramp to match, and combine to easily create a full interchange."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475700"
+msgctxt "2026960B-123007BB-6A475700"
 msgid "RealHighway QuickChanges"
 msgstr ""
 
@@ -482,7 +482,7 @@ msgid ""
 "Button contains starter/transition FLEX pieces for different RHW turn lane setups"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475900"
+msgctxt "2026960B-123007BB-6A475900"
 msgid "RealHighway FLEX Turn Lanes (FTLs)"
 msgstr ""
 
@@ -493,7 +493,7 @@ msgid ""
 "Button contains pieces to build FLEXFly Pieces"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475AF3"
+msgctxt "2026960B-123007BB-6A475AF3"
 msgid "RealHighway FLEXFly (LEGACY/DEPRECATED)"
 msgstr ""
 
@@ -504,7 +504,7 @@ msgid ""
 "Button contains pieces to build 3-Level Crossings"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475AF6"
+msgctxt "2026960B-123007BB-6A475AF6"
 msgid "RealHighway 3-Level Crossings"
 msgstr ""
 
@@ -515,7 +515,7 @@ msgid ""
 "Button contains pieces to build FLEXFly Pieces"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475B00"
+msgctxt "2026960B-123007BB-6A475B00"
 msgid "RealHighway FLEXFly"
 msgstr ""
 
@@ -528,7 +528,7 @@ msgid ""
 "NOTE: Most intersections require the use of TuLEPs."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475F00"
+msgctxt "2026960B-123007BB-6A475F00"
 msgid "Fractionally Angled RealHighway Intersections and Transitions"
 msgstr ""
 
@@ -539,7 +539,7 @@ msgid ""
 "Button contains straight pieces and curves to pieces to build Fractionally Angled RealHighway (FARHWs)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475F20"
+msgctxt "2026960B-123007BB-6A475F20"
 msgid "Fractionally Angled RealHighway"
 msgstr ""
 
@@ -550,7 +550,7 @@ msgid ""
 "Button contains pieces to build different FARHW Ramp Interfaces: The C1, F1, C2, F2, and C3 Ramp Interfaces"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475F30"
+msgctxt "2026960B-123007BB-6A475F30"
 msgid "Fractionally Angled RealHighway Ramp Interfaces"
 msgstr ""
 
@@ -561,7 +561,7 @@ msgid ""
 "Button contains Type C Ramp Interface Pieces for building interchanges with the RHW"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475F70"
+msgctxt "2026960B-123007BB-6A475F70"
 msgid "RealHighway Type C Ramp Interfaces"
 msgstr ""
 
@@ -572,7 +572,7 @@ msgid ""
 "Button contains Type F Ramp Interface Pieces for building interchanges with the RHW"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475F71"
+msgctxt "2026960B-123007BB-6A475F71"
 msgid "RealHighway Type F Ramp Interfaces"
 msgstr ""
 
@@ -585,7 +585,7 @@ msgid ""
 "NOTE: Ped Mall Tiles should not be used directly in front of Residential Zones where their zoning arrow is."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A476005"
+msgctxt "2026960B-123007BB-6A476005"
 msgid "Pedestrian Mall Tiles"
 msgstr ""
 
@@ -593,7 +593,7 @@ msgctxt "2026960B-123006AA-6A476100"
 msgid "A collection of pedestrian crossing FLEX pieces. Use them on their own at crossing locations, or as part of pedmall corridors."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A476100"
+msgctxt "2026960B-123007BB-6A476100"
 msgid "Pedestrian Revolution Mod (PRM) FLEX Crossings"
 msgstr ""
 
@@ -604,7 +604,7 @@ msgid ""
 "Button contains several different Puzzle and Helper Pieces for Street"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A476525"
+msgctxt "2026960B-123007BB-6A476525"
 msgid "Diagonal Street Helper Pieces"
 msgstr ""
 
@@ -615,7 +615,7 @@ msgid ""
 "Button contains Starter Pieces for Street Addon Mod (SAM)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A476700"
+msgctxt "2026960B-123007BB-6A476700"
 msgid "Street Addon Mod (SAM)"
 msgstr ""
 
@@ -623,7 +623,7 @@ msgctxt "2026960B-123006AA-6A476905"
 msgid "Plop one of these pieces on a flat area. It will raise or lower the terrain, and then destroy itself, providing a level area for a raised network of your choice. This is fully compatible with all slope mods."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A476905"
+msgctxt "2026960B-123007BB-6A476905"
 msgid "Hole Digger and Raiser Lots"
 msgstr ""
 
@@ -634,7 +634,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Avenues"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A476A00"
+msgctxt "2026960B-123007BB-6A476A00"
 msgid "Avenue Intersections"
 msgstr ""
 
@@ -645,7 +645,7 @@ msgid ""
 "Button contains several different overpasses for Road"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477000"
+msgctxt "2026960B-123007BB-6A477000"
 msgid "Road Overpasses"
 msgstr ""
 
@@ -656,7 +656,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Road"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477005"
+msgctxt "2026960B-123007BB-6A477005"
 msgid "7.5m Elevated Road Viaducts"
 msgstr ""
 
@@ -667,7 +667,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Road"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477200"
+msgctxt "2026960B-123007BB-6A477200"
 msgid "15m Elevated Road Viaducts"
 msgstr ""
 
@@ -678,7 +678,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Road, One-Way Road, or Avenue"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477500"
+msgctxt "2026960B-123007BB-6A477500"
 msgid "Wide Radius Curves (for Road, One-Way Road, Avenue, and Street) (Puzzle Pieces)"
 msgstr ""
 
@@ -689,7 +689,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Road, One-Way Road, and Avenue"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477600"
+msgctxt "2026960B-123007BB-6A477600"
 msgid "Fractionally-Angled Networks (for Road, One-Way Road, and Avenue)"
 msgstr ""
 
@@ -700,7 +700,7 @@ msgid ""
 "Once a puzzle piece is selected, use the [Home] and [End] keys to cycle through the various puzzle piece orientations"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477700"
+msgctxt "2026960B-123007BB-6A477700"
 msgid "Rural Road Puzzle Pieces"
 msgstr ""
 
@@ -711,7 +711,7 @@ msgid ""
 "Button contains pieces to interface between the NAM Elevated Road Puzzle Pieces and RHW networks, including overpasses and intersections"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477800"
+msgctxt "2026960B-123007BB-6A477800"
 msgid "Road/RHW Overpass and Interface Puzzle Pieces (DEPRECATED)"
 msgstr ""
 
@@ -722,7 +722,7 @@ msgid ""
 "Button contains several different FLEX Pieces for various networks"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477900"
+msgctxt "2026960B-123007BB-6A477900"
 msgid "Multi-Radius Curve (MRC) FLEX Pieces for Surface Networks"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgid ""
 "The new Subway-based FLUPs system can be found under the Highways menu."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477A00"
+msgctxt "2026960B-123007BB-6A477A00"
 msgid "Flexible Underpasses (FLUPs)"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgid ""
 "Button contains Starter Pieces for the 3, 5 and 7-lane Turning Lane Avenues (TLA-3,5,7), 2 and 6-lane Avenues (AVE-2,6), 3-lane Asymmetrical Road (ARD-3), 4 and 6-lane Roads RD-4,6) and 1, 3, 4 and 5-lane One-Way Roads (OWR-1,3,4,5)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477B00"
+msgctxt "2026960B-123007BB-6A477B00"
 msgid "Network Widening Mod (NWM) Starter Pieces"
 msgstr ""
 
@@ -761,7 +761,7 @@ msgid ""
 "Button contains Wide-Radius Curve Pieces for the single-tile NWM networks"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477B30"
+msgctxt "2026960B-123007BB-6A477B30"
 msgid "Network Widening Mod (NWM) Curve Pieces"
 msgstr ""
 
@@ -774,7 +774,7 @@ msgid ""
 "Note that most transitions involving single and dual-tile networks can be built using draggable means instead (such as direct connections or using the stub-to-stub method)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477B50"
+msgctxt "2026960B-123007BB-6A477B50"
 msgid "Network Widening Mod (NWM) Transition Pieces"
 msgstr ""
 
@@ -785,7 +785,7 @@ msgid ""
 "Button contains Neighbor Connector Pieces for the TLA-5, RD-4 and RD-6"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477BF0"
+msgctxt "2026960B-123007BB-6A477BF0"
 msgid "Network Widening Mod (NWM) Neighbor Connector Pieces"
 msgstr ""
 
@@ -796,7 +796,7 @@ msgid ""
 "Button contains FLEX Single Tile Roundabouts intersections for various road networks"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477C00"
+msgctxt "2026960B-123007BB-6A477C00"
 msgid "Single Tile Roundabouts"
 msgstr ""
 
@@ -809,7 +809,7 @@ msgid ""
 "Button contains OnSlope Transitions to start Alternate Style Road and Street Viaducts"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477E00"
+msgctxt "2026960B-123007BB-6A477E00"
 msgid "Road Viaduct Alternate Styles"
 msgstr ""
 
@@ -820,7 +820,7 @@ msgid ""
 "Button contains several different Starter and FLEX Pieces for Draggable Elevated Road Viaducts"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477F00"
+msgctxt "2026960B-123007BB-6A477F00"
 msgid "Draggable Elevated Road Viaducts"
 msgstr ""
 
@@ -833,7 +833,7 @@ msgid ""
 "Drag networks under (or over) the mid-section of the overpass to build the crossing.  Most networks and FLEX-based dual-networks are supported."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477F30"
+msgctxt "2026960B-123007BB-6A477F30"
 msgid "FLEX Overpasses"
 msgstr ""
 
@@ -844,7 +844,7 @@ msgid ""
 "Button contains several different overpasses for One-Way Road"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A478000"
+msgctxt "2026960B-123007BB-6A478000"
 msgid "One-Way Road Overpasses"
 msgstr ""
 
@@ -855,7 +855,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for One-Way Road"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A478005"
+msgctxt "2026960B-123007BB-6A478005"
 msgid "15m Elevated One-Way Road Viaducts"
 msgstr ""
 
@@ -866,7 +866,7 @@ msgid ""
 "Button contains pieces to interface between the NAM Elevated One-Way Road Puzzle Pieces and RHW networks, including overpasses and intersections"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A478800"
+msgctxt "2026960B-123007BB-6A478800"
 msgid "One-Way Road/RHW Overpass and Interface Puzzle Pieces (DEPRECATED)"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgctxt "2026960B-123006AA-6A478900"
 msgid "For use of the curved pieces for the Real Expressway Network. Use the Home/End key to rotate the FLEX Piece & use TAB/Shift-TAB (Ctrl-TAB/Ctrl-Shift-TAB on macOS) to cycle through the different types of REW Straights and Curves."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A478900"
+msgctxt "2026960B-123007BB-6A478900"
 msgid "Real Expressway FLEX Piece network tool and Curves."
 msgstr ""
 
@@ -885,7 +885,7 @@ msgid ""
 "Button contains FLEX pieces for different overrideable ramp interfaces.  Drag appropriate networks through to convert base ramp to match."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A478B00"
+msgctxt "2026960B-123007BB-6A478B00"
 msgid "RealExpressway (REW) One-Way Road FLEXRamps"
 msgstr ""
 
@@ -896,7 +896,7 @@ msgid ""
 "Button contains several different overpasses for Avenue"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A479000"
+msgctxt "2026960B-123007BB-6A479000"
 msgid "Avenue Overpasses"
 msgstr ""
 
@@ -907,7 +907,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Avenue"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A479005"
+msgctxt "2026960B-123007BB-6A479005"
 msgid "7.5m Elevated Avenue Viaducts"
 msgstr ""
 
@@ -918,7 +918,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Avenue"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A479200"
+msgctxt "2026960B-123007BB-6A479200"
 msgid "15m Elevated Avenue Viaducts"
 msgstr ""
 
@@ -929,7 +929,7 @@ msgid ""
 "Button contains pieces to interface between the NAM Elevated Avenue Puzzle Pieces and RHW networks, including overpasses and intersections"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A479900"
+msgctxt "2026960B-123007BB-6A479900"
 msgid "Avenue/RHW Overpass and Interface Puzzle Pieces (DEPRECATED)"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgid ""
 "FlexSPUI and Flex Diverging Diamond (FlexDDI) pieces are found under this button"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47991A"
+msgctxt "2026960B-123007BB-6A47991A"
 msgid "Specialized RHW x Surface Intersections"
 msgstr ""
 
@@ -953,7 +953,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Rail."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47A005"
+msgctxt "2026960B-123007BB-6A47A005"
 msgid "Rail Puzzle Pieces"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgctxt "2026960B-123006AA-6A47A130"
 msgid "Button contains FLEX pieces to elevated the Rail network to viaduct level (using the RealRailway (RRW) standard)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47A130"
+msgctxt "2026960B-123007BB-6A47A130"
 msgid "Draggable Elevated Railways (ERRW)"
 msgstr ""
 
@@ -972,7 +972,7 @@ msgid ""
 "Once a puzzle piece is selected, use the [Home] and [End] keys to cycle through the various puzzle piece orientations"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47A358"
+msgctxt "2026960B-123007BB-6A47A358"
 msgid "Wide Radius Railroad Curve and Double Track Rail Switch Puzzle Pieces"
 msgstr ""
 
@@ -983,7 +983,7 @@ msgid ""
 "Once a puzzle piece is selected, use the [Home] and [End] keys to cycle through the various puzzle piece orientations"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47A368"
+msgctxt "2026960B-123007BB-6A47A368"
 msgid "Fractional Angle Railroad (FARR) Puzzle Pieces"
 msgstr ""
 
@@ -994,7 +994,7 @@ msgid ""
 "Button contains pieces to interface between the NAM Elevated Rail Viaduct Puzzle Pieces and RHW networks, including overpasses and intersections"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47A800"
+msgctxt "2026960B-123007BB-6A47A800"
 msgid "Rail Viaduct/RHW Overpass and Interface Puzzle Pieces"
 msgstr ""
 
@@ -1005,7 +1005,7 @@ msgid ""
 "Once a puzzle piece is selected, use the [Home] and [End] keys to cycle through the various puzzle piece orientations"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47A900"
+msgctxt "2026960B-123007BB-6A47A900"
 msgid "Wide Radius Railroad Curve and Double Track Rail Switch Puzzle Pieces"
 msgstr ""
 
@@ -1016,7 +1016,7 @@ msgid ""
 "Button contains several different Pieces for Dual/Double-Decker Networking."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AA0F"
+msgctxt "2026960B-123007BB-6A47AA0F"
 msgid ""
 "Underground Rail\n"
 "Rail Tunnel under Roads Dual Networking Puzzle Pieces"
@@ -1029,7 +1029,7 @@ msgid ""
 "Button contains several different Pieces for Dual/Double-Decker Networking."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AA10"
+msgctxt "2026960B-123007BB-6A47AA10"
 msgid ""
 "Underground Rail\n"
 "Rail Tunnel under Ped Malls Dual Networking Puzzle Pieces"
@@ -1042,7 +1042,7 @@ msgid ""
 "Button contains several different Pieces for Maxis Roadways."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AA11"
+msgctxt "2026960B-123007BB-6A47AA11"
 msgid ""
 "Underground Rail\n"
 "Maxis Roadway Intersection Pieces"
@@ -1055,7 +1055,7 @@ msgid ""
 "Button contains several different Pieces for Railways."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AA12"
+msgctxt "2026960B-123007BB-6A47AA12"
 msgid ""
 "Underground Rail\n"
 "Railway Intersection Pieces"
@@ -1068,7 +1068,7 @@ msgid ""
 "Button contains several different Pieces for Tramways."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AA13"
+msgctxt "2026960B-123007BB-6A47AA13"
 msgid ""
 "Underground Rail\n"
 "Tramway Intersection Pieces"
@@ -1081,7 +1081,7 @@ msgid ""
 "Button contains several different Pieces for Dual/Double-Decker Networking."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AA8A"
+msgctxt "2026960B-123007BB-6A47AA8A"
 msgid ""
 "Underground Rail\n"
 "Miscellaneous Puzzle Pieces"
@@ -1091,7 +1091,7 @@ msgctxt "2026960B-123006AA-6A47AC00"
 msgid "All pieces in this section are FLEX and conform to flextrack standards!"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AC00"
+msgctxt "2026960B-123007BB-6A47AC00"
 msgid "RealRailway FLEX Curve Pieces."
 msgstr ""
 
@@ -1099,7 +1099,7 @@ msgctxt "2026960B-123006AA-6A47AC10"
 msgid "All pieces in this section are FLEX and conform to flextrack standards!"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AC10"
+msgctxt "2026960B-123007BB-6A47AC10"
 msgid "RealRailway FLEX Turnout Pieces."
 msgstr ""
 
@@ -1107,7 +1107,7 @@ msgctxt "2026960B-123006AA-6A47AD00"
 msgid "All pieces in this section are FLEX and conform to flextrack and FARR standards!\n"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AD00"
+msgctxt "2026960B-123007BB-6A47AD00"
 msgid "RealRailway FLEX Fractional Angled (FA) Pieces."
 msgstr ""
 
@@ -1118,7 +1118,7 @@ msgid ""
 "Button contains several different Pieces for Dual/Double-Decker Networking."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47B03A"
+msgctxt "2026960B-123007BB-6A47B03A"
 msgid "ElevatedRail Dual/Double-Decker Network Pieces"
 msgstr ""
 
@@ -1126,7 +1126,7 @@ msgctxt "2026960B-123006AA-6A47B049"
 msgid "These puzzle pieces are to allow you to cross NWM networks with ElRail over Road."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47B049"
+msgctxt "2026960B-123007BB-6A47B049"
 msgid "ElRail over Road NWM Intersections"
 msgstr ""
 
@@ -1137,7 +1137,7 @@ msgid ""
 "The construction lot vanishes automatically. Use the Road Tool to connect the network and to build intersections."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47B060"
+msgctxt "2026960B-123007BB-6A47B060"
 msgid "ElevatedRail over Avenue/Road-4 Puzzle Pieces"
 msgstr ""
 
@@ -1145,7 +1145,7 @@ msgctxt "2026960B-123006AA-6A47B10F"
 msgid "Puzzle Pieces to build a ground level extension of the Elevated Rail network for Light Rail/Trams."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47B10F"
+msgctxt "2026960B-123007BB-6A47B10F"
 msgid "Ground Light Rail (Tram)"
 msgstr ""
 
@@ -1156,7 +1156,7 @@ msgid ""
 "Connect the Elevated Rail network with the Starter Piece. The Elevated Rail will turn into a Ground Light Rail track."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47B3FF"
+msgctxt "2026960B-123007BB-6A47B3FF"
 msgid "Draggable Ground Light Rail (Tram)"
 msgstr ""
 
@@ -1164,7 +1164,7 @@ msgctxt "2026960B-123006AA-6A47B42A"
 msgid "For building Tram-Avenue (= GroundLightRail / Avenue) - Dual Network Pieces."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47B42A"
+msgctxt "2026960B-123007BB-6A47B42A"
 msgid "Tram-Avenue (GroundLightRail / Avenue) - Dual Network Pieces"
 msgstr ""
 
@@ -1175,7 +1175,7 @@ msgid ""
 "These puzzle pieces are designed so that you may plop them first or you may plop them on existing networks."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47B900"
+msgctxt "2026960B-123007BB-6A47B900"
 msgid "High Elevated Rail Puzzle Pieces"
 msgstr ""
 
@@ -1186,7 +1186,7 @@ msgid ""
 "Button contains Tram-in-Road Puzzle Pieces"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47BA00"
+msgctxt "2026960B-123007BB-6A47BA00"
 msgid "Tram-in-Road"
 msgstr ""
 
@@ -1194,7 +1194,7 @@ msgctxt "2026960B-123006AA-6A47BBA0"
 msgid "For utilizing the Tram Puzzle Pieces"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47BBA0"
+msgctxt "2026960B-123007BB-6A47BBA0"
 msgid "Tram-on-Road & texture variations"
 msgstr ""
 
@@ -1202,7 +1202,7 @@ msgctxt "2026960B-123006AA-6A47BC60"
 msgid "For utilizing the Tram Puzzle Pieces"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47BC60"
+msgctxt "2026960B-123007BB-6A47BC60"
 msgid "Tram-on-Street"
 msgstr ""
 
@@ -1213,7 +1213,7 @@ msgid ""
 "Button contains starters for two additional Ground Light Rail styles, plus filler pieces."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47BD00"
+msgctxt "2026960B-123007BB-6A47BD00"
 msgid "Draggable Ground Light Rail (Tram)--Additional Styles"
 msgstr ""
 
@@ -1224,7 +1224,7 @@ msgid ""
 "Button contains Starter, Filler and Overpass Puzzle Pieces for High Speed Rail (HSR)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47C000"
+msgctxt "2026960B-123007BB-6A47C000"
 msgid "High Speed Rail (HSR)"
 msgstr ""
 
@@ -1237,11 +1237,11 @@ msgid ""
 "GHSR is a ground level extension of High Speed Rail (HSR)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47C200"
+msgctxt "2026960B-123007BB-6A47C200"
 msgid "Ground High Speed Rail (GHSR)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47C700"
+msgctxt "2026960B-123007BB-6A47C700"
 msgid "Monorail Wide Radius Curve Puzzle Pieces"
 msgstr "モノレール広角カーブのパズルピース"
 
@@ -1259,7 +1259,7 @@ msgid ""
 "These puzzle pieces are designed so that you may plop them first or you may plop them on existing networks."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47C900"
+msgctxt "2026960B-123007BB-6A47C900"
 msgid "High Monorail Puzzle Pieces"
 msgstr ""
 
@@ -1267,7 +1267,7 @@ msgctxt "2026960B-123006AA-6A47CA00"
 msgid "For building Hybrid Railway straight track sections.  Hybrid Railway carries both normal Rail traffic and High Speed Rail (Monorail) traffic."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47CA00"
+msgctxt "2026960B-123007BB-6A47CA00"
 msgid "Hybrid Railway (Rail-High Speed Rail) Straight Sections"
 msgstr ""
 
@@ -1275,7 +1275,7 @@ msgctxt "2026960B-123006AA-6A47CB00"
 msgid "For building Hybrid Railway curves.  Hybrid Railway carries both normal Rail traffic and High Speed Rail (Monorail) traffic."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47CB00"
+msgctxt "2026960B-123007BB-6A47CB00"
 msgid "Hybrid Railway (Rail-High Speed Rail) Curves"
 msgstr ""
 
@@ -1286,7 +1286,7 @@ msgid ""
 "Hybrid Railway carries both normal Rail traffic and High Speed Rail (Monorail) traffic."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47CD00"
+msgctxt "2026960B-123007BB-6A47CD00"
 msgid "Hybrid Railway (Rail-High Speed Rail) Switches"
 msgstr ""
 
@@ -1297,7 +1297,7 @@ msgid ""
 "Use ground-level Hybrid Railway segments, and connect to the elevated end of the transitions (or to other already elevated sections) to elevate them."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47CE00"
+msgctxt "2026960B-123007BB-6A47CE00"
 msgid "Hybrid Railway (Rail-High Speed Rail) Height Transitions"
 msgstr ""
 
@@ -1305,7 +1305,7 @@ msgctxt "2026960B-123006AA-6A47DC00"
 msgid "Button contains Ground Highway Puzzle Pieces"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47DC00"
+msgctxt "2026960B-123007BB-6A47DC00"
 msgid "Ground Highway Puzzle Pieces"
 msgstr ""
 
@@ -1316,7 +1316,7 @@ msgid ""
 "Button contains Single-Sided Perpendicular Ramps for Elevated Highway"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47E010"
+msgctxt "2026960B-123007BB-6A47E010"
 msgid ""
 "Single-Sided Perpendicular Ramps\n"
 "\n"
@@ -1330,7 +1330,7 @@ msgid ""
 "Button contains Single-Sided Parallel Ramps for both Ground Highway and Elevated Highway"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47E050"
+msgctxt "2026960B-123007BB-6A47E050"
 msgid ""
 "Single-Sided Parallel Ramps\n"
 "\n"
@@ -1341,15 +1341,15 @@ msgctxt "2026960B-123006AA-6A47E100"
 msgid "Button contains Custom Interchanges"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47E100"
+msgctxt "2026960B-123007BB-6A47E100"
 msgid "Custom Interchanges"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47FFFF"
+msgctxt "2026960B-123007BB-6A47FFFF"
 msgid "Network Addon Mod Controller"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A476200"
+msgctxt "2026960B-123007BB-6A476200"
 msgid "Draggable Pedmalls"
 msgstr ""
 

--- a/ltext/ko/buttons.po
+++ b/ltext/ko/buttons.po
@@ -37,7 +37,7 @@ msgstr ""
 "\n"
 "지상 고속도로용와 고가 고속도로용이 모두 들어있습니다."
 
-msgctxt "2026960B-123006BB-52001000"
+msgctxt "2026960B-123007BB-52001000"
 msgid ""
 "Parallel Ramps\n"
 "\n"
@@ -57,7 +57,7 @@ msgstr ""
 "\n"
 "지상 고속도로용과 고가 고속도로용이 모두 들어있습니다."
 
-msgctxt "2026960B-123006BB-52001010"
+msgctxt "2026960B-123007BB-52001010"
 msgid ""
 "Overpass/Perpendicular Ramps\n"
 "\n"
@@ -77,7 +77,7 @@ msgstr ""
 "\n"
 "지상 고속도로용과 고가 고속도로용이 모두 들어있습니다."
 
-msgctxt "2026960B-123006BB-52001020"
+msgctxt "2026960B-123007BB-52001020"
 msgid ""
 "Cloverleaf\n"
 "\n"
@@ -97,7 +97,7 @@ msgstr ""
 "\n"
 "지상 고속도로용과 고가 고속도로용이 모두 들어있습니다."
 
-msgctxt "2026960B-123006BB-52002000"
+msgctxt "2026960B-123007BB-52002000"
 msgid ""
 "T-Intersections\n"
 "\n"
@@ -111,7 +111,7 @@ msgctxt "2026960B-123006AA-6A470100"
 msgid "With the Canal Addon Mod you can build functional canals"
 msgstr "수로 추가 모드를 이용하여 실제로 작동하는 운하를 만들 수 있습니다."
 
-msgctxt "2026960B-123006BB-6A470100"
+msgctxt "2026960B-123007BB-6A470100"
 msgid "Canal Addon Mod"
 msgstr "수로 추가 모드(CAN-AM)"
 
@@ -127,7 +127,7 @@ msgstr ""
 "여러 도로 네트워크의 유연한FLEX 회전차로 시작 조각과 유연한FLEX 교차로가 들어있습니다.\n"
 "유연한FLEX 시작 조각에 네트워크를 통과하도록 그어서 회전차로을 만들 수 있습니다."
 
-msgctxt "2026960B-123006BB-6A470460"
+msgctxt "2026960B-123007BB-6A470460"
 msgid "FLEX Turn Lanes (FTLs)"
 msgstr "유연한FLEX 회전차로(FTLs)"
 
@@ -141,7 +141,7 @@ msgstr ""
 "\n"
 "회전차로이 있는 유연한FLEX 교차로를 건설하는 빠른회전 구성이 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A4704A0"
+msgctxt "2026960B-123007BB-6A4704A0"
 msgid "QuickTurn (Pre-Built FLEX Turn Lane Setups)"
 msgstr "빠른회전(QuickTurn, 미리 조립된 유연한FLEX 회전차로 구성)"
 
@@ -155,7 +155,7 @@ msgstr ""
 "\n"
 "다양한 네트워크에 대응하는 회전차로 퍼즐 조각이 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A4704E0"
+msgctxt "2026960B-123007BB-6A4704E0"
 msgid "TuLEPs (Turn Lane Extension Pieces) (OLD)"
 msgstr "회전차로 확장 조각(TuLEPs) (구식)"
 
@@ -169,7 +169,7 @@ msgstr ""
 "\n"
 "7차선 회전차로 애비뉴(TLA-7) 및 6차선 애비뉴(AVE-6) 네트워크에 대응하는 회전차로 퍼즐 조각이 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A470600"
+msgctxt "2026960B-123007BB-6A470600"
 msgid "Network Widening Mod (NWM) Triple-Tile Network Turn Lane Extension Pieces (TuLEPs)"
 msgstr "네트워크 넓히기 모드(NWM) 세 칸 네트워크 회전차로 확장 조각(TuLEPs)"
 
@@ -183,7 +183,7 @@ msgstr ""
 "\n"
 "지상 고속도로용과 고가 고속도로용이 모두 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A473141"
+msgctxt "2026960B-123007BB-6A473141"
 msgid ""
 "Symphony Prefab Interchange Components\n"
 "\n"
@@ -203,7 +203,7 @@ msgstr ""
 "\n"
 "지상 고속도로용과 고가 고속도로용이 모두 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A473143"
+msgctxt "2026960B-123007BB-6A473143"
 msgid ""
 "Symphony Ramp Interfaces\n"
 "\n"
@@ -223,7 +223,7 @@ msgstr ""
 "\n"
 "첫 번째 조각은 시작 조각입니다."
 
-msgctxt "2026960B-123006BB-6A474000"
+msgctxt "2026960B-123007BB-6A474000"
 msgid "Single-Track Rail (STR)"
 msgstr "단선 철도(STR)"
 
@@ -239,7 +239,7 @@ msgstr ""
 "너비가 최대 12차선(RHW-12S)이고 높이가 최대 30m(L4)인 다양한 RHW 네트워크를 건설하는 시작 조각이 들어있습니다.\n"
 "시작 조각을 통과하도록 현실고속도로(RHW-2) 네트워크 도구를 그어서 원하는 재정의 네트워크를 건설할 수 있습니다."
 
-msgctxt "2026960B-123006BB-6A475000"
+msgctxt "2026960B-123007BB-6A475000"
 msgid "RealHighway (RHW) Starter Pieces"
 msgstr "현실고속도로(RHW) 시작 조각"
 
@@ -261,7 +261,7 @@ msgstr ""
 "\n"
 "지우개를 원하는 칸에 놓고 원하는 모양으로 다시 그리세요."
 
-msgctxt "2026960B-123006BB-6A475024"
+msgctxt "2026960B-123007BB-6A475024"
 msgid "Network Eraser"
 msgstr "네트워크 지우개"
 
@@ -275,7 +275,7 @@ msgstr ""
 "\n"
 "RHW 네트워크의 조그만 부분을 불안정한 환경에 건설할 때 사용하는 채움 조각이 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A475050"
+msgctxt "2026960B-123007BB-6A475050"
 msgid "RealHighway Filler Pieces"
 msgstr "현실고속도로 채움 조각"
 
@@ -293,7 +293,7 @@ msgstr ""
 "\n"
 "지원이 종료되었기 때문에 유연한FLEX 이웃 연결기를 대신 사용하는 것을 추천합니다."
 
-msgctxt "2026960B-123006BB-6A47508C"
+msgctxt "2026960B-123007BB-6A47508C"
 msgid "Old RealHighway Neighbor Connector Puzzle Pieces  - DEPRECATED"
 msgstr "구식 현실고속도로 이웃 연결기 조각 - 지원종료"
 
@@ -311,7 +311,7 @@ msgstr ""
 "\n"
 "주의: RHW-2를 제외한 모든 현실고속도로 이웃간 연결은 정상적으로 작동하려면 이웃 연결기 조각이 필요합니다. 그렇지 않으면 트럭만 RHW를 이용합니다."
 
-msgctxt "2026960B-123006BB-6A475090"
+msgctxt "2026960B-123007BB-6A475090"
 msgid "RealHighway FLEX Neighbor Connector Pieces (FLEX-NC)"
 msgstr "현실고속도로 유연한FLEX 이웃 연결기 조각(FLEX-NC)"
 
@@ -319,7 +319,7 @@ msgctxt "2026960B-123006AA-6A475100"
 msgid "For building DEPRECATED RealHighway Ramp Interfaces.  All of the functionality of the 47 pieces contained and many more are covered by the FLEXRamp system."
 msgstr "지원이 종료된 현실고속도로 램프 인터페이스를 건설합니다. 유연한FLEX 램프(FLEXRamp)가 여기에 들어있는 47개 조각과 더 많은 램프를 지원합니다."
 
-msgctxt "2026960B-123006BB-6A475100"
+msgctxt "2026960B-123007BB-6A475100"
 msgid "OBSOLETE RealHighway Ramp Interfaces (Static Puzzle-Based)"
 msgstr "구식 현실고속도로 램프 인터페이스 (정적 퍼즐 기반)"
 
@@ -333,7 +333,7 @@ msgstr ""
 "\n"
 "RHW 인터체인지에 사용되는 B형 램프 인터페이스가 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A475104"
+msgctxt "2026960B-123007BB-6A475104"
 msgid "RealHighway Type B Ramp Interfaces"
 msgstr "현실고속도로 B형 램프 인터페이스"
 
@@ -347,7 +347,7 @@ msgstr ""
 "\n"
 "RHW 인터체인지에 사용되는 E형 램프 인터페이스가 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A475109"
+msgctxt "2026960B-123007BB-6A475109"
 msgid "RealHighway Type E Ramp Interfaces"
 msgstr "현실고속도로 E형 램프 인터페이스"
 
@@ -361,7 +361,7 @@ msgstr ""
 "\n"
 "RHW 인터체인지에 사용되는 D형 램프 인터페이스가 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A47510A"
+msgctxt "2026960B-123007BB-6A47510A"
 msgid "RealHighway Type D Ramp Interfaces"
 msgstr "현실고속도로 D형 램프 인터페이스"
 
@@ -375,7 +375,7 @@ msgstr ""
 "\n"
 "배구공 교차로 다음에 있는 램프 퍼즐 조각은 지원이 종료되었습니다. 유연한FLEX 램프(FLEXRamp)나 드래그할 수 있는 램프 인터페이스(DRIs)를 대신 사용하는 것을 추천합니다."
 
-msgctxt "2026960B-123006BB-6A475118"
+msgctxt "2026960B-123007BB-6A475118"
 msgid "Specialized and Deprecated RealHighway Ramp Interfaces and Volleyball Crossings (Static Puzzle-Based)"
 msgstr "특수하거나 지원이 종료된 램프 인터페이스 및 배구공 교차로 (정적 퍼즐 기반)"
 
@@ -389,7 +389,7 @@ msgstr ""
 "\n"
 "다양한 재정의할 수 있는 램프 인터페이스 유연한FLEX 조각이 들어있습니다. 기본 램프를 통과하도록 적합한 네트워크를 그어서 모양을 바꿀 수 있습니다."
 
-msgctxt "2026960B-123006BB-6A4751F0"
+msgctxt "2026960B-123007BB-6A4751F0"
 msgid "RealHighway FLEXRamps"
 msgstr "현실고속도로 유연한FLEX 램프(FLEXRamps)"
 
@@ -403,7 +403,7 @@ msgstr ""
 "\n"
 "RHW 네트워크의 넓은 곡선 조각이 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A475220"
+msgctxt "2026960B-123007BB-6A475220"
 msgid "RealHighway Wide-Radius and Multi-Radius (Smooth) Curves"
 msgstr "현실고속도로 넓은 반지름 및 다중 반지름 곡선"
 
@@ -421,7 +421,7 @@ msgstr ""
 "\n"
 "지원이 종료되었으므로 유연한FLEX 너비 전환(FLEX-WT)을 대신 사용하는 것을 추천합니다."
 
-msgctxt "2026960B-123006BB-6A475300"
+msgctxt "2026960B-123007BB-6A475300"
 msgid "Old RealHighway Width Transition Puzzle Pieces - DEPRECATED"
 msgstr "구식 현실고속도로 너비 전환 퍼즐 조각 - 지원종료"
 
@@ -439,7 +439,7 @@ msgstr ""
 "\n"
 "여기에 있는 모든 기능이 유연한FLEX 높이 전환으로 복제되었으므로 이 버튼은 사용되지 않습니다."
 
-msgctxt "2026960B-123006BB-6A475312"
+msgctxt "2026960B-123007BB-6A475312"
 msgid "Old RealHighway Height Transition Puzzle Pieces  - DEPRECATED"
 msgstr "구식 현실고속도로 높이 전환 퍼즐 조각 - 지원종료"
 
@@ -453,7 +453,7 @@ msgstr ""
 "\n"
 "높ㅇ가 다른 RHW 네트워크 간의 전환 조각이 들어있습니다. RHW 네트워크를 이 조각에 그어서 모양을 바꾸세요."
 
-msgctxt "2026960B-123006BB-6A475330"
+msgctxt "2026960B-123007BB-6A475330"
 msgid "RealHighway FLEX Height Transitions (FLEX-HT)"
 msgstr "현실고속도로 유연한FLEX 높이 전환(FLEX-HT)"
 
@@ -467,7 +467,7 @@ msgstr ""
 "\n"
 "너비가 다른 RHW 네트워크 간의 전환 조각이 들어있습니다. RHW 네트워크를 이 조각에 그어서 모양을 바꾸세요."
 
-msgctxt "2026960B-123006BB-6A475336"
+msgctxt "2026960B-123007BB-6A475336"
 msgid "RealHighway FLEX Width Transitions (FLEX-WT)"
 msgstr "현실고속도로 유연한FLEX 너비 전환(FLEX-WT)"
 
@@ -481,7 +481,7 @@ msgstr ""
 "\n"
 "지상 고속도로용과 고가 고속도로용이 모두 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A475350"
+msgctxt "2026960B-123007BB-6A475350"
 msgid ""
 "Symphony Transitions\n"
 "\n"
@@ -501,7 +501,7 @@ msgstr ""
 "\n"
 "지상 고속도로용과 고가 고속도로용이 모두 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A475366"
+msgctxt "2026960B-123007BB-6A475366"
 msgid ""
 "Symphony Smooth Curves\n"
 "\n"
@@ -525,7 +525,7 @@ msgstr ""
 "\n"
 "주의: TuLEPs과는 다른 조각입니다."
 
-msgctxt "2026960B-123006BB-6A475400"
+msgctxt "2026960B-123007BB-6A475400"
 msgid "RealHighway Cosmetic Puzzle Pieces (for 1-Tile Networks)"
 msgstr "현실고속도로 꾸밈 퍼즐 조각(1칸 네트워크용)"
 
@@ -543,7 +543,7 @@ msgstr ""
 "\n"
 "주의: TuLEPs과는 다른 조각입니다."
 
-msgctxt "2026960B-123006BB-6A475410"
+msgctxt "2026960B-123007BB-6A475410"
 msgid "RealHighway Cosmetic Piece Transitions"
 msgstr "현실고속도로 꾸밈 조각 전환"
 
@@ -561,7 +561,7 @@ msgstr ""
 "\n"
 "주의: TuLEPs과는 다른 조각입니다."
 
-msgctxt "2026960B-123006BB-6A475440"
+msgctxt "2026960B-123007BB-6A475440"
 msgid "RealHighway Cosmetic Puzzle Pieces (for 2-Tile Networks)"
 msgstr "현실고속도로 꾸밈 퍼즐 조각(2칸 네트워크용)"
 
@@ -579,7 +579,7 @@ msgstr ""
 "\n"
 "주의: TuLEPs과는 다른 조각입니다."
 
-msgctxt "2026960B-123006BB-6A475471"
+msgctxt "2026960B-123007BB-6A475471"
 msgid "RealHighway Cosmetic Puzzle Pieces (for 3-Tile Networks)"
 msgstr "현실고속도로 꾸밈 퍼즐 조각(3칸 네트워크용)"
 
@@ -597,7 +597,7 @@ msgstr ""
 "\n"
 "<지원종료>"
 
-msgctxt "2026960B-123006BB-6A475500"
+msgctxt "2026960B-123007BB-6A475500"
 msgid "ERHW-over-RHW Diagonal Overpass Puzzle Pieces<DEPRECATED>"
 msgstr "ERHW 아래 RHW 대각선 고가도로 퍼즐 조각<지원종료>"
 
@@ -615,7 +615,7 @@ msgstr ""
 "\n"
 "지상 네트워크가 지하도로를 가로지를 때에는 상부교차 조각을 지하도로 위에 설치합니다."
 
-msgctxt "2026960B-123006BB-6A475600"
+msgctxt "2026960B-123007BB-6A475600"
 msgid "RHW Flexible Underpasses (FLUPs), Draggable Underground Roads (URoads), and Overcrossings"
 msgstr "RHW 유연한 지하도로(FLUPs), 드래그할 수 있는 지하 도로(URoads) 및 상부 교차"
 
@@ -629,7 +629,7 @@ msgstr ""
 "\n"
 "유연한 RHW 인터체인지 부품이 들어있습니다. 기본 램프를 통과하도록 적합한 네트워크를 그어서 모양을 바꿀 수 있으며, 이로써 쉽게 완전한 인터체인지를 건설할 수 있습니다."
 
-msgctxt "2026960B-123006BB-6A475700"
+msgctxt "2026960B-123007BB-6A475700"
 msgid "RealHighway QuickChanges"
 msgstr "현실고속도로 빠른 입체교차로(QuickChanges)"
 
@@ -643,7 +643,7 @@ msgstr ""
 "\n"
 "다양한 RHW 회전차로 구성이 있는 유연한FLEX 시작/전환 조각이 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A475900"
+msgctxt "2026960B-123007BB-6A475900"
 msgid "RealHighway FLEX Turn Lanes (FTLs)"
 msgstr "현실고속도로 유연한FLEX 회전차로(FTLs)"
 
@@ -657,7 +657,7 @@ msgstr ""
 "\n"
 "FLEXFly 조각이 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A475AF3"
+msgctxt "2026960B-123007BB-6A475AF3"
 msgid "RealHighway FLEXFly (LEGACY/DEPRECATED)"
 msgstr "현실고속도로 유연한FLEX 고가차도(FLEXFly) (구식/지원종료)"
 
@@ -671,7 +671,7 @@ msgstr ""
 "\n"
 "현실고속도로 3층 교차 조각이 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A475AF6"
+msgctxt "2026960B-123007BB-6A475AF6"
 msgid "RealHighway 3-Level Crossings"
 msgstr "현실고속도로 3층 교차"
 
@@ -685,7 +685,7 @@ msgstr ""
 "\n"
 "FLEXFly 조각이 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A475B00"
+msgctxt "2026960B-123007BB-6A475B00"
 msgid "RealHighway FLEXFly"
 msgstr "현실고속도로 유연한FLEX 고가차도(FLEXFly)"
 
@@ -703,7 +703,7 @@ msgstr ""
 "\n"
 "주의: 대다수 교차로는 TuLEPs를 사용해야 합니다."
 
-msgctxt "2026960B-123006BB-6A475F00"
+msgctxt "2026960B-123007BB-6A475F00"
 msgid "Fractionally Angled RealHighway Intersections and Transitions"
 msgstr "분수 각도 현실고속도로 교차로 및 전환"
 
@@ -717,7 +717,7 @@ msgstr ""
 "\n"
 "FARHW 직선 및 곡선 조각이 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A475F20"
+msgctxt "2026960B-123007BB-6A475F20"
 msgid "Fractionally Angled RealHighway"
 msgstr "분수 각도 현실고속도로"
 
@@ -731,7 +731,7 @@ msgstr ""
 "\n"
 "FARHW C1/F1/C2/F2/C3형 램프 인터페이스 조각이 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A475F30"
+msgctxt "2026960B-123007BB-6A475F30"
 msgid "Fractionally Angled RealHighway Ramp Interfaces"
 msgstr "분수 각도 현실고속도로 램프 인터페이스"
 
@@ -745,7 +745,7 @@ msgstr ""
 "\n"
 "RHW 인터체인지에 사용되는 C형 램프 인터페이스가 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A475F70"
+msgctxt "2026960B-123007BB-6A475F70"
 msgid "RealHighway Type C Ramp Interfaces"
 msgstr "현실고속도로 C형 램프 인터페이스"
 
@@ -759,7 +759,7 @@ msgstr ""
 "\n"
 "RHW 인터체인지에 사용되는 F형 램프 인터페이스가 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A475F71"
+msgctxt "2026960B-123007BB-6A475F71"
 msgid "RealHighway Type F Ramp Interfaces"
 msgstr "현실고속도로 F형 램프 인터페이스"
 
@@ -777,7 +777,7 @@ msgstr ""
 "\n"
 "주의: 보행자전용도로 조각은 주거 구역의 화살표에 직접 닿지 않아야 합니다."
 
-msgctxt "2026960B-123006BB-6A476005"
+msgctxt "2026960B-123007BB-6A476005"
 msgid "Pedestrian Mall Tiles"
 msgstr "보행자전용도로 조각"
 
@@ -785,7 +785,7 @@ msgctxt "2026960B-123006AA-6A476100"
 msgid "A collection of pedestrian crossing FLEX pieces. Use them on their own at crossing locations, or as part of pedmall corridors."
 msgstr "횡단보도 유연한FLEX 조각 묶음입니다. 건널만한 장소나 보행자전용도로의 일부분으로 건설하세요."
 
-msgctxt "2026960B-123006BB-6A476100"
+msgctxt "2026960B-123007BB-6A476100"
 msgid "Pedestrian Revolution Mod (PRM) FLEX Crossings"
 msgstr "보행자 혁신 모드(PRM) 유연한FLEX 횡단보도"
 
@@ -799,7 +799,7 @@ msgstr ""
 "\n"
 "다양한 거리 퍼즐 조각과 도움 조각이 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A476525"
+msgctxt "2026960B-123007BB-6A476525"
 msgid "Diagonal Street Helper Pieces"
 msgstr "대각선 거리 도움 조각"
 
@@ -813,7 +813,7 @@ msgstr ""
 "\n"
 "거리 추가 모드(SAM) 시작 조각이 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A476700"
+msgctxt "2026960B-123007BB-6A476700"
 msgid "Street Addon Mod (SAM)"
 msgstr "거리 추가 모드(SAM)"
 
@@ -821,7 +821,7 @@ msgctxt "2026960B-123006AA-6A476905"
 msgid "Plop one of these pieces on a flat area. It will raise or lower the terrain, and then destroy itself, providing a level area for a raised network of your choice. This is fully compatible with all slope mods."
 msgstr "평평한 지역에 조각을 설치하세요. 자형을 높이거나 낮추고, 그 즉시 사라집니다. 경사(slope) 모드와 완벽히 호환됩니다."
 
-msgctxt "2026960B-123006BB-6A476905"
+msgctxt "2026960B-123007BB-6A476905"
 msgid "Hole Digger and Raiser Lots"
 msgstr "구덩이 파기와 쌓기 랏"
 
@@ -835,7 +835,7 @@ msgstr ""
 "\n"
 "다양한 애비뉴 퍼즐 조각이 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A476A00"
+msgctxt "2026960B-123007BB-6A476A00"
 msgid "Avenue Intersections"
 msgstr "애비뉴 교차로"
 
@@ -849,7 +849,7 @@ msgstr ""
 "\n"
 "다양한 도로 고가도로가 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A477000"
+msgctxt "2026960B-123007BB-6A477000"
 msgid "Road Overpasses"
 msgstr "도로 고가도로"
 
@@ -863,7 +863,7 @@ msgstr ""
 "\n"
 "다양한 도로 퍼즐 조각이 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A477005"
+msgctxt "2026960B-123007BB-6A477005"
 msgid "7.5m Elevated Road Viaducts"
 msgstr "7.5m 고가 도로"
 
@@ -877,7 +877,7 @@ msgstr ""
 "\n"
 "다양한 도로 퍼즐 조각이 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A477200"
+msgctxt "2026960B-123007BB-6A477200"
 msgid "15m Elevated Road Viaducts"
 msgstr "15m 고가 도로"
 
@@ -891,7 +891,7 @@ msgstr ""
 "\n"
 "도로, 일방통행 도로 및 애비뉴의 다양한 퍼즐 조각이 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A477500"
+msgctxt "2026960B-123007BB-6A477500"
 msgid "Wide Radius Curves (for Road, One-Way Road, Avenue, and Street) (Puzzle Pieces)"
 msgstr "넓은 반지름 곡선(도로, 일방통행 도로, 애비뉴 및 거리) (퍼즐 조각)"
 
@@ -905,7 +905,7 @@ msgstr ""
 "\n"
 "도로, 일방통행 도로 및 애비뉴의 다양한 퍼즐 조각이 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A477600"
+msgctxt "2026960B-123007BB-6A477600"
 msgid "Fractionally-Angled Networks (for Road, One-Way Road, and Avenue)"
 msgstr "분수 각도 네트워크(도로, 일방통행 도로 및 애비뉴)"
 
@@ -919,7 +919,7 @@ msgstr ""
 "\n"
 "퍼즐 조각을 선택하고 [Home] 또는 [End]를 누르면 퍼즐 조각의 방향을 바꿀 수 있습니다."
 
-msgctxt "2026960B-123006BB-6A477700"
+msgctxt "2026960B-123007BB-6A477700"
 msgid "Rural Road Puzzle Pieces"
 msgstr "시골 도로 퍼즐 조각"
 
@@ -933,7 +933,7 @@ msgstr ""
 "\n"
 "NAM 고가 도로 퍼즐 조각과 RHW 네트워크가 상호작용하는 고가도로 및 교차로 조각이 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A477800"
+msgctxt "2026960B-123007BB-6A477800"
 msgid "Road/RHW Overpass and Interface Puzzle Pieces (DEPRECATED)"
 msgstr "도로/RHW 고가도로 및 인터페이스 퍼즐 조각(지원종료)"
 
@@ -947,7 +947,7 @@ msgstr ""
 "\n"
 "여러 네트워크의 다양한 유연한FLEX 조각이 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A477900"
+msgctxt "2026960B-123007BB-6A477900"
 msgid "Multi-Radius Curve (MRC) FLEX Pieces for Surface Networks"
 msgstr "다중 반지름 곡선(MRC) 유연한FLEX 조각(지상 네트워크용)"
 
@@ -973,7 +973,7 @@ msgstr ""
 "\n"
 "새 지하철 기반 FLUPs 시스템은 고속도로 메뉴에서 찾을 수 있습니다."
 
-msgctxt "2026960B-123006BB-6A477A00"
+msgctxt "2026960B-123007BB-6A477A00"
 msgid "Flexible Underpasses (FLUPs)"
 msgstr "유연한 지하도로(FLUPs)"
 
@@ -987,7 +987,7 @@ msgstr ""
 "\n"
 "3/5/7차선 회전차로 애비뉴(TLA-3,5,7), 2/6차선 애비뉴(AVE-2,6), 3차선 비대칭 도로(ARD-3), 4/6차선 도로(RD-4,6) 및 1/3/4/5차선 일방통행 도로(OWR-1,3,4,5)의 시작 조각이 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A477B00"
+msgctxt "2026960B-123007BB-6A477B00"
 msgid "Network Widening Mod (NWM) Starter Pieces"
 msgstr "네트워크 넓히기 모드(NWM) 시작 조각"
 
@@ -1001,7 +1001,7 @@ msgstr ""
 "\n"
 "한 칸 NWM 네트워크의 넓은 반지름 곡선 조각이 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A477B30"
+msgctxt "2026960B-123007BB-6A477B30"
 msgid "Network Widening Mod (NWM) Curve Pieces"
 msgstr "네트워크 넓히기 모드(NWM) 곡선 조각"
 
@@ -1019,7 +1019,7 @@ msgstr ""
 "\n"
 "대다수 한 칸 또는 두 칸 네트워크의 전환은 그어서(직접 연결하거나 비비기 방법[stub-to-stub method]을 이용해서) 건설할 수 있습니다."
 
-msgctxt "2026960B-123006BB-6A477B50"
+msgctxt "2026960B-123007BB-6A477B50"
 msgid "Network Widening Mod (NWM) Transition Pieces"
 msgstr "네트워크 넓히기 모드(NWM) 전환 조각"
 
@@ -1033,7 +1033,7 @@ msgstr ""
 "\n"
 "TLA-5, RD-4 및 RD-6의 이웃 연결기 조각이 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A477BF0"
+msgctxt "2026960B-123007BB-6A477BF0"
 msgid "Network Widening Mod (NWM) Neighbor Connector Pieces"
 msgstr "네트워크 넓히기 모드(NWM) 이웃 연결기 조각"
 
@@ -1047,7 +1047,7 @@ msgstr ""
 "\n"
 "여러 도로 네트워크의 유연한FLEX 한 칸 회전교차로가 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A477C00"
+msgctxt "2026960B-123007BB-6A477C00"
 msgid "Single Tile Roundabouts"
 msgstr "한 칸 회전교차로"
 
@@ -1065,7 +1065,7 @@ msgstr ""
 "\n"
 "대체 스타일 고가 도로 경사-위 전환 조각이 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A477E00"
+msgctxt "2026960B-123007BB-6A477E00"
 msgid "Road Viaduct Alternate Styles"
 msgstr "고가 도로 대체 스타일"
 
@@ -1079,7 +1079,7 @@ msgstr ""
 "\n"
 "드래그할 수 있는 고가 도로의 다양한 시작 조각과 유연한FLEX 조각이 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A477F00"
+msgctxt "2026960B-123007BB-6A477F00"
 msgid "Draggable Elevated Road Viaducts"
 msgstr "드래그할 수 있는 고가 도로"
 
@@ -1097,7 +1097,7 @@ msgstr ""
 "\n"
 "고가도로 중간 부분에 네트워크를 그어서 고가도로를 가로지를 수 있습니다. 대다수 네트워크와 유연FLEX 기반 이중 네트워크가 이를 지원합니다."
 
-msgctxt "2026960B-123006BB-6A477F30"
+msgctxt "2026960B-123007BB-6A477F30"
 msgid "FLEX Overpasses"
 msgstr "유연한FLEX 고가도로"
 
@@ -1111,7 +1111,7 @@ msgstr ""
 "\n"
 "다양한 일방통행 도로의 고가도로가 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A478000"
+msgctxt "2026960B-123007BB-6A478000"
 msgid "One-Way Road Overpasses"
 msgstr "일방통행 도로 고가도로"
 
@@ -1125,7 +1125,7 @@ msgstr ""
 "\n"
 "다양한 일방통행 도로 퍼즐 조각이 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A478005"
+msgctxt "2026960B-123007BB-6A478005"
 msgid "15m Elevated One-Way Road Viaducts"
 msgstr "15m 고가 일방통행 도로"
 
@@ -1139,7 +1139,7 @@ msgstr ""
 "\n"
 "NAM 고가 일방통행 도로 퍼즐 조각과 RHW 네트워크가 상호작용하는 고가도로 및 교차로 조각이 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A478800"
+msgctxt "2026960B-123007BB-6A478800"
 msgid "One-Way Road/RHW Overpass and Interface Puzzle Pieces (DEPRECATED)"
 msgstr "일방통행 도로/RHW 고가도로 및 인터페이스 퍼즐 조각(지원종료)"
 
@@ -1147,7 +1147,7 @@ msgctxt "2026960B-123006AA-6A478900"
 msgid "For use of the curved pieces for the Real Expressway Network. Use the Home/End key to rotate the FLEX Piece & use TAB/Shift-TAB (Ctrl-TAB/Ctrl-Shift-TAB on macOS) to cycle through the different types of REW Straights and Curves."
 msgstr "현실 자동차전용도로 네트워크의 곡선 조각을 건설합니다. [Home] 또는 [End]를 누르면 유연한FLEX 조각이 회전하며, [TAB] 또는 [Shift] + [TAB](macOS에서는 [Ctrl] + [TAB] 또는 [Ctrl] + [Shift] + [TAB])을 누르면 다음 또는 이전 조각으로 이동합니다."
 
-msgctxt "2026960B-123006BB-6A478900"
+msgctxt "2026960B-123007BB-6A478900"
 msgid "Real Expressway FLEX Piece network tool and Curves."
 msgstr "현실 자동차전용도로 유연한FLEX 조각 네트워크 도구 및 곡선"
 
@@ -1161,7 +1161,7 @@ msgstr ""
 "\n"
 "다양한 재정의할 수 있는 램프 인터페이스의 유연한FLEX 조각이 들어있습니다. 기본 램프를 통과하도록 적합한 네트워크를 그어서 원하는 모양으로 바꿉니다."
 
-msgctxt "2026960B-123006BB-6A478B00"
+msgctxt "2026960B-123007BB-6A478B00"
 msgid "RealExpressway (REW) One-Way Road FLEXRamps"
 msgstr "현실 자동차전용도로(REW) 일방통행 도로 유연한FLEX 램프(FLEXRamps)"
 
@@ -1175,7 +1175,7 @@ msgstr ""
 "\n"
 "다양한 애비뉴 고가도로가 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A479000"
+msgctxt "2026960B-123007BB-6A479000"
 msgid "Avenue Overpasses"
 msgstr "애비뉴 고가도로"
 
@@ -1189,7 +1189,7 @@ msgstr ""
 "\n"
 "다양한 애비뉴 퍼즐 조각이 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A479005"
+msgctxt "2026960B-123007BB-6A479005"
 msgid "7.5m Elevated Avenue Viaducts"
 msgstr "7.5m 고가 애비뉴"
 
@@ -1203,7 +1203,7 @@ msgstr ""
 "\n"
 "다양한 애비뉴 퍼즐 조각이 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A479200"
+msgctxt "2026960B-123007BB-6A479200"
 msgid "15m Elevated Avenue Viaducts"
 msgstr "15m 고가 애비뉴"
 
@@ -1217,7 +1217,7 @@ msgstr ""
 "\n"
 "NAM 고가 애비뉴 퍼즐 조각과 RHW 네트워크가 상호작용하는 고가도로 및 교차로 조각이 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A479900"
+msgctxt "2026960B-123007BB-6A479900"
 msgid "Avenue/RHW Overpass and Interface Puzzle Pieces (DEPRECATED)"
 msgstr "애비뉴/RHW 고가도로 및 인터페이스 퍼즐 조각(지원종료)"
 
@@ -1235,7 +1235,7 @@ msgstr ""
 "\n"
 "유연한 단일점 도시형 입체교차로(FlexSPUI)와 유연한FLEX 갈라지는 다이아몬드 입체교차로(FlexDDI) 조각 역시 여기에 있습니다."
 
-msgctxt "2026960B-123006BB-6A47991A"
+msgctxt "2026960B-123007BB-6A47991A"
 msgid "Specialized RHW x Surface Intersections"
 msgstr "특수 RHW x 지상 교차로"
 
@@ -1249,7 +1249,7 @@ msgstr ""
 "\n"
 "다양한 철도 퍼즐 조각이 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A47A005"
+msgctxt "2026960B-123007BB-6A47A005"
 msgid "Rail Puzzle Pieces"
 msgstr "철도 퍼즐 조각"
 
@@ -1257,7 +1257,7 @@ msgctxt "2026960B-123006AA-6A47A130"
 msgid "Button contains FLEX pieces to elevated the Rail network to viaduct level (using the RealRailway (RRW) standard)"
 msgstr "고가 철도를 건설할 수 있는 유연한FLEX 조각이 들어있습니다. [현실철도(RRW) 표준을 준수]"
 
-msgctxt "2026960B-123006BB-6A47A130"
+msgctxt "2026960B-123007BB-6A47A130"
 msgid "Draggable Elevated Railways (ERRW)"
 msgstr "드래그할 수 있는 고가 철도(ERRW)"
 
@@ -1271,7 +1271,7 @@ msgstr ""
 "\n"
 "퍼즐 조각을 선택하고 [Home] 또는 [End]를 누르면 퍼즐 조각의 방향을 바꿀 수 있습니다."
 
-msgctxt "2026960B-123006BB-6A47A358"
+msgctxt "2026960B-123007BB-6A47A358"
 msgid "Wide Radius Railroad Curve and Double Track Rail Switch Puzzle Pieces"
 msgstr "넓은 반지름 철도 곡선 및 복선 철도 분기 퍼즐 조각"
 
@@ -1285,7 +1285,7 @@ msgstr ""
 "\n"
 "퍼즐 조각을 선택하고 [Home] 또는 [End]를 누르면 퍼즐 조각의 방향을 바꿀 수 있습니다."
 
-msgctxt "2026960B-123006BB-6A47A368"
+msgctxt "2026960B-123007BB-6A47A368"
 msgid "Fractional Angle Railroad (FARR) Puzzle Pieces"
 msgstr "분수 각도 철도(FARR) 퍼즐 조각"
 
@@ -1299,7 +1299,7 @@ msgstr ""
 "\n"
 "NAM 고가 철도 퍼즐 조각과 RHW 네트워크가 상호작용하는 고가철도 및 교차로 조각이 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A47A800"
+msgctxt "2026960B-123007BB-6A47A800"
 msgid "Rail Viaduct/RHW Overpass and Interface Puzzle Pieces"
 msgstr "고가 철도/RHW 고가철도 및 인터페이스 퍼즐 조각"
 
@@ -1313,7 +1313,7 @@ msgstr ""
 "\n"
 "퍼즐 조각을 선택하고 [Home] 또는 [End]를 누르면 퍼즐 조각의 방향을 바꿀 수 있습니다."
 
-msgctxt "2026960B-123006BB-6A47A900"
+msgctxt "2026960B-123007BB-6A47A900"
 msgid "Wide Radius Railroad Curve and Double Track Rail Switch Puzzle Pieces"
 msgstr "넓은 반지름 철도 곡선 및 복선 철도 분기 퍼즐 조각"
 
@@ -1327,7 +1327,7 @@ msgstr ""
 "\n"
 "다양한 이중/복층 네트워크 조각이 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A47AA0F"
+msgctxt "2026960B-123007BB-6A47AA0F"
 msgid ""
 "Underground Rail\n"
 "Rail Tunnel under Roads Dual Networking Puzzle Pieces"
@@ -1345,7 +1345,7 @@ msgstr ""
 "\n"
 "다양한 이중/복층 네트워크 조각이 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A47AA10"
+msgctxt "2026960B-123007BB-6A47AA10"
 msgid ""
 "Underground Rail\n"
 "Rail Tunnel under Ped Malls Dual Networking Puzzle Pieces"
@@ -1363,7 +1363,7 @@ msgstr ""
 "\n"
 "다양한 맥시스 도로 조각이 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A47AA11"
+msgctxt "2026960B-123007BB-6A47AA11"
 msgid ""
 "Underground Rail\n"
 "Maxis Roadway Intersection Pieces"
@@ -1381,7 +1381,7 @@ msgstr ""
 "\n"
 "다양한 철도 조각이 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A47AA12"
+msgctxt "2026960B-123007BB-6A47AA12"
 msgid ""
 "Underground Rail\n"
 "Railway Intersection Pieces"
@@ -1399,7 +1399,7 @@ msgstr ""
 "\n"
 "다양한 전차 조각이 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A47AA13"
+msgctxt "2026960B-123007BB-6A47AA13"
 msgid ""
 "Underground Rail\n"
 "Tramway Intersection Pieces"
@@ -1417,7 +1417,7 @@ msgstr ""
 "\n"
 "다양한 이중/복층 네트워크 조각이 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A47AA8A"
+msgctxt "2026960B-123007BB-6A47AA8A"
 msgid ""
 "Underground Rail\n"
 "Miscellaneous Puzzle Pieces"
@@ -1429,7 +1429,7 @@ msgctxt "2026960B-123006AA-6A47AC00"
 msgid "All pieces in this section are FLEX and conform to flextrack standards!"
 msgstr "모든 조각이 유연FLEX하고 유연한 선로(flextrack)와 FARR 표준을 준수합니다!"
 
-msgctxt "2026960B-123006BB-6A47AC00"
+msgctxt "2026960B-123007BB-6A47AC00"
 msgid "RealRailway FLEX Curve Pieces."
 msgstr "현실철도 유연한FLEX 곡선 조각"
 
@@ -1437,7 +1437,7 @@ msgctxt "2026960B-123006AA-6A47AC10"
 msgid "All pieces in this section are FLEX and conform to flextrack standards!"
 msgstr "모든 조각이 유연FLEX하고 유연한 선로(flextrack)와 FARR 표준을 준수합니다!"
 
-msgctxt "2026960B-123006BB-6A47AC10"
+msgctxt "2026960B-123007BB-6A47AC10"
 msgid "RealRailway FLEX Turnout Pieces."
 msgstr "현실철도 유연한FLEX 곡선 조각"
 
@@ -1445,7 +1445,7 @@ msgctxt "2026960B-123006AA-6A47AD00"
 msgid "All pieces in this section are FLEX and conform to flextrack and FARR standards!\n"
 msgstr "모든 조각이 유연FLEX하고 유연한 선로(flextrack)와 FARR 표준을 준수합니다!\n"
 
-msgctxt "2026960B-123006BB-6A47AD00"
+msgctxt "2026960B-123007BB-6A47AD00"
 msgid "RealRailway FLEX Fractional Angled (FA) Pieces."
 msgstr "현실철도 유연한FLEX 분수 각도(FA) 조각"
 
@@ -1459,7 +1459,7 @@ msgstr ""
 "\n"
 "다양한 이중/복층 네트워크가 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A47B03A"
+msgctxt "2026960B-123007BB-6A47B03A"
 msgid "ElevatedRail Dual/Double-Decker Network Pieces"
 msgstr "지상전철 이중/복층 네트워크 조각"
 
@@ -1467,7 +1467,7 @@ msgctxt "2026960B-123006AA-6A47B049"
 msgid "These puzzle pieces are to allow you to cross NWM networks with ElRail over Road."
 msgstr "지상전철-도로와 NWM의 교차로를 건설할 수 있는 퍼즐 조각이 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A47B049"
+msgctxt "2026960B-123007BB-6A47B049"
 msgid "ElRail over Road NWM Intersections"
 msgstr "지상전철-도로와 NWM 교차로"
 
@@ -1481,7 +1481,7 @@ msgstr ""
 "\n"
 "공사 부지는 자동적으로 사라집니다. 도로 도구를 이용하여 네트워크를 연결하고 교차로를 건설하세요."
 
-msgctxt "2026960B-123006BB-6A47B060"
+msgctxt "2026960B-123007BB-6A47B060"
 msgid "ElevatedRail over Avenue/Road-4 Puzzle Pieces"
 msgstr "지상전철-애비뉴/RD-4 퍼즐 조각"
 
@@ -1489,7 +1489,7 @@ msgctxt "2026960B-123006AA-6A47B10F"
 msgid "Puzzle Pieces to build a ground level extension of the Elevated Rail network for Light Rail/Trams."
 msgstr "전차 퍼즐 조각을 건설합니다."
 
-msgctxt "2026960B-123006BB-6A47B10F"
+msgctxt "2026960B-123007BB-6A47B10F"
 msgid "Ground Light Rail (Tram)"
 msgstr "전차"
 
@@ -1503,7 +1503,7 @@ msgstr ""
 "\n"
 "시작 조각을 통과하도록 지상전철 네트워크 도구를 그어서 전차를 건설합니다."
 
-msgctxt "2026960B-123006BB-6A47B3FF"
+msgctxt "2026960B-123007BB-6A47B3FF"
 msgid "Draggable Ground Light Rail (Tram)"
 msgstr "드래그할 수 있는 전차"
 
@@ -1511,7 +1511,7 @@ msgctxt "2026960B-123006AA-6A47B42A"
 msgid "For building Tram-Avenue (= GroundLightRail / Avenue) - Dual Network Pieces."
 msgstr "전차전용-애비뉴 - 이중 네트워크 조각을 건설합니다."
 
-msgctxt "2026960B-123006BB-6A47B42A"
+msgctxt "2026960B-123007BB-6A47B42A"
 msgid "Tram-Avenue (GroundLightRail / Avenue) - Dual Network Pieces"
 msgstr "전차전용-애비뉴 - 이중 네트워크 조각"
 
@@ -1525,7 +1525,7 @@ msgstr ""
 "\n"
 "맨 땅에 건설하거나 기존에 있는 네트워크 위에 건설할 수 있도록 설계되었습니다."
 
-msgctxt "2026960B-123006BB-6A47B900"
+msgctxt "2026960B-123007BB-6A47B900"
 msgid "High Elevated Rail Puzzle Pieces"
 msgstr "초고가 지상전철 퍼즐 조각"
 
@@ -1539,7 +1539,7 @@ msgstr ""
 "\n"
 "전차전용-도로 조각이 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A47BA00"
+msgctxt "2026960B-123007BB-6A47BA00"
 msgid "Tram-in-Road"
 msgstr "전차전용-도로"
 
@@ -1547,7 +1547,7 @@ msgctxt "2026960B-123006AA-6A47BBA0"
 msgid "For utilizing the Tram Puzzle Pieces"
 msgstr "전차 조각을 건설합니다."
 
-msgctxt "2026960B-123006BB-6A47BBA0"
+msgctxt "2026960B-123007BB-6A47BBA0"
 msgid "Tram-on-Road & texture variations"
 msgstr "전차겸용-도로 & 변형 텍스처"
 
@@ -1555,7 +1555,7 @@ msgctxt "2026960B-123006AA-6A47BC60"
 msgid "For utilizing the Tram Puzzle Pieces"
 msgstr "전차 조각을 건설합니다."
 
-msgctxt "2026960B-123006BB-6A47BC60"
+msgctxt "2026960B-123007BB-6A47BC60"
 msgid "Tram-on-Street"
 msgstr "전차겸용-거리"
 
@@ -1569,7 +1569,7 @@ msgstr ""
 "\n"
 "두 종류의 전차 시작 조각과 채움 조각이 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A47BD00"
+msgctxt "2026960B-123007BB-6A47BD00"
 msgid "Draggable Ground Light Rail (Tram)--Additional Styles"
 msgstr "드래그할 수 있는 전차 --추가 스타일"
 
@@ -1583,7 +1583,7 @@ msgstr ""
 "\n"
 "고속철도(HSR)의 시작 조각, 채움 조각, 고가철도 조각이 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A47C000"
+msgctxt "2026960B-123007BB-6A47C000"
 msgid "High Speed Rail (HSR)"
 msgstr "고속철도(HSR)"
 
@@ -1601,11 +1601,11 @@ msgstr ""
 "\n"
 "GHSR은 지상 높이의 고속철도(HSR)입니다."
 
-msgctxt "2026960B-123006BB-6A47C200"
+msgctxt "2026960B-123007BB-6A47C200"
 msgid "Ground High Speed Rail (GHSR)"
 msgstr "지상 고속철도(GHSR)"
 
-msgctxt "2026960B-123006BB-6A47C700"
+msgctxt "2026960B-123007BB-6A47C700"
 msgid "Monorail Wide Radius Curve Puzzle Pieces"
 msgstr "모노레일 넓은 반지름 곡선 퍼즐 조각"
 
@@ -1629,7 +1629,7 @@ msgstr ""
 "\n"
 "맨 땅에 건설하거나 기존에 있는 네트워크 위에 건설할 수 있도록 설계되었습니다."
 
-msgctxt "2026960B-123006BB-6A47C900"
+msgctxt "2026960B-123007BB-6A47C900"
 msgid "High Monorail Puzzle Pieces"
 msgstr "초고가 모노레일 퍼즐 조각"
 
@@ -1637,7 +1637,7 @@ msgctxt "2026960B-123006AA-6A47CA00"
 msgid "For building Hybrid Railway straight track sections.  Hybrid Railway carries both normal Rail traffic and High Speed Rail (Monorail) traffic."
 msgstr "직선 하이브리드 철도를 건설합니다.  하이브리드 철도는 철도와 고속철도(모노레일)을 모두 수송합니다."
 
-msgctxt "2026960B-123006BB-6A47CA00"
+msgctxt "2026960B-123007BB-6A47CA00"
 msgid "Hybrid Railway (Rail-High Speed Rail) Straight Sections"
 msgstr "하이브리드 철도 직선 조각"
 
@@ -1645,7 +1645,7 @@ msgctxt "2026960B-123006AA-6A47CB00"
 msgid "For building Hybrid Railway curves.  Hybrid Railway carries both normal Rail traffic and High Speed Rail (Monorail) traffic."
 msgstr "곡선 하이브리드 철도를 건설합니다.  하이브리드 철도는 철도와 고속철도(모노레일)을 모두 수송합니다."
 
-msgctxt "2026960B-123006BB-6A47CB00"
+msgctxt "2026960B-123007BB-6A47CB00"
 msgid "Hybrid Railway (Rail-High Speed Rail) Curves"
 msgstr "하이브리드 철도 곡선"
 
@@ -1659,7 +1659,7 @@ msgstr ""
 "\n"
 "하이브리드 철도는 철도와 고속철도(모노레일)을 모두 수송합니다."
 
-msgctxt "2026960B-123006BB-6A47CD00"
+msgctxt "2026960B-123007BB-6A47CD00"
 msgid "Hybrid Railway (Rail-High Speed Rail) Switches"
 msgstr "하이브리드 철도 분기"
 
@@ -1673,7 +1673,7 @@ msgstr ""
 "\n"
 "지상 하이브리드 철도를 고가 전환 끝부분에 연결하거나 다른 고가 하이브리드 철도에 연결하세요."
 
-msgctxt "2026960B-123006BB-6A47CE00"
+msgctxt "2026960B-123007BB-6A47CE00"
 msgid "Hybrid Railway (Rail-High Speed Rail) Height Transitions"
 msgstr "하이브리드 철도 높이 전환"
 
@@ -1681,7 +1681,7 @@ msgctxt "2026960B-123006AA-6A47DC00"
 msgid "Button contains Ground Highway Puzzle Pieces"
 msgstr "지상 고속도로 퍼즐 조각이 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A47DC00"
+msgctxt "2026960B-123007BB-6A47DC00"
 msgid "Ground Highway Puzzle Pieces"
 msgstr "지상 고속도로 퍼즐 조각"
 
@@ -1695,7 +1695,7 @@ msgstr ""
 "\n"
 "고가 고속도로용 한쪽 수직 램프가 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A47E010"
+msgctxt "2026960B-123007BB-6A47E010"
 msgid ""
 "Single-Sided Perpendicular Ramps\n"
 "\n"
@@ -1715,7 +1715,7 @@ msgstr ""
 "\n"
 "지상 고속도로용과 고가 고속도로용이 모두 들어있습니다."
 
-msgctxt "2026960B-123006BB-6A47E050"
+msgctxt "2026960B-123007BB-6A47E050"
 msgid ""
 "Single-Sided Parallel Ramps\n"
 "\n"
@@ -1729,15 +1729,15 @@ msgctxt "2026960B-123006AA-6A47E100"
 msgid "Button contains Custom Interchanges"
 msgstr "추가 입체교차로(Custom Interchanges)가 들어 있습니다."
 
-msgctxt "2026960B-123006BB-6A47E100"
+msgctxt "2026960B-123007BB-6A47E100"
 msgid "Custom Interchanges"
 msgstr "추가 입체교차로"
 
-msgctxt "2026960B-123006BB-6A47FFFF"
+msgctxt "2026960B-123007BB-6A47FFFF"
 msgid "Network Addon Mod Controller"
 msgstr "네트워크 추가 모드(NAM) 컨트롤러"
 
-msgctxt "2026960B-123006BB-6A476200"
+msgctxt "2026960B-123007BB-6A476200"
 msgid "Draggable Pedmalls"
 msgstr "드래그할 수 있는 보행자전용도로"
 

--- a/ltext/nl/buttons.po
+++ b/ltext/nl/buttons.po
@@ -31,7 +31,7 @@ msgid ""
 "Button contains Parallel Ramps for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-52001000"
+msgctxt "2026960B-123007BB-52001000"
 msgid ""
 "Parallel Ramps\n"
 "\n"
@@ -45,7 +45,7 @@ msgid ""
 "Button contains Overpass/Perpendicular Ramps for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-52001010"
+msgctxt "2026960B-123007BB-52001010"
 msgid ""
 "Overpass/Perpendicular Ramps\n"
 "\n"
@@ -59,7 +59,7 @@ msgid ""
 "Button contains Cloverleaves for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-52001020"
+msgctxt "2026960B-123007BB-52001020"
 msgid ""
 "Cloverleaf\n"
 "\n"
@@ -73,7 +73,7 @@ msgid ""
 "Button contains T-Intersections for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-52002000"
+msgctxt "2026960B-123007BB-52002000"
 msgid ""
 "T-Intersections\n"
 "\n"
@@ -84,7 +84,7 @@ msgctxt "2026960B-123006AA-6A470100"
 msgid "With the Canal Addon Mod you can build functional canals"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A470100"
+msgctxt "2026960B-123007BB-6A470100"
 msgid "Canal Addon Mod"
 msgstr ""
 
@@ -96,7 +96,7 @@ msgid ""
 "Drag the listed network through the FLEX/Starter Piece to construct the turn lane."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A470460"
+msgctxt "2026960B-123007BB-6A470460"
 msgid "FLEX Turn Lanes (FTLs)"
 msgstr ""
 
@@ -107,7 +107,7 @@ msgid ""
 "Button contains QuickTurn setups, which are FLEX intersections with turn lanes"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A4704A0"
+msgctxt "2026960B-123007BB-6A4704A0"
 msgid "QuickTurn (Pre-Built FLEX Turn Lane Setups)"
 msgstr ""
 
@@ -118,7 +118,7 @@ msgid ""
 "Button contains Turn Lane and Slip Lane Puzzle Pieces for various networks and configurations"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A4704E0"
+msgctxt "2026960B-123007BB-6A4704E0"
 msgid "TuLEPs (Turn Lane Extension Pieces) (OLD)"
 msgstr ""
 
@@ -129,7 +129,7 @@ msgid ""
 "Button contains Turn Lane puzzle pieces for 7-lane Turning Lane Avenue (TLA-7) and 6-lane Avenue (AVE-6) networks"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A470600"
+msgctxt "2026960B-123007BB-6A470600"
 msgid "Network Widening Mod (NWM) Triple-Tile Network Turn Lane Extension Pieces (TuLEPs)"
 msgstr ""
 
@@ -140,7 +140,7 @@ msgid ""
 "Button contains components for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A473141"
+msgctxt "2026960B-123007BB-6A473141"
 msgid ""
 "Symphony Prefab Interchange Components\n"
 "\n"
@@ -154,7 +154,7 @@ msgid ""
 "Button contains components for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A473143"
+msgctxt "2026960B-123007BB-6A473143"
 msgid ""
 "Symphony Ramp Interfaces\n"
 "\n"
@@ -168,7 +168,7 @@ msgid ""
 "The first item is the starter piece."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A474000"
+msgctxt "2026960B-123007BB-6A474000"
 msgid "Single-Track Rail (STR)"
 msgstr ""
 
@@ -180,7 +180,7 @@ msgid ""
 "Drag the RealHighway (RHW-2) network tool through the Starter Piece to construct the desired override network."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475000"
+msgctxt "2026960B-123007BB-6A475000"
 msgid "RealHighway (RHW) Starter Pieces"
 msgstr ""
 
@@ -195,7 +195,7 @@ msgid ""
 "Place down Eraser onto desired tile and redraw anything if needed"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475024"
+msgctxt "2026960B-123007BB-6A475024"
 msgid "Network Eraser"
 msgstr ""
 
@@ -206,7 +206,7 @@ msgid ""
 "Button contains Filler Pieces to build RHW networks in smaller chunks, in unstable situations"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475050"
+msgctxt "2026960B-123007BB-6A475050"
 msgid "RealHighway Filler Pieces"
 msgstr ""
 
@@ -219,7 +219,7 @@ msgid ""
 "These items are DEPRECATED, and the use of the FLEX Neighbor Connections is recommended instead."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47508C"
+msgctxt "2026960B-123007BB-6A47508C"
 msgid "Old RealHighway Neighbor Connector Puzzle Pieces  - DEPRECATED"
 msgstr ""
 
@@ -232,7 +232,7 @@ msgid ""
 "NOTE: ALL REALHIGHWAY NEIGHBOR CONNECTIONS (EXCEPT RHW-2) ARE REQUIRED TO USE NEIGHBOR CONNECTOR PIECES TO ENSURE PROPERLY FUNCTIONING NEIGHBOR CONNECTIONS--OTHERWISE ONLY FREIGHT TRUCKS WILL USE THE RHW"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475090"
+msgctxt "2026960B-123007BB-6A475090"
 msgid "RealHighway FLEX Neighbor Connector Pieces (FLEX-NC)"
 msgstr ""
 
@@ -240,7 +240,7 @@ msgctxt "2026960B-123006AA-6A475100"
 msgid "For building DEPRECATED RealHighway Ramp Interfaces.  All of the functionality of the 47 pieces contained and many more are covered by the FLEXRamp system."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475100"
+msgctxt "2026960B-123007BB-6A475100"
 msgid "OBSOLETE RealHighway Ramp Interfaces (Static Puzzle-Based)"
 msgstr ""
 
@@ -251,7 +251,7 @@ msgid ""
 "Button contains Type B Ramp Interface Pieces for building interchanges with the RHW"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475104"
+msgctxt "2026960B-123007BB-6A475104"
 msgid "RealHighway Type B Ramp Interfaces"
 msgstr ""
 
@@ -262,7 +262,7 @@ msgid ""
 "Button contains Type E Ramp Interface Pieces for building interchanges with the RHW"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475109"
+msgctxt "2026960B-123007BB-6A475109"
 msgid "RealHighway Type E Ramp Interfaces"
 msgstr ""
 
@@ -273,7 +273,7 @@ msgid ""
 "Button contains Type D Ramp Interface Pieces for building interchanges with the RHW"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47510A"
+msgctxt "2026960B-123007BB-6A47510A"
 msgid "RealHighway Type D Ramp Interfaces"
 msgstr ""
 
@@ -284,7 +284,7 @@ msgid ""
 "Deprecated puzzle piece ramps follow Volleyball pieces - use of the FLEXRamps or Draggable Ramp Interfaces (DRIs) is recommended instead of using the deprecated puzzle pieces."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475118"
+msgctxt "2026960B-123007BB-6A475118"
 msgid "Specialized and Deprecated RealHighway Ramp Interfaces and Volleyball Crossings (Static Puzzle-Based)"
 msgstr ""
 
@@ -295,7 +295,7 @@ msgid ""
 "Button contains FLEX pieces for different overrideable ramp interfaces.  Drag appropriate networks through to convert base ramp to match."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A4751F0"
+msgctxt "2026960B-123007BB-6A4751F0"
 msgid "RealHighway FLEXRamps"
 msgstr ""
 
@@ -306,7 +306,7 @@ msgid ""
 "Button contains pieces to build Wide Curves for the RHW networks"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475220"
+msgctxt "2026960B-123007BB-6A475220"
 msgid "RealHighway Wide-Radius and Multi-Radius (Smooth) Curves"
 msgstr ""
 
@@ -319,7 +319,7 @@ msgid ""
 "These items are DEPRECATED and use of the FLEX Width Transitions (FLEX-WT) is recommended instead."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475300"
+msgctxt "2026960B-123007BB-6A475300"
 msgid "Old RealHighway Width Transition Puzzle Pieces - DEPRECATED"
 msgstr ""
 
@@ -332,7 +332,7 @@ msgid ""
 "All functionality here has been duplicated with the FLEX Height Transitions, and as such, this button is DEPRECATED."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475312"
+msgctxt "2026960B-123007BB-6A475312"
 msgid "Old RealHighway Height Transition Puzzle Pieces  - DEPRECATED"
 msgstr ""
 
@@ -343,7 +343,7 @@ msgid ""
 "Button contains pieces to transition between RHW networks of different heights.  Pieces begin as RHW-2 transitions, and dragging another RHW network into them will convert them to fit."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475330"
+msgctxt "2026960B-123007BB-6A475330"
 msgid "RealHighway FLEX Height Transitions (FLEX-HT)"
 msgstr ""
 
@@ -354,7 +354,7 @@ msgid ""
 "Button contains pieces to transition between RHW networks of different widths.  Dragging another RHW network into them will convert them to fit."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475336"
+msgctxt "2026960B-123007BB-6A475336"
 msgid "RealHighway FLEX Width Transitions (FLEX-WT)"
 msgstr ""
 
@@ -365,7 +365,7 @@ msgid ""
 "Button contains components for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475350"
+msgctxt "2026960B-123007BB-6A475350"
 msgid ""
 "Symphony Transitions\n"
 "\n"
@@ -379,7 +379,7 @@ msgid ""
 "Button contains components for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475366"
+msgctxt "2026960B-123007BB-6A475366"
 msgid ""
 "Symphony Smooth Curves\n"
 "\n"
@@ -395,7 +395,7 @@ msgid ""
 "NOTE: These pieces should NOT be confused with TuLEPs."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475400"
+msgctxt "2026960B-123007BB-6A475400"
 msgid "RealHighway Cosmetic Puzzle Pieces (for 1-Tile Networks)"
 msgstr ""
 
@@ -408,7 +408,7 @@ msgid ""
 "NOTE: These pieces should NOT be confused with TuLEPs."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475410"
+msgctxt "2026960B-123007BB-6A475410"
 msgid "RealHighway Cosmetic Piece Transitions"
 msgstr ""
 
@@ -421,7 +421,7 @@ msgid ""
 "NOTE: These pieces should NOT be confused with TuLEPs."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475440"
+msgctxt "2026960B-123007BB-6A475440"
 msgid "RealHighway Cosmetic Puzzle Pieces (for 2-Tile Networks)"
 msgstr ""
 
@@ -434,7 +434,7 @@ msgid ""
 "NOTE: These pieces should NOT be confused with TuLEPs."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475471"
+msgctxt "2026960B-123007BB-6A475471"
 msgid "RealHighway Cosmetic Puzzle Pieces (for 3-Tile Networks)"
 msgstr ""
 
@@ -447,7 +447,7 @@ msgid ""
 "<DEPRECATED>"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475500"
+msgctxt "2026960B-123007BB-6A475500"
 msgid "ERHW-over-RHW Diagonal Overpass Puzzle Pieces<DEPRECATED>"
 msgstr ""
 
@@ -460,7 +460,7 @@ msgid ""
 "Place overcrossing pieces on top of underground roadways whenever a surface network crosses over, to allow traffic to pass underground."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475600"
+msgctxt "2026960B-123007BB-6A475600"
 msgid "RHW Flexible Underpasses (FLUPs), Draggable Underground Roads (URoads), and Overcrossings"
 msgstr ""
 
@@ -471,7 +471,7 @@ msgid ""
 "Button contains flexible RHW interchange segments.  Drag appropriate networks through to convert base ramp to match, and combine to easily create a full interchange."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475700"
+msgctxt "2026960B-123007BB-6A475700"
 msgid "RealHighway QuickChanges"
 msgstr ""
 
@@ -482,7 +482,7 @@ msgid ""
 "Button contains starter/transition FLEX pieces for different RHW turn lane setups"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475900"
+msgctxt "2026960B-123007BB-6A475900"
 msgid "RealHighway FLEX Turn Lanes (FTLs)"
 msgstr ""
 
@@ -493,7 +493,7 @@ msgid ""
 "Button contains pieces to build FLEXFly Pieces"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475AF3"
+msgctxt "2026960B-123007BB-6A475AF3"
 msgid "RealHighway FLEXFly (LEGACY/DEPRECATED)"
 msgstr ""
 
@@ -504,7 +504,7 @@ msgid ""
 "Button contains pieces to build 3-Level Crossings"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475AF6"
+msgctxt "2026960B-123007BB-6A475AF6"
 msgid "RealHighway 3-Level Crossings"
 msgstr ""
 
@@ -515,7 +515,7 @@ msgid ""
 "Button contains pieces to build FLEXFly Pieces"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475B00"
+msgctxt "2026960B-123007BB-6A475B00"
 msgid "RealHighway FLEXFly"
 msgstr ""
 
@@ -528,7 +528,7 @@ msgid ""
 "NOTE: Most intersections require the use of TuLEPs."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475F00"
+msgctxt "2026960B-123007BB-6A475F00"
 msgid "Fractionally Angled RealHighway Intersections and Transitions"
 msgstr ""
 
@@ -539,7 +539,7 @@ msgid ""
 "Button contains straight pieces and curves to pieces to build Fractionally Angled RealHighway (FARHWs)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475F20"
+msgctxt "2026960B-123007BB-6A475F20"
 msgid "Fractionally Angled RealHighway"
 msgstr ""
 
@@ -550,7 +550,7 @@ msgid ""
 "Button contains pieces to build different FARHW Ramp Interfaces: The C1, F1, C2, F2, and C3 Ramp Interfaces"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475F30"
+msgctxt "2026960B-123007BB-6A475F30"
 msgid "Fractionally Angled RealHighway Ramp Interfaces"
 msgstr ""
 
@@ -561,7 +561,7 @@ msgid ""
 "Button contains Type C Ramp Interface Pieces for building interchanges with the RHW"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475F70"
+msgctxt "2026960B-123007BB-6A475F70"
 msgid "RealHighway Type C Ramp Interfaces"
 msgstr ""
 
@@ -572,7 +572,7 @@ msgid ""
 "Button contains Type F Ramp Interface Pieces for building interchanges with the RHW"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475F71"
+msgctxt "2026960B-123007BB-6A475F71"
 msgid "RealHighway Type F Ramp Interfaces"
 msgstr ""
 
@@ -585,7 +585,7 @@ msgid ""
 "NOTE: Ped Mall Tiles should not be used directly in front of Residential Zones where their zoning arrow is."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A476005"
+msgctxt "2026960B-123007BB-6A476005"
 msgid "Pedestrian Mall Tiles"
 msgstr ""
 
@@ -593,7 +593,7 @@ msgctxt "2026960B-123006AA-6A476100"
 msgid "A collection of pedestrian crossing FLEX pieces. Use them on their own at crossing locations, or as part of pedmall corridors."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A476100"
+msgctxt "2026960B-123007BB-6A476100"
 msgid "Pedestrian Revolution Mod (PRM) FLEX Crossings"
 msgstr ""
 
@@ -604,7 +604,7 @@ msgid ""
 "Button contains several different Puzzle and Helper Pieces for Street"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A476525"
+msgctxt "2026960B-123007BB-6A476525"
 msgid "Diagonal Street Helper Pieces"
 msgstr ""
 
@@ -615,7 +615,7 @@ msgid ""
 "Button contains Starter Pieces for Street Addon Mod (SAM)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A476700"
+msgctxt "2026960B-123007BB-6A476700"
 msgid "Street Addon Mod (SAM)"
 msgstr ""
 
@@ -623,7 +623,7 @@ msgctxt "2026960B-123006AA-6A476905"
 msgid "Plop one of these pieces on a flat area. It will raise or lower the terrain, and then destroy itself, providing a level area for a raised network of your choice. This is fully compatible with all slope mods."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A476905"
+msgctxt "2026960B-123007BB-6A476905"
 msgid "Hole Digger and Raiser Lots"
 msgstr ""
 
@@ -634,7 +634,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Avenues"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A476A00"
+msgctxt "2026960B-123007BB-6A476A00"
 msgid "Avenue Intersections"
 msgstr ""
 
@@ -645,7 +645,7 @@ msgid ""
 "Button contains several different overpasses for Road"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477000"
+msgctxt "2026960B-123007BB-6A477000"
 msgid "Road Overpasses"
 msgstr ""
 
@@ -656,7 +656,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Road"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477005"
+msgctxt "2026960B-123007BB-6A477005"
 msgid "7.5m Elevated Road Viaducts"
 msgstr ""
 
@@ -667,7 +667,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Road"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477200"
+msgctxt "2026960B-123007BB-6A477200"
 msgid "15m Elevated Road Viaducts"
 msgstr ""
 
@@ -678,7 +678,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Road, One-Way Road, or Avenue"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477500"
+msgctxt "2026960B-123007BB-6A477500"
 msgid "Wide Radius Curves (for Road, One-Way Road, Avenue, and Street) (Puzzle Pieces)"
 msgstr ""
 
@@ -689,7 +689,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Road, One-Way Road, and Avenue"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477600"
+msgctxt "2026960B-123007BB-6A477600"
 msgid "Fractionally-Angled Networks (for Road, One-Way Road, and Avenue)"
 msgstr ""
 
@@ -700,7 +700,7 @@ msgid ""
 "Once a puzzle piece is selected, use the [Home] and [End] keys to cycle through the various puzzle piece orientations"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477700"
+msgctxt "2026960B-123007BB-6A477700"
 msgid "Rural Road Puzzle Pieces"
 msgstr ""
 
@@ -711,7 +711,7 @@ msgid ""
 "Button contains pieces to interface between the NAM Elevated Road Puzzle Pieces and RHW networks, including overpasses and intersections"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477800"
+msgctxt "2026960B-123007BB-6A477800"
 msgid "Road/RHW Overpass and Interface Puzzle Pieces (DEPRECATED)"
 msgstr ""
 
@@ -722,7 +722,7 @@ msgid ""
 "Button contains several different FLEX Pieces for various networks"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477900"
+msgctxt "2026960B-123007BB-6A477900"
 msgid "Multi-Radius Curve (MRC) FLEX Pieces for Surface Networks"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgid ""
 "The new Subway-based FLUPs system can be found under the Highways menu."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477A00"
+msgctxt "2026960B-123007BB-6A477A00"
 msgid "Flexible Underpasses (FLUPs)"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgid ""
 "Button contains Starter Pieces for the 3, 5 and 7-lane Turning Lane Avenues (TLA-3,5,7), 2 and 6-lane Avenues (AVE-2,6), 3-lane Asymmetrical Road (ARD-3), 4 and 6-lane Roads RD-4,6) and 1, 3, 4 and 5-lane One-Way Roads (OWR-1,3,4,5)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477B00"
+msgctxt "2026960B-123007BB-6A477B00"
 msgid "Network Widening Mod (NWM) Starter Pieces"
 msgstr ""
 
@@ -761,7 +761,7 @@ msgid ""
 "Button contains Wide-Radius Curve Pieces for the single-tile NWM networks"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477B30"
+msgctxt "2026960B-123007BB-6A477B30"
 msgid "Network Widening Mod (NWM) Curve Pieces"
 msgstr ""
 
@@ -774,7 +774,7 @@ msgid ""
 "Note that most transitions involving single and dual-tile networks can be built using draggable means instead (such as direct connections or using the stub-to-stub method)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477B50"
+msgctxt "2026960B-123007BB-6A477B50"
 msgid "Network Widening Mod (NWM) Transition Pieces"
 msgstr ""
 
@@ -785,7 +785,7 @@ msgid ""
 "Button contains Neighbor Connector Pieces for the TLA-5, RD-4 and RD-6"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477BF0"
+msgctxt "2026960B-123007BB-6A477BF0"
 msgid "Network Widening Mod (NWM) Neighbor Connector Pieces"
 msgstr ""
 
@@ -796,7 +796,7 @@ msgid ""
 "Button contains FLEX Single Tile Roundabouts intersections for various road networks"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477C00"
+msgctxt "2026960B-123007BB-6A477C00"
 msgid "Single Tile Roundabouts"
 msgstr ""
 
@@ -809,7 +809,7 @@ msgid ""
 "Button contains OnSlope Transitions to start Alternate Style Road and Street Viaducts"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477E00"
+msgctxt "2026960B-123007BB-6A477E00"
 msgid "Road Viaduct Alternate Styles"
 msgstr ""
 
@@ -820,7 +820,7 @@ msgid ""
 "Button contains several different Starter and FLEX Pieces for Draggable Elevated Road Viaducts"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477F00"
+msgctxt "2026960B-123007BB-6A477F00"
 msgid "Draggable Elevated Road Viaducts"
 msgstr ""
 
@@ -833,7 +833,7 @@ msgid ""
 "Drag networks under (or over) the mid-section of the overpass to build the crossing.  Most networks and FLEX-based dual-networks are supported."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477F30"
+msgctxt "2026960B-123007BB-6A477F30"
 msgid "FLEX Overpasses"
 msgstr ""
 
@@ -844,7 +844,7 @@ msgid ""
 "Button contains several different overpasses for One-Way Road"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A478000"
+msgctxt "2026960B-123007BB-6A478000"
 msgid "One-Way Road Overpasses"
 msgstr ""
 
@@ -855,7 +855,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for One-Way Road"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A478005"
+msgctxt "2026960B-123007BB-6A478005"
 msgid "15m Elevated One-Way Road Viaducts"
 msgstr ""
 
@@ -866,7 +866,7 @@ msgid ""
 "Button contains pieces to interface between the NAM Elevated One-Way Road Puzzle Pieces and RHW networks, including overpasses and intersections"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A478800"
+msgctxt "2026960B-123007BB-6A478800"
 msgid "One-Way Road/RHW Overpass and Interface Puzzle Pieces (DEPRECATED)"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgctxt "2026960B-123006AA-6A478900"
 msgid "For use of the curved pieces for the Real Expressway Network. Use the Home/End key to rotate the FLEX Piece & use TAB/Shift-TAB (Ctrl-TAB/Ctrl-Shift-TAB on macOS) to cycle through the different types of REW Straights and Curves."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A478900"
+msgctxt "2026960B-123007BB-6A478900"
 msgid "Real Expressway FLEX Piece network tool and Curves."
 msgstr ""
 
@@ -885,7 +885,7 @@ msgid ""
 "Button contains FLEX pieces for different overrideable ramp interfaces.  Drag appropriate networks through to convert base ramp to match."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A478B00"
+msgctxt "2026960B-123007BB-6A478B00"
 msgid "RealExpressway (REW) One-Way Road FLEXRamps"
 msgstr ""
 
@@ -896,7 +896,7 @@ msgid ""
 "Button contains several different overpasses for Avenue"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A479000"
+msgctxt "2026960B-123007BB-6A479000"
 msgid "Avenue Overpasses"
 msgstr ""
 
@@ -907,7 +907,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Avenue"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A479005"
+msgctxt "2026960B-123007BB-6A479005"
 msgid "7.5m Elevated Avenue Viaducts"
 msgstr ""
 
@@ -918,7 +918,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Avenue"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A479200"
+msgctxt "2026960B-123007BB-6A479200"
 msgid "15m Elevated Avenue Viaducts"
 msgstr ""
 
@@ -929,7 +929,7 @@ msgid ""
 "Button contains pieces to interface between the NAM Elevated Avenue Puzzle Pieces and RHW networks, including overpasses and intersections"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A479900"
+msgctxt "2026960B-123007BB-6A479900"
 msgid "Avenue/RHW Overpass and Interface Puzzle Pieces (DEPRECATED)"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgid ""
 "FlexSPUI and Flex Diverging Diamond (FlexDDI) pieces are found under this button"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47991A"
+msgctxt "2026960B-123007BB-6A47991A"
 msgid "Specialized RHW x Surface Intersections"
 msgstr ""
 
@@ -953,7 +953,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Rail."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47A005"
+msgctxt "2026960B-123007BB-6A47A005"
 msgid "Rail Puzzle Pieces"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgctxt "2026960B-123006AA-6A47A130"
 msgid "Button contains FLEX pieces to elevated the Rail network to viaduct level (using the RealRailway (RRW) standard)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47A130"
+msgctxt "2026960B-123007BB-6A47A130"
 msgid "Draggable Elevated Railways (ERRW)"
 msgstr ""
 
@@ -972,7 +972,7 @@ msgid ""
 "Once a puzzle piece is selected, use the [Home] and [End] keys to cycle through the various puzzle piece orientations"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47A358"
+msgctxt "2026960B-123007BB-6A47A358"
 msgid "Wide Radius Railroad Curve and Double Track Rail Switch Puzzle Pieces"
 msgstr ""
 
@@ -983,7 +983,7 @@ msgid ""
 "Once a puzzle piece is selected, use the [Home] and [End] keys to cycle through the various puzzle piece orientations"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47A368"
+msgctxt "2026960B-123007BB-6A47A368"
 msgid "Fractional Angle Railroad (FARR) Puzzle Pieces"
 msgstr ""
 
@@ -994,7 +994,7 @@ msgid ""
 "Button contains pieces to interface between the NAM Elevated Rail Viaduct Puzzle Pieces and RHW networks, including overpasses and intersections"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47A800"
+msgctxt "2026960B-123007BB-6A47A800"
 msgid "Rail Viaduct/RHW Overpass and Interface Puzzle Pieces"
 msgstr ""
 
@@ -1005,7 +1005,7 @@ msgid ""
 "Once a puzzle piece is selected, use the [Home] and [End] keys to cycle through the various puzzle piece orientations"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47A900"
+msgctxt "2026960B-123007BB-6A47A900"
 msgid "Wide Radius Railroad Curve and Double Track Rail Switch Puzzle Pieces"
 msgstr ""
 
@@ -1016,7 +1016,7 @@ msgid ""
 "Button contains several different Pieces for Dual/Double-Decker Networking."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AA0F"
+msgctxt "2026960B-123007BB-6A47AA0F"
 msgid ""
 "Underground Rail\n"
 "Rail Tunnel under Roads Dual Networking Puzzle Pieces"
@@ -1029,7 +1029,7 @@ msgid ""
 "Button contains several different Pieces for Dual/Double-Decker Networking."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AA10"
+msgctxt "2026960B-123007BB-6A47AA10"
 msgid ""
 "Underground Rail\n"
 "Rail Tunnel under Ped Malls Dual Networking Puzzle Pieces"
@@ -1042,7 +1042,7 @@ msgid ""
 "Button contains several different Pieces for Maxis Roadways."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AA11"
+msgctxt "2026960B-123007BB-6A47AA11"
 msgid ""
 "Underground Rail\n"
 "Maxis Roadway Intersection Pieces"
@@ -1055,7 +1055,7 @@ msgid ""
 "Button contains several different Pieces for Railways."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AA12"
+msgctxt "2026960B-123007BB-6A47AA12"
 msgid ""
 "Underground Rail\n"
 "Railway Intersection Pieces"
@@ -1068,7 +1068,7 @@ msgid ""
 "Button contains several different Pieces for Tramways."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AA13"
+msgctxt "2026960B-123007BB-6A47AA13"
 msgid ""
 "Underground Rail\n"
 "Tramway Intersection Pieces"
@@ -1081,7 +1081,7 @@ msgid ""
 "Button contains several different Pieces for Dual/Double-Decker Networking."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AA8A"
+msgctxt "2026960B-123007BB-6A47AA8A"
 msgid ""
 "Underground Rail\n"
 "Miscellaneous Puzzle Pieces"
@@ -1091,7 +1091,7 @@ msgctxt "2026960B-123006AA-6A47AC00"
 msgid "All pieces in this section are FLEX and conform to flextrack standards!"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AC00"
+msgctxt "2026960B-123007BB-6A47AC00"
 msgid "RealRailway FLEX Curve Pieces."
 msgstr ""
 
@@ -1099,7 +1099,7 @@ msgctxt "2026960B-123006AA-6A47AC10"
 msgid "All pieces in this section are FLEX and conform to flextrack standards!"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AC10"
+msgctxt "2026960B-123007BB-6A47AC10"
 msgid "RealRailway FLEX Turnout Pieces."
 msgstr ""
 
@@ -1107,7 +1107,7 @@ msgctxt "2026960B-123006AA-6A47AD00"
 msgid "All pieces in this section are FLEX and conform to flextrack and FARR standards!\n"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AD00"
+msgctxt "2026960B-123007BB-6A47AD00"
 msgid "RealRailway FLEX Fractional Angled (FA) Pieces."
 msgstr ""
 
@@ -1118,7 +1118,7 @@ msgid ""
 "Button contains several different Pieces for Dual/Double-Decker Networking."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47B03A"
+msgctxt "2026960B-123007BB-6A47B03A"
 msgid "ElevatedRail Dual/Double-Decker Network Pieces"
 msgstr ""
 
@@ -1126,7 +1126,7 @@ msgctxt "2026960B-123006AA-6A47B049"
 msgid "These puzzle pieces are to allow you to cross NWM networks with ElRail over Road."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47B049"
+msgctxt "2026960B-123007BB-6A47B049"
 msgid "ElRail over Road NWM Intersections"
 msgstr ""
 
@@ -1137,7 +1137,7 @@ msgid ""
 "The construction lot vanishes automatically. Use the Road Tool to connect the network and to build intersections."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47B060"
+msgctxt "2026960B-123007BB-6A47B060"
 msgid "ElevatedRail over Avenue/Road-4 Puzzle Pieces"
 msgstr ""
 
@@ -1145,7 +1145,7 @@ msgctxt "2026960B-123006AA-6A47B10F"
 msgid "Puzzle Pieces to build a ground level extension of the Elevated Rail network for Light Rail/Trams."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47B10F"
+msgctxt "2026960B-123007BB-6A47B10F"
 msgid "Ground Light Rail (Tram)"
 msgstr ""
 
@@ -1156,7 +1156,7 @@ msgid ""
 "Connect the Elevated Rail network with the Starter Piece. The Elevated Rail will turn into a Ground Light Rail track."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47B3FF"
+msgctxt "2026960B-123007BB-6A47B3FF"
 msgid "Draggable Ground Light Rail (Tram)"
 msgstr ""
 
@@ -1164,7 +1164,7 @@ msgctxt "2026960B-123006AA-6A47B42A"
 msgid "For building Tram-Avenue (= GroundLightRail / Avenue) - Dual Network Pieces."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47B42A"
+msgctxt "2026960B-123007BB-6A47B42A"
 msgid "Tram-Avenue (GroundLightRail / Avenue) - Dual Network Pieces"
 msgstr ""
 
@@ -1175,7 +1175,7 @@ msgid ""
 "These puzzle pieces are designed so that you may plop them first or you may plop them on existing networks."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47B900"
+msgctxt "2026960B-123007BB-6A47B900"
 msgid "High Elevated Rail Puzzle Pieces"
 msgstr ""
 
@@ -1186,7 +1186,7 @@ msgid ""
 "Button contains Tram-in-Road Puzzle Pieces"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47BA00"
+msgctxt "2026960B-123007BB-6A47BA00"
 msgid "Tram-in-Road"
 msgstr ""
 
@@ -1194,7 +1194,7 @@ msgctxt "2026960B-123006AA-6A47BBA0"
 msgid "For utilizing the Tram Puzzle Pieces"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47BBA0"
+msgctxt "2026960B-123007BB-6A47BBA0"
 msgid "Tram-on-Road & texture variations"
 msgstr ""
 
@@ -1202,7 +1202,7 @@ msgctxt "2026960B-123006AA-6A47BC60"
 msgid "For utilizing the Tram Puzzle Pieces"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47BC60"
+msgctxt "2026960B-123007BB-6A47BC60"
 msgid "Tram-on-Street"
 msgstr ""
 
@@ -1213,7 +1213,7 @@ msgid ""
 "Button contains starters for two additional Ground Light Rail styles, plus filler pieces."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47BD00"
+msgctxt "2026960B-123007BB-6A47BD00"
 msgid "Draggable Ground Light Rail (Tram)--Additional Styles"
 msgstr ""
 
@@ -1227,7 +1227,7 @@ msgstr ""
 "\n"
 "Deze knop bevat Starters, Vullers en Overpassage Puzzelstukjes voor Verhoogde Hogesnelheidslijnen (HSR)"
 
-msgctxt "2026960B-123006BB-6A47C000"
+msgctxt "2026960B-123007BB-6A47C000"
 msgid "High Speed Rail (HSR)"
 msgstr "Verhoogde Hogesnelheidslijn (HSR)"
 
@@ -1245,11 +1245,11 @@ msgstr ""
 "\n"
 "GHSR is een verbreding van het HSR-netwerk, dat over de begane grond loopt"
 
-msgctxt "2026960B-123006BB-6A47C200"
+msgctxt "2026960B-123007BB-6A47C200"
 msgid "Ground High Speed Rail (GHSR)"
 msgstr "Hogesnelheidslijn (GHSR)"
 
-msgctxt "2026960B-123006BB-6A47C700"
+msgctxt "2026960B-123007BB-6A47C700"
 msgid "Monorail Wide Radius Curve Puzzle Pieces"
 msgstr ""
 
@@ -1267,7 +1267,7 @@ msgid ""
 "These puzzle pieces are designed so that you may plop them first or you may plop them on existing networks."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47C900"
+msgctxt "2026960B-123007BB-6A47C900"
 msgid "High Monorail Puzzle Pieces"
 msgstr ""
 
@@ -1275,7 +1275,7 @@ msgctxt "2026960B-123006AA-6A47CA00"
 msgid "For building Hybrid Railway straight track sections.  Hybrid Railway carries both normal Rail traffic and High Speed Rail (Monorail) traffic."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47CA00"
+msgctxt "2026960B-123007BB-6A47CA00"
 msgid "Hybrid Railway (Rail-High Speed Rail) Straight Sections"
 msgstr ""
 
@@ -1283,7 +1283,7 @@ msgctxt "2026960B-123006AA-6A47CB00"
 msgid "For building Hybrid Railway curves.  Hybrid Railway carries both normal Rail traffic and High Speed Rail (Monorail) traffic."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47CB00"
+msgctxt "2026960B-123007BB-6A47CB00"
 msgid "Hybrid Railway (Rail-High Speed Rail) Curves"
 msgstr ""
 
@@ -1294,7 +1294,7 @@ msgid ""
 "Hybrid Railway carries both normal Rail traffic and High Speed Rail (Monorail) traffic."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47CD00"
+msgctxt "2026960B-123007BB-6A47CD00"
 msgid "Hybrid Railway (Rail-High Speed Rail) Switches"
 msgstr ""
 
@@ -1305,7 +1305,7 @@ msgid ""
 "Use ground-level Hybrid Railway segments, and connect to the elevated end of the transitions (or to other already elevated sections) to elevate them."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47CE00"
+msgctxt "2026960B-123007BB-6A47CE00"
 msgid "Hybrid Railway (Rail-High Speed Rail) Height Transitions"
 msgstr ""
 
@@ -1313,7 +1313,7 @@ msgctxt "2026960B-123006AA-6A47DC00"
 msgid "Button contains Ground Highway Puzzle Pieces"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47DC00"
+msgctxt "2026960B-123007BB-6A47DC00"
 msgid "Ground Highway Puzzle Pieces"
 msgstr ""
 
@@ -1324,7 +1324,7 @@ msgid ""
 "Button contains Single-Sided Perpendicular Ramps for Elevated Highway"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47E010"
+msgctxt "2026960B-123007BB-6A47E010"
 msgid ""
 "Single-Sided Perpendicular Ramps\n"
 "\n"
@@ -1338,7 +1338,7 @@ msgid ""
 "Button contains Single-Sided Parallel Ramps for both Ground Highway and Elevated Highway"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47E050"
+msgctxt "2026960B-123007BB-6A47E050"
 msgid ""
 "Single-Sided Parallel Ramps\n"
 "\n"
@@ -1349,15 +1349,15 @@ msgctxt "2026960B-123006AA-6A47E100"
 msgid "Button contains Custom Interchanges"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47E100"
+msgctxt "2026960B-123007BB-6A47E100"
 msgid "Custom Interchanges"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47FFFF"
+msgctxt "2026960B-123007BB-6A47FFFF"
 msgid "Network Addon Mod Controller"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A476200"
+msgctxt "2026960B-123007BB-6A476200"
 msgid "Draggable Pedmalls"
 msgstr ""
 

--- a/ltext/pt/buttons.po
+++ b/ltext/pt/buttons.po
@@ -31,7 +31,7 @@ msgid ""
 "Button contains Parallel Ramps for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-52001000"
+msgctxt "2026960B-123007BB-52001000"
 msgid ""
 "Parallel Ramps\n"
 "\n"
@@ -45,7 +45,7 @@ msgid ""
 "Button contains Overpass/Perpendicular Ramps for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-52001010"
+msgctxt "2026960B-123007BB-52001010"
 msgid ""
 "Overpass/Perpendicular Ramps\n"
 "\n"
@@ -59,7 +59,7 @@ msgid ""
 "Button contains Cloverleaves for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-52001020"
+msgctxt "2026960B-123007BB-52001020"
 msgid ""
 "Cloverleaf\n"
 "\n"
@@ -73,7 +73,7 @@ msgid ""
 "Button contains T-Intersections for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-52002000"
+msgctxt "2026960B-123007BB-52002000"
 msgid ""
 "T-Intersections\n"
 "\n"
@@ -84,7 +84,7 @@ msgctxt "2026960B-123006AA-6A470100"
 msgid "With the Canal Addon Mod you can build functional canals"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A470100"
+msgctxt "2026960B-123007BB-6A470100"
 msgid "Canal Addon Mod"
 msgstr ""
 
@@ -96,7 +96,7 @@ msgid ""
 "Drag the listed network through the FLEX/Starter Piece to construct the turn lane."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A470460"
+msgctxt "2026960B-123007BB-6A470460"
 msgid "FLEX Turn Lanes (FTLs)"
 msgstr ""
 
@@ -107,7 +107,7 @@ msgid ""
 "Button contains QuickTurn setups, which are FLEX intersections with turn lanes"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A4704A0"
+msgctxt "2026960B-123007BB-6A4704A0"
 msgid "QuickTurn (Pre-Built FLEX Turn Lane Setups)"
 msgstr ""
 
@@ -118,7 +118,7 @@ msgid ""
 "Button contains Turn Lane and Slip Lane Puzzle Pieces for various networks and configurations"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A4704E0"
+msgctxt "2026960B-123007BB-6A4704E0"
 msgid "TuLEPs (Turn Lane Extension Pieces) (OLD)"
 msgstr ""
 
@@ -129,7 +129,7 @@ msgid ""
 "Button contains Turn Lane puzzle pieces for 7-lane Turning Lane Avenue (TLA-7) and 6-lane Avenue (AVE-6) networks"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A470600"
+msgctxt "2026960B-123007BB-6A470600"
 msgid "Network Widening Mod (NWM) Triple-Tile Network Turn Lane Extension Pieces (TuLEPs)"
 msgstr ""
 
@@ -140,7 +140,7 @@ msgid ""
 "Button contains components for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A473141"
+msgctxt "2026960B-123007BB-6A473141"
 msgid ""
 "Symphony Prefab Interchange Components\n"
 "\n"
@@ -154,7 +154,7 @@ msgid ""
 "Button contains components for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A473143"
+msgctxt "2026960B-123007BB-6A473143"
 msgid ""
 "Symphony Ramp Interfaces\n"
 "\n"
@@ -168,7 +168,7 @@ msgid ""
 "The first item is the starter piece."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A474000"
+msgctxt "2026960B-123007BB-6A474000"
 msgid "Single-Track Rail (STR)"
 msgstr ""
 
@@ -180,7 +180,7 @@ msgid ""
 "Drag the RealHighway (RHW-2) network tool through the Starter Piece to construct the desired override network."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475000"
+msgctxt "2026960B-123007BB-6A475000"
 msgid "RealHighway (RHW) Starter Pieces"
 msgstr ""
 
@@ -195,7 +195,7 @@ msgid ""
 "Place down Eraser onto desired tile and redraw anything if needed"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475024"
+msgctxt "2026960B-123007BB-6A475024"
 msgid "Network Eraser"
 msgstr ""
 
@@ -206,7 +206,7 @@ msgid ""
 "Button contains Filler Pieces to build RHW networks in smaller chunks, in unstable situations"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475050"
+msgctxt "2026960B-123007BB-6A475050"
 msgid "RealHighway Filler Pieces"
 msgstr ""
 
@@ -219,7 +219,7 @@ msgid ""
 "These items are DEPRECATED, and the use of the FLEX Neighbor Connections is recommended instead."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47508C"
+msgctxt "2026960B-123007BB-6A47508C"
 msgid "Old RealHighway Neighbor Connector Puzzle Pieces  - DEPRECATED"
 msgstr ""
 
@@ -232,7 +232,7 @@ msgid ""
 "NOTE: ALL REALHIGHWAY NEIGHBOR CONNECTIONS (EXCEPT RHW-2) ARE REQUIRED TO USE NEIGHBOR CONNECTOR PIECES TO ENSURE PROPERLY FUNCTIONING NEIGHBOR CONNECTIONS--OTHERWISE ONLY FREIGHT TRUCKS WILL USE THE RHW"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475090"
+msgctxt "2026960B-123007BB-6A475090"
 msgid "RealHighway FLEX Neighbor Connector Pieces (FLEX-NC)"
 msgstr ""
 
@@ -240,7 +240,7 @@ msgctxt "2026960B-123006AA-6A475100"
 msgid "For building DEPRECATED RealHighway Ramp Interfaces.  All of the functionality of the 47 pieces contained and many more are covered by the FLEXRamp system."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475100"
+msgctxt "2026960B-123007BB-6A475100"
 msgid "OBSOLETE RealHighway Ramp Interfaces (Static Puzzle-Based)"
 msgstr ""
 
@@ -251,7 +251,7 @@ msgid ""
 "Button contains Type B Ramp Interface Pieces for building interchanges with the RHW"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475104"
+msgctxt "2026960B-123007BB-6A475104"
 msgid "RealHighway Type B Ramp Interfaces"
 msgstr ""
 
@@ -262,7 +262,7 @@ msgid ""
 "Button contains Type E Ramp Interface Pieces for building interchanges with the RHW"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475109"
+msgctxt "2026960B-123007BB-6A475109"
 msgid "RealHighway Type E Ramp Interfaces"
 msgstr ""
 
@@ -273,7 +273,7 @@ msgid ""
 "Button contains Type D Ramp Interface Pieces for building interchanges with the RHW"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47510A"
+msgctxt "2026960B-123007BB-6A47510A"
 msgid "RealHighway Type D Ramp Interfaces"
 msgstr ""
 
@@ -284,7 +284,7 @@ msgid ""
 "Deprecated puzzle piece ramps follow Volleyball pieces - use of the FLEXRamps or Draggable Ramp Interfaces (DRIs) is recommended instead of using the deprecated puzzle pieces."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475118"
+msgctxt "2026960B-123007BB-6A475118"
 msgid "Specialized and Deprecated RealHighway Ramp Interfaces and Volleyball Crossings (Static Puzzle-Based)"
 msgstr ""
 
@@ -295,7 +295,7 @@ msgid ""
 "Button contains FLEX pieces for different overrideable ramp interfaces.  Drag appropriate networks through to convert base ramp to match."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A4751F0"
+msgctxt "2026960B-123007BB-6A4751F0"
 msgid "RealHighway FLEXRamps"
 msgstr ""
 
@@ -306,7 +306,7 @@ msgid ""
 "Button contains pieces to build Wide Curves for the RHW networks"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475220"
+msgctxt "2026960B-123007BB-6A475220"
 msgid "RealHighway Wide-Radius and Multi-Radius (Smooth) Curves"
 msgstr ""
 
@@ -319,7 +319,7 @@ msgid ""
 "These items are DEPRECATED and use of the FLEX Width Transitions (FLEX-WT) is recommended instead."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475300"
+msgctxt "2026960B-123007BB-6A475300"
 msgid "Old RealHighway Width Transition Puzzle Pieces - DEPRECATED"
 msgstr ""
 
@@ -332,7 +332,7 @@ msgid ""
 "All functionality here has been duplicated with the FLEX Height Transitions, and as such, this button is DEPRECATED."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475312"
+msgctxt "2026960B-123007BB-6A475312"
 msgid "Old RealHighway Height Transition Puzzle Pieces  - DEPRECATED"
 msgstr ""
 
@@ -343,7 +343,7 @@ msgid ""
 "Button contains pieces to transition between RHW networks of different heights.  Pieces begin as RHW-2 transitions, and dragging another RHW network into them will convert them to fit."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475330"
+msgctxt "2026960B-123007BB-6A475330"
 msgid "RealHighway FLEX Height Transitions (FLEX-HT)"
 msgstr ""
 
@@ -354,7 +354,7 @@ msgid ""
 "Button contains pieces to transition between RHW networks of different widths.  Dragging another RHW network into them will convert them to fit."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475336"
+msgctxt "2026960B-123007BB-6A475336"
 msgid "RealHighway FLEX Width Transitions (FLEX-WT)"
 msgstr ""
 
@@ -365,7 +365,7 @@ msgid ""
 "Button contains components for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475350"
+msgctxt "2026960B-123007BB-6A475350"
 msgid ""
 "Symphony Transitions\n"
 "\n"
@@ -379,7 +379,7 @@ msgid ""
 "Button contains components for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475366"
+msgctxt "2026960B-123007BB-6A475366"
 msgid ""
 "Symphony Smooth Curves\n"
 "\n"
@@ -395,7 +395,7 @@ msgid ""
 "NOTE: These pieces should NOT be confused with TuLEPs."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475400"
+msgctxt "2026960B-123007BB-6A475400"
 msgid "RealHighway Cosmetic Puzzle Pieces (for 1-Tile Networks)"
 msgstr ""
 
@@ -408,7 +408,7 @@ msgid ""
 "NOTE: These pieces should NOT be confused with TuLEPs."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475410"
+msgctxt "2026960B-123007BB-6A475410"
 msgid "RealHighway Cosmetic Piece Transitions"
 msgstr ""
 
@@ -421,7 +421,7 @@ msgid ""
 "NOTE: These pieces should NOT be confused with TuLEPs."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475440"
+msgctxt "2026960B-123007BB-6A475440"
 msgid "RealHighway Cosmetic Puzzle Pieces (for 2-Tile Networks)"
 msgstr ""
 
@@ -434,7 +434,7 @@ msgid ""
 "NOTE: These pieces should NOT be confused with TuLEPs."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475471"
+msgctxt "2026960B-123007BB-6A475471"
 msgid "RealHighway Cosmetic Puzzle Pieces (for 3-Tile Networks)"
 msgstr ""
 
@@ -447,7 +447,7 @@ msgid ""
 "<DEPRECATED>"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475500"
+msgctxt "2026960B-123007BB-6A475500"
 msgid "ERHW-over-RHW Diagonal Overpass Puzzle Pieces<DEPRECATED>"
 msgstr ""
 
@@ -460,7 +460,7 @@ msgid ""
 "Place overcrossing pieces on top of underground roadways whenever a surface network crosses over, to allow traffic to pass underground."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475600"
+msgctxt "2026960B-123007BB-6A475600"
 msgid "RHW Flexible Underpasses (FLUPs), Draggable Underground Roads (URoads), and Overcrossings"
 msgstr ""
 
@@ -471,7 +471,7 @@ msgid ""
 "Button contains flexible RHW interchange segments.  Drag appropriate networks through to convert base ramp to match, and combine to easily create a full interchange."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475700"
+msgctxt "2026960B-123007BB-6A475700"
 msgid "RealHighway QuickChanges"
 msgstr ""
 
@@ -482,7 +482,7 @@ msgid ""
 "Button contains starter/transition FLEX pieces for different RHW turn lane setups"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475900"
+msgctxt "2026960B-123007BB-6A475900"
 msgid "RealHighway FLEX Turn Lanes (FTLs)"
 msgstr ""
 
@@ -493,7 +493,7 @@ msgid ""
 "Button contains pieces to build FLEXFly Pieces"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475AF3"
+msgctxt "2026960B-123007BB-6A475AF3"
 msgid "RealHighway FLEXFly (LEGACY/DEPRECATED)"
 msgstr ""
 
@@ -504,7 +504,7 @@ msgid ""
 "Button contains pieces to build 3-Level Crossings"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475AF6"
+msgctxt "2026960B-123007BB-6A475AF6"
 msgid "RealHighway 3-Level Crossings"
 msgstr ""
 
@@ -515,7 +515,7 @@ msgid ""
 "Button contains pieces to build FLEXFly Pieces"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475B00"
+msgctxt "2026960B-123007BB-6A475B00"
 msgid "RealHighway FLEXFly"
 msgstr ""
 
@@ -528,7 +528,7 @@ msgid ""
 "NOTE: Most intersections require the use of TuLEPs."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475F00"
+msgctxt "2026960B-123007BB-6A475F00"
 msgid "Fractionally Angled RealHighway Intersections and Transitions"
 msgstr ""
 
@@ -539,7 +539,7 @@ msgid ""
 "Button contains straight pieces and curves to pieces to build Fractionally Angled RealHighway (FARHWs)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475F20"
+msgctxt "2026960B-123007BB-6A475F20"
 msgid "Fractionally Angled RealHighway"
 msgstr ""
 
@@ -550,7 +550,7 @@ msgid ""
 "Button contains pieces to build different FARHW Ramp Interfaces: The C1, F1, C2, F2, and C3 Ramp Interfaces"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475F30"
+msgctxt "2026960B-123007BB-6A475F30"
 msgid "Fractionally Angled RealHighway Ramp Interfaces"
 msgstr ""
 
@@ -561,7 +561,7 @@ msgid ""
 "Button contains Type C Ramp Interface Pieces for building interchanges with the RHW"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475F70"
+msgctxt "2026960B-123007BB-6A475F70"
 msgid "RealHighway Type C Ramp Interfaces"
 msgstr ""
 
@@ -572,7 +572,7 @@ msgid ""
 "Button contains Type F Ramp Interface Pieces for building interchanges with the RHW"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475F71"
+msgctxt "2026960B-123007BB-6A475F71"
 msgid "RealHighway Type F Ramp Interfaces"
 msgstr ""
 
@@ -585,7 +585,7 @@ msgid ""
 "NOTE: Ped Mall Tiles should not be used directly in front of Residential Zones where their zoning arrow is."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A476005"
+msgctxt "2026960B-123007BB-6A476005"
 msgid "Pedestrian Mall Tiles"
 msgstr ""
 
@@ -593,7 +593,7 @@ msgctxt "2026960B-123006AA-6A476100"
 msgid "A collection of pedestrian crossing FLEX pieces. Use them on their own at crossing locations, or as part of pedmall corridors."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A476100"
+msgctxt "2026960B-123007BB-6A476100"
 msgid "Pedestrian Revolution Mod (PRM) FLEX Crossings"
 msgstr ""
 
@@ -604,7 +604,7 @@ msgid ""
 "Button contains several different Puzzle and Helper Pieces for Street"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A476525"
+msgctxt "2026960B-123007BB-6A476525"
 msgid "Diagonal Street Helper Pieces"
 msgstr ""
 
@@ -615,7 +615,7 @@ msgid ""
 "Button contains Starter Pieces for Street Addon Mod (SAM)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A476700"
+msgctxt "2026960B-123007BB-6A476700"
 msgid "Street Addon Mod (SAM)"
 msgstr ""
 
@@ -623,7 +623,7 @@ msgctxt "2026960B-123006AA-6A476905"
 msgid "Plop one of these pieces on a flat area. It will raise or lower the terrain, and then destroy itself, providing a level area for a raised network of your choice. This is fully compatible with all slope mods."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A476905"
+msgctxt "2026960B-123007BB-6A476905"
 msgid "Hole Digger and Raiser Lots"
 msgstr ""
 
@@ -634,7 +634,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Avenues"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A476A00"
+msgctxt "2026960B-123007BB-6A476A00"
 msgid "Avenue Intersections"
 msgstr ""
 
@@ -645,7 +645,7 @@ msgid ""
 "Button contains several different overpasses for Road"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477000"
+msgctxt "2026960B-123007BB-6A477000"
 msgid "Road Overpasses"
 msgstr ""
 
@@ -656,7 +656,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Road"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477005"
+msgctxt "2026960B-123007BB-6A477005"
 msgid "7.5m Elevated Road Viaducts"
 msgstr ""
 
@@ -667,7 +667,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Road"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477200"
+msgctxt "2026960B-123007BB-6A477200"
 msgid "15m Elevated Road Viaducts"
 msgstr ""
 
@@ -678,7 +678,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Road, One-Way Road, or Avenue"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477500"
+msgctxt "2026960B-123007BB-6A477500"
 msgid "Wide Radius Curves (for Road, One-Way Road, Avenue, and Street) (Puzzle Pieces)"
 msgstr ""
 
@@ -689,7 +689,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Road, One-Way Road, and Avenue"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477600"
+msgctxt "2026960B-123007BB-6A477600"
 msgid "Fractionally-Angled Networks (for Road, One-Way Road, and Avenue)"
 msgstr ""
 
@@ -700,7 +700,7 @@ msgid ""
 "Once a puzzle piece is selected, use the [Home] and [End] keys to cycle through the various puzzle piece orientations"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477700"
+msgctxt "2026960B-123007BB-6A477700"
 msgid "Rural Road Puzzle Pieces"
 msgstr ""
 
@@ -711,7 +711,7 @@ msgid ""
 "Button contains pieces to interface between the NAM Elevated Road Puzzle Pieces and RHW networks, including overpasses and intersections"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477800"
+msgctxt "2026960B-123007BB-6A477800"
 msgid "Road/RHW Overpass and Interface Puzzle Pieces (DEPRECATED)"
 msgstr ""
 
@@ -722,7 +722,7 @@ msgid ""
 "Button contains several different FLEX Pieces for various networks"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477900"
+msgctxt "2026960B-123007BB-6A477900"
 msgid "Multi-Radius Curve (MRC) FLEX Pieces for Surface Networks"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgid ""
 "The new Subway-based FLUPs system can be found under the Highways menu."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477A00"
+msgctxt "2026960B-123007BB-6A477A00"
 msgid "Flexible Underpasses (FLUPs)"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgid ""
 "Button contains Starter Pieces for the 3, 5 and 7-lane Turning Lane Avenues (TLA-3,5,7), 2 and 6-lane Avenues (AVE-2,6), 3-lane Asymmetrical Road (ARD-3), 4 and 6-lane Roads RD-4,6) and 1, 3, 4 and 5-lane One-Way Roads (OWR-1,3,4,5)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477B00"
+msgctxt "2026960B-123007BB-6A477B00"
 msgid "Network Widening Mod (NWM) Starter Pieces"
 msgstr ""
 
@@ -761,7 +761,7 @@ msgid ""
 "Button contains Wide-Radius Curve Pieces for the single-tile NWM networks"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477B30"
+msgctxt "2026960B-123007BB-6A477B30"
 msgid "Network Widening Mod (NWM) Curve Pieces"
 msgstr ""
 
@@ -774,7 +774,7 @@ msgid ""
 "Note that most transitions involving single and dual-tile networks can be built using draggable means instead (such as direct connections or using the stub-to-stub method)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477B50"
+msgctxt "2026960B-123007BB-6A477B50"
 msgid "Network Widening Mod (NWM) Transition Pieces"
 msgstr ""
 
@@ -785,7 +785,7 @@ msgid ""
 "Button contains Neighbor Connector Pieces for the TLA-5, RD-4 and RD-6"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477BF0"
+msgctxt "2026960B-123007BB-6A477BF0"
 msgid "Network Widening Mod (NWM) Neighbor Connector Pieces"
 msgstr ""
 
@@ -796,7 +796,7 @@ msgid ""
 "Button contains FLEX Single Tile Roundabouts intersections for various road networks"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477C00"
+msgctxt "2026960B-123007BB-6A477C00"
 msgid "Single Tile Roundabouts"
 msgstr ""
 
@@ -809,7 +809,7 @@ msgid ""
 "Button contains OnSlope Transitions to start Alternate Style Road and Street Viaducts"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477E00"
+msgctxt "2026960B-123007BB-6A477E00"
 msgid "Road Viaduct Alternate Styles"
 msgstr ""
 
@@ -820,7 +820,7 @@ msgid ""
 "Button contains several different Starter and FLEX Pieces for Draggable Elevated Road Viaducts"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477F00"
+msgctxt "2026960B-123007BB-6A477F00"
 msgid "Draggable Elevated Road Viaducts"
 msgstr ""
 
@@ -833,7 +833,7 @@ msgid ""
 "Drag networks under (or over) the mid-section of the overpass to build the crossing.  Most networks and FLEX-based dual-networks are supported."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477F30"
+msgctxt "2026960B-123007BB-6A477F30"
 msgid "FLEX Overpasses"
 msgstr ""
 
@@ -844,7 +844,7 @@ msgid ""
 "Button contains several different overpasses for One-Way Road"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A478000"
+msgctxt "2026960B-123007BB-6A478000"
 msgid "One-Way Road Overpasses"
 msgstr ""
 
@@ -855,7 +855,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for One-Way Road"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A478005"
+msgctxt "2026960B-123007BB-6A478005"
 msgid "15m Elevated One-Way Road Viaducts"
 msgstr ""
 
@@ -866,7 +866,7 @@ msgid ""
 "Button contains pieces to interface between the NAM Elevated One-Way Road Puzzle Pieces and RHW networks, including overpasses and intersections"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A478800"
+msgctxt "2026960B-123007BB-6A478800"
 msgid "One-Way Road/RHW Overpass and Interface Puzzle Pieces (DEPRECATED)"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgctxt "2026960B-123006AA-6A478900"
 msgid "For use of the curved pieces for the Real Expressway Network. Use the Home/End key to rotate the FLEX Piece & use TAB/Shift-TAB (Ctrl-TAB/Ctrl-Shift-TAB on macOS) to cycle through the different types of REW Straights and Curves."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A478900"
+msgctxt "2026960B-123007BB-6A478900"
 msgid "Real Expressway FLEX Piece network tool and Curves."
 msgstr ""
 
@@ -885,7 +885,7 @@ msgid ""
 "Button contains FLEX pieces for different overrideable ramp interfaces.  Drag appropriate networks through to convert base ramp to match."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A478B00"
+msgctxt "2026960B-123007BB-6A478B00"
 msgid "RealExpressway (REW) One-Way Road FLEXRamps"
 msgstr ""
 
@@ -896,7 +896,7 @@ msgid ""
 "Button contains several different overpasses for Avenue"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A479000"
+msgctxt "2026960B-123007BB-6A479000"
 msgid "Avenue Overpasses"
 msgstr ""
 
@@ -907,7 +907,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Avenue"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A479005"
+msgctxt "2026960B-123007BB-6A479005"
 msgid "7.5m Elevated Avenue Viaducts"
 msgstr ""
 
@@ -918,7 +918,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Avenue"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A479200"
+msgctxt "2026960B-123007BB-6A479200"
 msgid "15m Elevated Avenue Viaducts"
 msgstr ""
 
@@ -929,7 +929,7 @@ msgid ""
 "Button contains pieces to interface between the NAM Elevated Avenue Puzzle Pieces and RHW networks, including overpasses and intersections"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A479900"
+msgctxt "2026960B-123007BB-6A479900"
 msgid "Avenue/RHW Overpass and Interface Puzzle Pieces (DEPRECATED)"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgid ""
 "FlexSPUI and Flex Diverging Diamond (FlexDDI) pieces are found under this button"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47991A"
+msgctxt "2026960B-123007BB-6A47991A"
 msgid "Specialized RHW x Surface Intersections"
 msgstr ""
 
@@ -953,7 +953,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Rail."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47A005"
+msgctxt "2026960B-123007BB-6A47A005"
 msgid "Rail Puzzle Pieces"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgctxt "2026960B-123006AA-6A47A130"
 msgid "Button contains FLEX pieces to elevated the Rail network to viaduct level (using the RealRailway (RRW) standard)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47A130"
+msgctxt "2026960B-123007BB-6A47A130"
 msgid "Draggable Elevated Railways (ERRW)"
 msgstr ""
 
@@ -972,7 +972,7 @@ msgid ""
 "Once a puzzle piece is selected, use the [Home] and [End] keys to cycle through the various puzzle piece orientations"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47A358"
+msgctxt "2026960B-123007BB-6A47A358"
 msgid "Wide Radius Railroad Curve and Double Track Rail Switch Puzzle Pieces"
 msgstr ""
 
@@ -983,7 +983,7 @@ msgid ""
 "Once a puzzle piece is selected, use the [Home] and [End] keys to cycle through the various puzzle piece orientations"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47A368"
+msgctxt "2026960B-123007BB-6A47A368"
 msgid "Fractional Angle Railroad (FARR) Puzzle Pieces"
 msgstr ""
 
@@ -994,7 +994,7 @@ msgid ""
 "Button contains pieces to interface between the NAM Elevated Rail Viaduct Puzzle Pieces and RHW networks, including overpasses and intersections"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47A800"
+msgctxt "2026960B-123007BB-6A47A800"
 msgid "Rail Viaduct/RHW Overpass and Interface Puzzle Pieces"
 msgstr ""
 
@@ -1005,7 +1005,7 @@ msgid ""
 "Once a puzzle piece is selected, use the [Home] and [End] keys to cycle through the various puzzle piece orientations"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47A900"
+msgctxt "2026960B-123007BB-6A47A900"
 msgid "Wide Radius Railroad Curve and Double Track Rail Switch Puzzle Pieces"
 msgstr ""
 
@@ -1016,7 +1016,7 @@ msgid ""
 "Button contains several different Pieces for Dual/Double-Decker Networking."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AA0F"
+msgctxt "2026960B-123007BB-6A47AA0F"
 msgid ""
 "Underground Rail\n"
 "Rail Tunnel under Roads Dual Networking Puzzle Pieces"
@@ -1029,7 +1029,7 @@ msgid ""
 "Button contains several different Pieces for Dual/Double-Decker Networking."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AA10"
+msgctxt "2026960B-123007BB-6A47AA10"
 msgid ""
 "Underground Rail\n"
 "Rail Tunnel under Ped Malls Dual Networking Puzzle Pieces"
@@ -1042,7 +1042,7 @@ msgid ""
 "Button contains several different Pieces for Maxis Roadways."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AA11"
+msgctxt "2026960B-123007BB-6A47AA11"
 msgid ""
 "Underground Rail\n"
 "Maxis Roadway Intersection Pieces"
@@ -1055,7 +1055,7 @@ msgid ""
 "Button contains several different Pieces for Railways."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AA12"
+msgctxt "2026960B-123007BB-6A47AA12"
 msgid ""
 "Underground Rail\n"
 "Railway Intersection Pieces"
@@ -1068,7 +1068,7 @@ msgid ""
 "Button contains several different Pieces for Tramways."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AA13"
+msgctxt "2026960B-123007BB-6A47AA13"
 msgid ""
 "Underground Rail\n"
 "Tramway Intersection Pieces"
@@ -1081,7 +1081,7 @@ msgid ""
 "Button contains several different Pieces for Dual/Double-Decker Networking."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AA8A"
+msgctxt "2026960B-123007BB-6A47AA8A"
 msgid ""
 "Underground Rail\n"
 "Miscellaneous Puzzle Pieces"
@@ -1091,7 +1091,7 @@ msgctxt "2026960B-123006AA-6A47AC00"
 msgid "All pieces in this section are FLEX and conform to flextrack standards!"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AC00"
+msgctxt "2026960B-123007BB-6A47AC00"
 msgid "RealRailway FLEX Curve Pieces."
 msgstr ""
 
@@ -1099,7 +1099,7 @@ msgctxt "2026960B-123006AA-6A47AC10"
 msgid "All pieces in this section are FLEX and conform to flextrack standards!"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AC10"
+msgctxt "2026960B-123007BB-6A47AC10"
 msgid "RealRailway FLEX Turnout Pieces."
 msgstr ""
 
@@ -1107,7 +1107,7 @@ msgctxt "2026960B-123006AA-6A47AD00"
 msgid "All pieces in this section are FLEX and conform to flextrack and FARR standards!\n"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AD00"
+msgctxt "2026960B-123007BB-6A47AD00"
 msgid "RealRailway FLEX Fractional Angled (FA) Pieces."
 msgstr ""
 
@@ -1118,7 +1118,7 @@ msgid ""
 "Button contains several different Pieces for Dual/Double-Decker Networking."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47B03A"
+msgctxt "2026960B-123007BB-6A47B03A"
 msgid "ElevatedRail Dual/Double-Decker Network Pieces"
 msgstr ""
 
@@ -1126,7 +1126,7 @@ msgctxt "2026960B-123006AA-6A47B049"
 msgid "These puzzle pieces are to allow you to cross NWM networks with ElRail over Road."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47B049"
+msgctxt "2026960B-123007BB-6A47B049"
 msgid "ElRail over Road NWM Intersections"
 msgstr ""
 
@@ -1137,7 +1137,7 @@ msgid ""
 "The construction lot vanishes automatically. Use the Road Tool to connect the network and to build intersections."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47B060"
+msgctxt "2026960B-123007BB-6A47B060"
 msgid "ElevatedRail over Avenue/Road-4 Puzzle Pieces"
 msgstr ""
 
@@ -1145,7 +1145,7 @@ msgctxt "2026960B-123006AA-6A47B10F"
 msgid "Puzzle Pieces to build a ground level extension of the Elevated Rail network for Light Rail/Trams."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47B10F"
+msgctxt "2026960B-123007BB-6A47B10F"
 msgid "Ground Light Rail (Tram)"
 msgstr ""
 
@@ -1156,7 +1156,7 @@ msgid ""
 "Connect the Elevated Rail network with the Starter Piece. The Elevated Rail will turn into a Ground Light Rail track."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47B3FF"
+msgctxt "2026960B-123007BB-6A47B3FF"
 msgid "Draggable Ground Light Rail (Tram)"
 msgstr ""
 
@@ -1164,7 +1164,7 @@ msgctxt "2026960B-123006AA-6A47B42A"
 msgid "For building Tram-Avenue (= GroundLightRail / Avenue) - Dual Network Pieces."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47B42A"
+msgctxt "2026960B-123007BB-6A47B42A"
 msgid "Tram-Avenue (GroundLightRail / Avenue) - Dual Network Pieces"
 msgstr ""
 
@@ -1175,7 +1175,7 @@ msgid ""
 "These puzzle pieces are designed so that you may plop them first or you may plop them on existing networks."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47B900"
+msgctxt "2026960B-123007BB-6A47B900"
 msgid "High Elevated Rail Puzzle Pieces"
 msgstr ""
 
@@ -1186,7 +1186,7 @@ msgid ""
 "Button contains Tram-in-Road Puzzle Pieces"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47BA00"
+msgctxt "2026960B-123007BB-6A47BA00"
 msgid "Tram-in-Road"
 msgstr ""
 
@@ -1194,7 +1194,7 @@ msgctxt "2026960B-123006AA-6A47BBA0"
 msgid "For utilizing the Tram Puzzle Pieces"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47BBA0"
+msgctxt "2026960B-123007BB-6A47BBA0"
 msgid "Tram-on-Road & texture variations"
 msgstr ""
 
@@ -1202,7 +1202,7 @@ msgctxt "2026960B-123006AA-6A47BC60"
 msgid "For utilizing the Tram Puzzle Pieces"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47BC60"
+msgctxt "2026960B-123007BB-6A47BC60"
 msgid "Tram-on-Street"
 msgstr ""
 
@@ -1213,7 +1213,7 @@ msgid ""
 "Button contains starters for two additional Ground Light Rail styles, plus filler pieces."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47BD00"
+msgctxt "2026960B-123007BB-6A47BD00"
 msgid "Draggable Ground Light Rail (Tram)--Additional Styles"
 msgstr ""
 
@@ -1224,7 +1224,7 @@ msgid ""
 "Button contains Starter, Filler and Overpass Puzzle Pieces for High Speed Rail (HSR)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47C000"
+msgctxt "2026960B-123007BB-6A47C000"
 msgid "High Speed Rail (HSR)"
 msgstr ""
 
@@ -1237,11 +1237,11 @@ msgid ""
 "GHSR is a ground level extension of High Speed Rail (HSR)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47C200"
+msgctxt "2026960B-123007BB-6A47C200"
 msgid "Ground High Speed Rail (GHSR)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47C700"
+msgctxt "2026960B-123007BB-6A47C700"
 msgid "Monorail Wide Radius Curve Puzzle Pieces"
 msgstr ""
 
@@ -1259,7 +1259,7 @@ msgid ""
 "These puzzle pieces are designed so that you may plop them first or you may plop them on existing networks."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47C900"
+msgctxt "2026960B-123007BB-6A47C900"
 msgid "High Monorail Puzzle Pieces"
 msgstr ""
 
@@ -1267,7 +1267,7 @@ msgctxt "2026960B-123006AA-6A47CA00"
 msgid "For building Hybrid Railway straight track sections.  Hybrid Railway carries both normal Rail traffic and High Speed Rail (Monorail) traffic."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47CA00"
+msgctxt "2026960B-123007BB-6A47CA00"
 msgid "Hybrid Railway (Rail-High Speed Rail) Straight Sections"
 msgstr ""
 
@@ -1275,7 +1275,7 @@ msgctxt "2026960B-123006AA-6A47CB00"
 msgid "For building Hybrid Railway curves.  Hybrid Railway carries both normal Rail traffic and High Speed Rail (Monorail) traffic."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47CB00"
+msgctxt "2026960B-123007BB-6A47CB00"
 msgid "Hybrid Railway (Rail-High Speed Rail) Curves"
 msgstr ""
 
@@ -1286,7 +1286,7 @@ msgid ""
 "Hybrid Railway carries both normal Rail traffic and High Speed Rail (Monorail) traffic."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47CD00"
+msgctxt "2026960B-123007BB-6A47CD00"
 msgid "Hybrid Railway (Rail-High Speed Rail) Switches"
 msgstr ""
 
@@ -1297,7 +1297,7 @@ msgid ""
 "Use ground-level Hybrid Railway segments, and connect to the elevated end of the transitions (or to other already elevated sections) to elevate them."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47CE00"
+msgctxt "2026960B-123007BB-6A47CE00"
 msgid "Hybrid Railway (Rail-High Speed Rail) Height Transitions"
 msgstr ""
 
@@ -1305,7 +1305,7 @@ msgctxt "2026960B-123006AA-6A47DC00"
 msgid "Button contains Ground Highway Puzzle Pieces"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47DC00"
+msgctxt "2026960B-123007BB-6A47DC00"
 msgid "Ground Highway Puzzle Pieces"
 msgstr ""
 
@@ -1316,7 +1316,7 @@ msgid ""
 "Button contains Single-Sided Perpendicular Ramps for Elevated Highway"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47E010"
+msgctxt "2026960B-123007BB-6A47E010"
 msgid ""
 "Single-Sided Perpendicular Ramps\n"
 "\n"
@@ -1330,7 +1330,7 @@ msgid ""
 "Button contains Single-Sided Parallel Ramps for both Ground Highway and Elevated Highway"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47E050"
+msgctxt "2026960B-123007BB-6A47E050"
 msgid ""
 "Single-Sided Parallel Ramps\n"
 "\n"
@@ -1341,15 +1341,15 @@ msgctxt "2026960B-123006AA-6A47E100"
 msgid "Button contains Custom Interchanges"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47E100"
+msgctxt "2026960B-123007BB-6A47E100"
 msgid "Custom Interchanges"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47FFFF"
+msgctxt "2026960B-123007BB-6A47FFFF"
 msgid "Network Addon Mod Controller"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A476200"
+msgctxt "2026960B-123007BB-6A476200"
 msgid "Draggable Pedmalls"
 msgstr ""
 

--- a/ltext/sv/buttons.po
+++ b/ltext/sv/buttons.po
@@ -31,7 +31,7 @@ msgid ""
 "Button contains Parallel Ramps for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-52001000"
+msgctxt "2026960B-123007BB-52001000"
 msgid ""
 "Parallel Ramps\n"
 "\n"
@@ -45,7 +45,7 @@ msgid ""
 "Button contains Overpass/Perpendicular Ramps for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-52001010"
+msgctxt "2026960B-123007BB-52001010"
 msgid ""
 "Overpass/Perpendicular Ramps\n"
 "\n"
@@ -59,7 +59,7 @@ msgid ""
 "Button contains Cloverleaves for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-52001020"
+msgctxt "2026960B-123007BB-52001020"
 msgid ""
 "Cloverleaf\n"
 "\n"
@@ -73,7 +73,7 @@ msgid ""
 "Button contains T-Intersections for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-52002000"
+msgctxt "2026960B-123007BB-52002000"
 msgid ""
 "T-Intersections\n"
 "\n"
@@ -84,7 +84,7 @@ msgctxt "2026960B-123006AA-6A470100"
 msgid "With the Canal Addon Mod you can build functional canals"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A470100"
+msgctxt "2026960B-123007BB-6A470100"
 msgid "Canal Addon Mod"
 msgstr ""
 
@@ -96,7 +96,7 @@ msgid ""
 "Drag the listed network through the FLEX/Starter Piece to construct the turn lane."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A470460"
+msgctxt "2026960B-123007BB-6A470460"
 msgid "FLEX Turn Lanes (FTLs)"
 msgstr ""
 
@@ -107,7 +107,7 @@ msgid ""
 "Button contains QuickTurn setups, which are FLEX intersections with turn lanes"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A4704A0"
+msgctxt "2026960B-123007BB-6A4704A0"
 msgid "QuickTurn (Pre-Built FLEX Turn Lane Setups)"
 msgstr ""
 
@@ -118,7 +118,7 @@ msgid ""
 "Button contains Turn Lane and Slip Lane Puzzle Pieces for various networks and configurations"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A4704E0"
+msgctxt "2026960B-123007BB-6A4704E0"
 msgid "TuLEPs (Turn Lane Extension Pieces) (OLD)"
 msgstr ""
 
@@ -129,7 +129,7 @@ msgid ""
 "Button contains Turn Lane puzzle pieces for 7-lane Turning Lane Avenue (TLA-7) and 6-lane Avenue (AVE-6) networks"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A470600"
+msgctxt "2026960B-123007BB-6A470600"
 msgid "Network Widening Mod (NWM) Triple-Tile Network Turn Lane Extension Pieces (TuLEPs)"
 msgstr ""
 
@@ -140,7 +140,7 @@ msgid ""
 "Button contains components for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A473141"
+msgctxt "2026960B-123007BB-6A473141"
 msgid ""
 "Symphony Prefab Interchange Components\n"
 "\n"
@@ -154,7 +154,7 @@ msgid ""
 "Button contains components for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A473143"
+msgctxt "2026960B-123007BB-6A473143"
 msgid ""
 "Symphony Ramp Interfaces\n"
 "\n"
@@ -168,7 +168,7 @@ msgid ""
 "The first item is the starter piece."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A474000"
+msgctxt "2026960B-123007BB-6A474000"
 msgid "Single-Track Rail (STR)"
 msgstr ""
 
@@ -180,7 +180,7 @@ msgid ""
 "Drag the RealHighway (RHW-2) network tool through the Starter Piece to construct the desired override network."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475000"
+msgctxt "2026960B-123007BB-6A475000"
 msgid "RealHighway (RHW) Starter Pieces"
 msgstr ""
 
@@ -195,7 +195,7 @@ msgid ""
 "Place down Eraser onto desired tile and redraw anything if needed"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475024"
+msgctxt "2026960B-123007BB-6A475024"
 msgid "Network Eraser"
 msgstr ""
 
@@ -206,7 +206,7 @@ msgid ""
 "Button contains Filler Pieces to build RHW networks in smaller chunks, in unstable situations"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475050"
+msgctxt "2026960B-123007BB-6A475050"
 msgid "RealHighway Filler Pieces"
 msgstr ""
 
@@ -219,7 +219,7 @@ msgid ""
 "These items are DEPRECATED, and the use of the FLEX Neighbor Connections is recommended instead."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47508C"
+msgctxt "2026960B-123007BB-6A47508C"
 msgid "Old RealHighway Neighbor Connector Puzzle Pieces  - DEPRECATED"
 msgstr ""
 
@@ -232,7 +232,7 @@ msgid ""
 "NOTE: ALL REALHIGHWAY NEIGHBOR CONNECTIONS (EXCEPT RHW-2) ARE REQUIRED TO USE NEIGHBOR CONNECTOR PIECES TO ENSURE PROPERLY FUNCTIONING NEIGHBOR CONNECTIONS--OTHERWISE ONLY FREIGHT TRUCKS WILL USE THE RHW"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475090"
+msgctxt "2026960B-123007BB-6A475090"
 msgid "RealHighway FLEX Neighbor Connector Pieces (FLEX-NC)"
 msgstr ""
 
@@ -240,7 +240,7 @@ msgctxt "2026960B-123006AA-6A475100"
 msgid "For building DEPRECATED RealHighway Ramp Interfaces.  All of the functionality of the 47 pieces contained and many more are covered by the FLEXRamp system."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475100"
+msgctxt "2026960B-123007BB-6A475100"
 msgid "OBSOLETE RealHighway Ramp Interfaces (Static Puzzle-Based)"
 msgstr ""
 
@@ -251,7 +251,7 @@ msgid ""
 "Button contains Type B Ramp Interface Pieces for building interchanges with the RHW"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475104"
+msgctxt "2026960B-123007BB-6A475104"
 msgid "RealHighway Type B Ramp Interfaces"
 msgstr ""
 
@@ -262,7 +262,7 @@ msgid ""
 "Button contains Type E Ramp Interface Pieces for building interchanges with the RHW"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475109"
+msgctxt "2026960B-123007BB-6A475109"
 msgid "RealHighway Type E Ramp Interfaces"
 msgstr ""
 
@@ -273,7 +273,7 @@ msgid ""
 "Button contains Type D Ramp Interface Pieces for building interchanges with the RHW"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47510A"
+msgctxt "2026960B-123007BB-6A47510A"
 msgid "RealHighway Type D Ramp Interfaces"
 msgstr ""
 
@@ -284,7 +284,7 @@ msgid ""
 "Deprecated puzzle piece ramps follow Volleyball pieces - use of the FLEXRamps or Draggable Ramp Interfaces (DRIs) is recommended instead of using the deprecated puzzle pieces."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475118"
+msgctxt "2026960B-123007BB-6A475118"
 msgid "Specialized and Deprecated RealHighway Ramp Interfaces and Volleyball Crossings (Static Puzzle-Based)"
 msgstr ""
 
@@ -295,7 +295,7 @@ msgid ""
 "Button contains FLEX pieces for different overrideable ramp interfaces.  Drag appropriate networks through to convert base ramp to match."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A4751F0"
+msgctxt "2026960B-123007BB-6A4751F0"
 msgid "RealHighway FLEXRamps"
 msgstr ""
 
@@ -306,7 +306,7 @@ msgid ""
 "Button contains pieces to build Wide Curves for the RHW networks"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475220"
+msgctxt "2026960B-123007BB-6A475220"
 msgid "RealHighway Wide-Radius and Multi-Radius (Smooth) Curves"
 msgstr ""
 
@@ -319,7 +319,7 @@ msgid ""
 "These items are DEPRECATED and use of the FLEX Width Transitions (FLEX-WT) is recommended instead."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475300"
+msgctxt "2026960B-123007BB-6A475300"
 msgid "Old RealHighway Width Transition Puzzle Pieces - DEPRECATED"
 msgstr ""
 
@@ -332,7 +332,7 @@ msgid ""
 "All functionality here has been duplicated with the FLEX Height Transitions, and as such, this button is DEPRECATED."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475312"
+msgctxt "2026960B-123007BB-6A475312"
 msgid "Old RealHighway Height Transition Puzzle Pieces  - DEPRECATED"
 msgstr ""
 
@@ -343,7 +343,7 @@ msgid ""
 "Button contains pieces to transition between RHW networks of different heights.  Pieces begin as RHW-2 transitions, and dragging another RHW network into them will convert them to fit."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475330"
+msgctxt "2026960B-123007BB-6A475330"
 msgid "RealHighway FLEX Height Transitions (FLEX-HT)"
 msgstr ""
 
@@ -354,7 +354,7 @@ msgid ""
 "Button contains pieces to transition between RHW networks of different widths.  Dragging another RHW network into them will convert them to fit."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475336"
+msgctxt "2026960B-123007BB-6A475336"
 msgid "RealHighway FLEX Width Transitions (FLEX-WT)"
 msgstr ""
 
@@ -365,7 +365,7 @@ msgid ""
 "Button contains components for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475350"
+msgctxt "2026960B-123007BB-6A475350"
 msgid ""
 "Symphony Transitions\n"
 "\n"
@@ -379,7 +379,7 @@ msgid ""
 "Button contains components for both Ground Highway and Elevated Highway."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475366"
+msgctxt "2026960B-123007BB-6A475366"
 msgid ""
 "Symphony Smooth Curves\n"
 "\n"
@@ -395,7 +395,7 @@ msgid ""
 "NOTE: These pieces should NOT be confused with TuLEPs."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475400"
+msgctxt "2026960B-123007BB-6A475400"
 msgid "RealHighway Cosmetic Puzzle Pieces (for 1-Tile Networks)"
 msgstr ""
 
@@ -408,7 +408,7 @@ msgid ""
 "NOTE: These pieces should NOT be confused with TuLEPs."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475410"
+msgctxt "2026960B-123007BB-6A475410"
 msgid "RealHighway Cosmetic Piece Transitions"
 msgstr ""
 
@@ -421,7 +421,7 @@ msgid ""
 "NOTE: These pieces should NOT be confused with TuLEPs."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475440"
+msgctxt "2026960B-123007BB-6A475440"
 msgid "RealHighway Cosmetic Puzzle Pieces (for 2-Tile Networks)"
 msgstr ""
 
@@ -434,7 +434,7 @@ msgid ""
 "NOTE: These pieces should NOT be confused with TuLEPs."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475471"
+msgctxt "2026960B-123007BB-6A475471"
 msgid "RealHighway Cosmetic Puzzle Pieces (for 3-Tile Networks)"
 msgstr ""
 
@@ -447,7 +447,7 @@ msgid ""
 "<DEPRECATED>"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475500"
+msgctxt "2026960B-123007BB-6A475500"
 msgid "ERHW-over-RHW Diagonal Overpass Puzzle Pieces<DEPRECATED>"
 msgstr ""
 
@@ -460,7 +460,7 @@ msgid ""
 "Place overcrossing pieces on top of underground roadways whenever a surface network crosses over, to allow traffic to pass underground."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475600"
+msgctxt "2026960B-123007BB-6A475600"
 msgid "RHW Flexible Underpasses (FLUPs), Draggable Underground Roads (URoads), and Overcrossings"
 msgstr ""
 
@@ -471,7 +471,7 @@ msgid ""
 "Button contains flexible RHW interchange segments.  Drag appropriate networks through to convert base ramp to match, and combine to easily create a full interchange."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475700"
+msgctxt "2026960B-123007BB-6A475700"
 msgid "RealHighway QuickChanges"
 msgstr ""
 
@@ -482,7 +482,7 @@ msgid ""
 "Button contains starter/transition FLEX pieces for different RHW turn lane setups"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475900"
+msgctxt "2026960B-123007BB-6A475900"
 msgid "RealHighway FLEX Turn Lanes (FTLs)"
 msgstr ""
 
@@ -493,7 +493,7 @@ msgid ""
 "Button contains pieces to build FLEXFly Pieces"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475AF3"
+msgctxt "2026960B-123007BB-6A475AF3"
 msgid "RealHighway FLEXFly (LEGACY/DEPRECATED)"
 msgstr ""
 
@@ -504,7 +504,7 @@ msgid ""
 "Button contains pieces to build 3-Level Crossings"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475AF6"
+msgctxt "2026960B-123007BB-6A475AF6"
 msgid "RealHighway 3-Level Crossings"
 msgstr ""
 
@@ -515,7 +515,7 @@ msgid ""
 "Button contains pieces to build FLEXFly Pieces"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475B00"
+msgctxt "2026960B-123007BB-6A475B00"
 msgid "RealHighway FLEXFly"
 msgstr ""
 
@@ -528,7 +528,7 @@ msgid ""
 "NOTE: Most intersections require the use of TuLEPs."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475F00"
+msgctxt "2026960B-123007BB-6A475F00"
 msgid "Fractionally Angled RealHighway Intersections and Transitions"
 msgstr ""
 
@@ -539,7 +539,7 @@ msgid ""
 "Button contains straight pieces and curves to pieces to build Fractionally Angled RealHighway (FARHWs)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475F20"
+msgctxt "2026960B-123007BB-6A475F20"
 msgid "Fractionally Angled RealHighway"
 msgstr ""
 
@@ -550,7 +550,7 @@ msgid ""
 "Button contains pieces to build different FARHW Ramp Interfaces: The C1, F1, C2, F2, and C3 Ramp Interfaces"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475F30"
+msgctxt "2026960B-123007BB-6A475F30"
 msgid "Fractionally Angled RealHighway Ramp Interfaces"
 msgstr ""
 
@@ -561,7 +561,7 @@ msgid ""
 "Button contains Type C Ramp Interface Pieces for building interchanges with the RHW"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475F70"
+msgctxt "2026960B-123007BB-6A475F70"
 msgid "RealHighway Type C Ramp Interfaces"
 msgstr ""
 
@@ -572,7 +572,7 @@ msgid ""
 "Button contains Type F Ramp Interface Pieces for building interchanges with the RHW"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A475F71"
+msgctxt "2026960B-123007BB-6A475F71"
 msgid "RealHighway Type F Ramp Interfaces"
 msgstr ""
 
@@ -585,7 +585,7 @@ msgid ""
 "NOTE: Ped Mall Tiles should not be used directly in front of Residential Zones where their zoning arrow is."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A476005"
+msgctxt "2026960B-123007BB-6A476005"
 msgid "Pedestrian Mall Tiles"
 msgstr ""
 
@@ -593,7 +593,7 @@ msgctxt "2026960B-123006AA-6A476100"
 msgid "A collection of pedestrian crossing FLEX pieces. Use them on their own at crossing locations, or as part of pedmall corridors."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A476100"
+msgctxt "2026960B-123007BB-6A476100"
 msgid "Pedestrian Revolution Mod (PRM) FLEX Crossings"
 msgstr ""
 
@@ -604,7 +604,7 @@ msgid ""
 "Button contains several different Puzzle and Helper Pieces for Street"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A476525"
+msgctxt "2026960B-123007BB-6A476525"
 msgid "Diagonal Street Helper Pieces"
 msgstr ""
 
@@ -615,7 +615,7 @@ msgid ""
 "Button contains Starter Pieces for Street Addon Mod (SAM)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A476700"
+msgctxt "2026960B-123007BB-6A476700"
 msgid "Street Addon Mod (SAM)"
 msgstr ""
 
@@ -623,7 +623,7 @@ msgctxt "2026960B-123006AA-6A476905"
 msgid "Plop one of these pieces on a flat area. It will raise or lower the terrain, and then destroy itself, providing a level area for a raised network of your choice. This is fully compatible with all slope mods."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A476905"
+msgctxt "2026960B-123007BB-6A476905"
 msgid "Hole Digger and Raiser Lots"
 msgstr ""
 
@@ -634,7 +634,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Avenues"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A476A00"
+msgctxt "2026960B-123007BB-6A476A00"
 msgid "Avenue Intersections"
 msgstr ""
 
@@ -645,7 +645,7 @@ msgid ""
 "Button contains several different overpasses for Road"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477000"
+msgctxt "2026960B-123007BB-6A477000"
 msgid "Road Overpasses"
 msgstr ""
 
@@ -656,7 +656,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Road"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477005"
+msgctxt "2026960B-123007BB-6A477005"
 msgid "7.5m Elevated Road Viaducts"
 msgstr ""
 
@@ -667,7 +667,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Road"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477200"
+msgctxt "2026960B-123007BB-6A477200"
 msgid "15m Elevated Road Viaducts"
 msgstr ""
 
@@ -678,7 +678,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Road, One-Way Road, or Avenue"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477500"
+msgctxt "2026960B-123007BB-6A477500"
 msgid "Wide Radius Curves (for Road, One-Way Road, Avenue, and Street) (Puzzle Pieces)"
 msgstr ""
 
@@ -689,7 +689,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Road, One-Way Road, and Avenue"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477600"
+msgctxt "2026960B-123007BB-6A477600"
 msgid "Fractionally-Angled Networks (for Road, One-Way Road, and Avenue)"
 msgstr ""
 
@@ -700,7 +700,7 @@ msgid ""
 "Once a puzzle piece is selected, use the [Home] and [End] keys to cycle through the various puzzle piece orientations"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477700"
+msgctxt "2026960B-123007BB-6A477700"
 msgid "Rural Road Puzzle Pieces"
 msgstr ""
 
@@ -711,7 +711,7 @@ msgid ""
 "Button contains pieces to interface between the NAM Elevated Road Puzzle Pieces and RHW networks, including overpasses and intersections"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477800"
+msgctxt "2026960B-123007BB-6A477800"
 msgid "Road/RHW Overpass and Interface Puzzle Pieces (DEPRECATED)"
 msgstr ""
 
@@ -722,7 +722,7 @@ msgid ""
 "Button contains several different FLEX Pieces for various networks"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477900"
+msgctxt "2026960B-123007BB-6A477900"
 msgid "Multi-Radius Curve (MRC) FLEX Pieces for Surface Networks"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgid ""
 "The new Subway-based FLUPs system can be found under the Highways menu."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477A00"
+msgctxt "2026960B-123007BB-6A477A00"
 msgid "Flexible Underpasses (FLUPs)"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgid ""
 "Button contains Starter Pieces for the 3, 5 and 7-lane Turning Lane Avenues (TLA-3,5,7), 2 and 6-lane Avenues (AVE-2,6), 3-lane Asymmetrical Road (ARD-3), 4 and 6-lane Roads RD-4,6) and 1, 3, 4 and 5-lane One-Way Roads (OWR-1,3,4,5)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477B00"
+msgctxt "2026960B-123007BB-6A477B00"
 msgid "Network Widening Mod (NWM) Starter Pieces"
 msgstr ""
 
@@ -761,7 +761,7 @@ msgid ""
 "Button contains Wide-Radius Curve Pieces for the single-tile NWM networks"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477B30"
+msgctxt "2026960B-123007BB-6A477B30"
 msgid "Network Widening Mod (NWM) Curve Pieces"
 msgstr ""
 
@@ -774,7 +774,7 @@ msgid ""
 "Note that most transitions involving single and dual-tile networks can be built using draggable means instead (such as direct connections or using the stub-to-stub method)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477B50"
+msgctxt "2026960B-123007BB-6A477B50"
 msgid "Network Widening Mod (NWM) Transition Pieces"
 msgstr ""
 
@@ -785,7 +785,7 @@ msgid ""
 "Button contains Neighbor Connector Pieces for the TLA-5, RD-4 and RD-6"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477BF0"
+msgctxt "2026960B-123007BB-6A477BF0"
 msgid "Network Widening Mod (NWM) Neighbor Connector Pieces"
 msgstr ""
 
@@ -796,7 +796,7 @@ msgid ""
 "Button contains FLEX Single Tile Roundabouts intersections for various road networks"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477C00"
+msgctxt "2026960B-123007BB-6A477C00"
 msgid "Single Tile Roundabouts"
 msgstr ""
 
@@ -809,7 +809,7 @@ msgid ""
 "Button contains OnSlope Transitions to start Alternate Style Road and Street Viaducts"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477E00"
+msgctxt "2026960B-123007BB-6A477E00"
 msgid "Road Viaduct Alternate Styles"
 msgstr ""
 
@@ -820,7 +820,7 @@ msgid ""
 "Button contains several different Starter and FLEX Pieces for Draggable Elevated Road Viaducts"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477F00"
+msgctxt "2026960B-123007BB-6A477F00"
 msgid "Draggable Elevated Road Viaducts"
 msgstr ""
 
@@ -833,7 +833,7 @@ msgid ""
 "Drag networks under (or over) the mid-section of the overpass to build the crossing.  Most networks and FLEX-based dual-networks are supported."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A477F30"
+msgctxt "2026960B-123007BB-6A477F30"
 msgid "FLEX Overpasses"
 msgstr ""
 
@@ -844,7 +844,7 @@ msgid ""
 "Button contains several different overpasses for One-Way Road"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A478000"
+msgctxt "2026960B-123007BB-6A478000"
 msgid "One-Way Road Overpasses"
 msgstr ""
 
@@ -855,7 +855,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for One-Way Road"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A478005"
+msgctxt "2026960B-123007BB-6A478005"
 msgid "15m Elevated One-Way Road Viaducts"
 msgstr ""
 
@@ -866,7 +866,7 @@ msgid ""
 "Button contains pieces to interface between the NAM Elevated One-Way Road Puzzle Pieces and RHW networks, including overpasses and intersections"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A478800"
+msgctxt "2026960B-123007BB-6A478800"
 msgid "One-Way Road/RHW Overpass and Interface Puzzle Pieces (DEPRECATED)"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgctxt "2026960B-123006AA-6A478900"
 msgid "For use of the curved pieces for the Real Expressway Network. Use the Home/End key to rotate the FLEX Piece & use TAB/Shift-TAB (Ctrl-TAB/Ctrl-Shift-TAB on macOS) to cycle through the different types of REW Straights and Curves."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A478900"
+msgctxt "2026960B-123007BB-6A478900"
 msgid "Real Expressway FLEX Piece network tool and Curves."
 msgstr ""
 
@@ -885,7 +885,7 @@ msgid ""
 "Button contains FLEX pieces for different overrideable ramp interfaces.  Drag appropriate networks through to convert base ramp to match."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A478B00"
+msgctxt "2026960B-123007BB-6A478B00"
 msgid "RealExpressway (REW) One-Way Road FLEXRamps"
 msgstr ""
 
@@ -896,7 +896,7 @@ msgid ""
 "Button contains several different overpasses for Avenue"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A479000"
+msgctxt "2026960B-123007BB-6A479000"
 msgid "Avenue Overpasses"
 msgstr ""
 
@@ -907,7 +907,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Avenue"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A479005"
+msgctxt "2026960B-123007BB-6A479005"
 msgid "7.5m Elevated Avenue Viaducts"
 msgstr ""
 
@@ -918,7 +918,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Avenue"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A479200"
+msgctxt "2026960B-123007BB-6A479200"
 msgid "15m Elevated Avenue Viaducts"
 msgstr ""
 
@@ -929,7 +929,7 @@ msgid ""
 "Button contains pieces to interface between the NAM Elevated Avenue Puzzle Pieces and RHW networks, including overpasses and intersections"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A479900"
+msgctxt "2026960B-123007BB-6A479900"
 msgid "Avenue/RHW Overpass and Interface Puzzle Pieces (DEPRECATED)"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgid ""
 "FlexSPUI and Flex Diverging Diamond (FlexDDI) pieces are found under this button"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47991A"
+msgctxt "2026960B-123007BB-6A47991A"
 msgid "Specialized RHW x Surface Intersections"
 msgstr ""
 
@@ -953,7 +953,7 @@ msgid ""
 "Button contains several different Puzzle Pieces for Rail."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47A005"
+msgctxt "2026960B-123007BB-6A47A005"
 msgid "Rail Puzzle Pieces"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgctxt "2026960B-123006AA-6A47A130"
 msgid "Button contains FLEX pieces to elevated the Rail network to viaduct level (using the RealRailway (RRW) standard)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47A130"
+msgctxt "2026960B-123007BB-6A47A130"
 msgid "Draggable Elevated Railways (ERRW)"
 msgstr ""
 
@@ -972,7 +972,7 @@ msgid ""
 "Once a puzzle piece is selected, use the [Home] and [End] keys to cycle through the various puzzle piece orientations"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47A358"
+msgctxt "2026960B-123007BB-6A47A358"
 msgid "Wide Radius Railroad Curve and Double Track Rail Switch Puzzle Pieces"
 msgstr ""
 
@@ -983,7 +983,7 @@ msgid ""
 "Once a puzzle piece is selected, use the [Home] and [End] keys to cycle through the various puzzle piece orientations"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47A368"
+msgctxt "2026960B-123007BB-6A47A368"
 msgid "Fractional Angle Railroad (FARR) Puzzle Pieces"
 msgstr ""
 
@@ -994,7 +994,7 @@ msgid ""
 "Button contains pieces to interface between the NAM Elevated Rail Viaduct Puzzle Pieces and RHW networks, including overpasses and intersections"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47A800"
+msgctxt "2026960B-123007BB-6A47A800"
 msgid "Rail Viaduct/RHW Overpass and Interface Puzzle Pieces"
 msgstr ""
 
@@ -1005,7 +1005,7 @@ msgid ""
 "Once a puzzle piece is selected, use the [Home] and [End] keys to cycle through the various puzzle piece orientations"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47A900"
+msgctxt "2026960B-123007BB-6A47A900"
 msgid "Wide Radius Railroad Curve and Double Track Rail Switch Puzzle Pieces"
 msgstr ""
 
@@ -1016,7 +1016,7 @@ msgid ""
 "Button contains several different Pieces for Dual/Double-Decker Networking."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AA0F"
+msgctxt "2026960B-123007BB-6A47AA0F"
 msgid ""
 "Underground Rail\n"
 "Rail Tunnel under Roads Dual Networking Puzzle Pieces"
@@ -1029,7 +1029,7 @@ msgid ""
 "Button contains several different Pieces for Dual/Double-Decker Networking."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AA10"
+msgctxt "2026960B-123007BB-6A47AA10"
 msgid ""
 "Underground Rail\n"
 "Rail Tunnel under Ped Malls Dual Networking Puzzle Pieces"
@@ -1042,7 +1042,7 @@ msgid ""
 "Button contains several different Pieces for Maxis Roadways."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AA11"
+msgctxt "2026960B-123007BB-6A47AA11"
 msgid ""
 "Underground Rail\n"
 "Maxis Roadway Intersection Pieces"
@@ -1055,7 +1055,7 @@ msgid ""
 "Button contains several different Pieces for Railways."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AA12"
+msgctxt "2026960B-123007BB-6A47AA12"
 msgid ""
 "Underground Rail\n"
 "Railway Intersection Pieces"
@@ -1068,7 +1068,7 @@ msgid ""
 "Button contains several different Pieces for Tramways."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AA13"
+msgctxt "2026960B-123007BB-6A47AA13"
 msgid ""
 "Underground Rail\n"
 "Tramway Intersection Pieces"
@@ -1081,7 +1081,7 @@ msgid ""
 "Button contains several different Pieces for Dual/Double-Decker Networking."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AA8A"
+msgctxt "2026960B-123007BB-6A47AA8A"
 msgid ""
 "Underground Rail\n"
 "Miscellaneous Puzzle Pieces"
@@ -1091,7 +1091,7 @@ msgctxt "2026960B-123006AA-6A47AC00"
 msgid "All pieces in this section are FLEX and conform to flextrack standards!"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AC00"
+msgctxt "2026960B-123007BB-6A47AC00"
 msgid "RealRailway FLEX Curve Pieces."
 msgstr ""
 
@@ -1099,7 +1099,7 @@ msgctxt "2026960B-123006AA-6A47AC10"
 msgid "All pieces in this section are FLEX and conform to flextrack standards!"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AC10"
+msgctxt "2026960B-123007BB-6A47AC10"
 msgid "RealRailway FLEX Turnout Pieces."
 msgstr ""
 
@@ -1107,7 +1107,7 @@ msgctxt "2026960B-123006AA-6A47AD00"
 msgid "All pieces in this section are FLEX and conform to flextrack and FARR standards!\n"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47AD00"
+msgctxt "2026960B-123007BB-6A47AD00"
 msgid "RealRailway FLEX Fractional Angled (FA) Pieces."
 msgstr ""
 
@@ -1118,7 +1118,7 @@ msgid ""
 "Button contains several different Pieces for Dual/Double-Decker Networking."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47B03A"
+msgctxt "2026960B-123007BB-6A47B03A"
 msgid "ElevatedRail Dual/Double-Decker Network Pieces"
 msgstr ""
 
@@ -1126,7 +1126,7 @@ msgctxt "2026960B-123006AA-6A47B049"
 msgid "These puzzle pieces are to allow you to cross NWM networks with ElRail over Road."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47B049"
+msgctxt "2026960B-123007BB-6A47B049"
 msgid "ElRail over Road NWM Intersections"
 msgstr ""
 
@@ -1137,7 +1137,7 @@ msgid ""
 "The construction lot vanishes automatically. Use the Road Tool to connect the network and to build intersections."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47B060"
+msgctxt "2026960B-123007BB-6A47B060"
 msgid "ElevatedRail over Avenue/Road-4 Puzzle Pieces"
 msgstr ""
 
@@ -1145,7 +1145,7 @@ msgctxt "2026960B-123006AA-6A47B10F"
 msgid "Puzzle Pieces to build a ground level extension of the Elevated Rail network for Light Rail/Trams."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47B10F"
+msgctxt "2026960B-123007BB-6A47B10F"
 msgid "Ground Light Rail (Tram)"
 msgstr ""
 
@@ -1156,7 +1156,7 @@ msgid ""
 "Connect the Elevated Rail network with the Starter Piece. The Elevated Rail will turn into a Ground Light Rail track."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47B3FF"
+msgctxt "2026960B-123007BB-6A47B3FF"
 msgid "Draggable Ground Light Rail (Tram)"
 msgstr ""
 
@@ -1164,7 +1164,7 @@ msgctxt "2026960B-123006AA-6A47B42A"
 msgid "For building Tram-Avenue (= GroundLightRail / Avenue) - Dual Network Pieces."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47B42A"
+msgctxt "2026960B-123007BB-6A47B42A"
 msgid "Tram-Avenue (GroundLightRail / Avenue) - Dual Network Pieces"
 msgstr ""
 
@@ -1175,7 +1175,7 @@ msgid ""
 "These puzzle pieces are designed so that you may plop them first or you may plop them on existing networks."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47B900"
+msgctxt "2026960B-123007BB-6A47B900"
 msgid "High Elevated Rail Puzzle Pieces"
 msgstr ""
 
@@ -1186,7 +1186,7 @@ msgid ""
 "Button contains Tram-in-Road Puzzle Pieces"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47BA00"
+msgctxt "2026960B-123007BB-6A47BA00"
 msgid "Tram-in-Road"
 msgstr ""
 
@@ -1194,7 +1194,7 @@ msgctxt "2026960B-123006AA-6A47BBA0"
 msgid "For utilizing the Tram Puzzle Pieces"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47BBA0"
+msgctxt "2026960B-123007BB-6A47BBA0"
 msgid "Tram-on-Road & texture variations"
 msgstr ""
 
@@ -1202,7 +1202,7 @@ msgctxt "2026960B-123006AA-6A47BC60"
 msgid "For utilizing the Tram Puzzle Pieces"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47BC60"
+msgctxt "2026960B-123007BB-6A47BC60"
 msgid "Tram-on-Street"
 msgstr ""
 
@@ -1213,7 +1213,7 @@ msgid ""
 "Button contains starters for two additional Ground Light Rail styles, plus filler pieces."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47BD00"
+msgctxt "2026960B-123007BB-6A47BD00"
 msgid "Draggable Ground Light Rail (Tram)--Additional Styles"
 msgstr ""
 
@@ -1224,7 +1224,7 @@ msgid ""
 "Button contains Starter, Filler and Overpass Puzzle Pieces for High Speed Rail (HSR)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47C000"
+msgctxt "2026960B-123007BB-6A47C000"
 msgid "High Speed Rail (HSR)"
 msgstr ""
 
@@ -1237,11 +1237,11 @@ msgid ""
 "GHSR is a ground level extension of High Speed Rail (HSR)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47C200"
+msgctxt "2026960B-123007BB-6A47C200"
 msgid "Ground High Speed Rail (GHSR)"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47C700"
+msgctxt "2026960B-123007BB-6A47C700"
 msgid "Monorail Wide Radius Curve Puzzle Pieces"
 msgstr ""
 
@@ -1259,7 +1259,7 @@ msgid ""
 "These puzzle pieces are designed so that you may plop them first or you may plop them on existing networks."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47C900"
+msgctxt "2026960B-123007BB-6A47C900"
 msgid "High Monorail Puzzle Pieces"
 msgstr ""
 
@@ -1267,7 +1267,7 @@ msgctxt "2026960B-123006AA-6A47CA00"
 msgid "For building Hybrid Railway straight track sections.  Hybrid Railway carries both normal Rail traffic and High Speed Rail (Monorail) traffic."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47CA00"
+msgctxt "2026960B-123007BB-6A47CA00"
 msgid "Hybrid Railway (Rail-High Speed Rail) Straight Sections"
 msgstr ""
 
@@ -1275,7 +1275,7 @@ msgctxt "2026960B-123006AA-6A47CB00"
 msgid "For building Hybrid Railway curves.  Hybrid Railway carries both normal Rail traffic and High Speed Rail (Monorail) traffic."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47CB00"
+msgctxt "2026960B-123007BB-6A47CB00"
 msgid "Hybrid Railway (Rail-High Speed Rail) Curves"
 msgstr ""
 
@@ -1286,7 +1286,7 @@ msgid ""
 "Hybrid Railway carries both normal Rail traffic and High Speed Rail (Monorail) traffic."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47CD00"
+msgctxt "2026960B-123007BB-6A47CD00"
 msgid "Hybrid Railway (Rail-High Speed Rail) Switches"
 msgstr ""
 
@@ -1297,7 +1297,7 @@ msgid ""
 "Use ground-level Hybrid Railway segments, and connect to the elevated end of the transitions (or to other already elevated sections) to elevate them."
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47CE00"
+msgctxt "2026960B-123007BB-6A47CE00"
 msgid "Hybrid Railway (Rail-High Speed Rail) Height Transitions"
 msgstr ""
 
@@ -1305,7 +1305,7 @@ msgctxt "2026960B-123006AA-6A47DC00"
 msgid "Button contains Ground Highway Puzzle Pieces"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47DC00"
+msgctxt "2026960B-123007BB-6A47DC00"
 msgid "Ground Highway Puzzle Pieces"
 msgstr ""
 
@@ -1316,7 +1316,7 @@ msgid ""
 "Button contains Single-Sided Perpendicular Ramps for Elevated Highway"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47E010"
+msgctxt "2026960B-123007BB-6A47E010"
 msgid ""
 "Single-Sided Perpendicular Ramps\n"
 "\n"
@@ -1330,7 +1330,7 @@ msgid ""
 "Button contains Single-Sided Parallel Ramps for both Ground Highway and Elevated Highway"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47E050"
+msgctxt "2026960B-123007BB-6A47E050"
 msgid ""
 "Single-Sided Parallel Ramps\n"
 "\n"
@@ -1341,15 +1341,15 @@ msgctxt "2026960B-123006AA-6A47E100"
 msgid "Button contains Custom Interchanges"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47E100"
+msgctxt "2026960B-123007BB-6A47E100"
 msgid "Custom Interchanges"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A47FFFF"
+msgctxt "2026960B-123007BB-6A47FFFF"
 msgid "Network Addon Mod Controller"
 msgstr ""
 
-msgctxt "2026960B-123006BB-6A476200"
+msgctxt "2026960B-123007BB-6A476200"
 msgid "Draggable Pedmalls"
 msgstr ""
 


### PR DESCRIPTION
Changes the GID of all NAM button LTEXTs from 0x123006BB to 0x123007BB to mitigate collision between different language offsets.  This will allow all locales to be installed at the same time without conflict.