### PR TITLE
Pricklyg00 new bridges MarApr2024

### DIFF
--- a/Controller/Bridge Controller/00001000.rul
+++ b/Controller/Bridge Controller/00001000.rul
@@ -4415,6 +4415,2074 @@ end
 end
 
 
+# Yellow Steel Girder (RD-2) by IDS2 (09/23)
+
+bridge 26
+
+# abutment start - 1 tile
+section as
+	piece <0x40390000, 0>
+end 
+
+# pillar section - 3 tiles
+section pi
+	piece <0x40391000, 0>
+	piece <0x40392000, 0>
+	piece <0x40391000, 0>
+end 
+
+# span only - 1 tile
+section sp
+	piece <0x40393000, 0>
+end 
+
+# combined repeat segment - 4 tiles
+section ps
+	piece pi sp
+end
+
+#abutment end - 1 tile
+section ae
+	piece <0x40390000, 2>
+end
+
+	length 5
+	piece as 3*sp ae
+	end
+	
+	length 6
+	piece as 4*sp ae
+	end
+	
+	length 7
+	piece as sp ps ae
+	end
+	
+	length 8
+	piece as sp ps sp ae
+	end
+	
+	length 9
+	piece as 2*sp ps sp ae
+	end
+	
+	length 10
+	piece as 2*sp ps 2*sp ae
+	end
+	
+	length 11
+	piece as sp 2*ps ae
+	end
+	
+	length 12
+	piece as 2*sp 2*ps ae
+	end
+	
+	length 13
+	piece as 2*sp 2*ps sp ae
+	end
+	
+	length 14
+	piece as 2*sp ps sp ps sp ae
+	end
+	
+	length 15
+	piece as sp 3*ps ae
+	end
+	
+	length 16
+	piece as 2*sp 3*ps ae
+	end
+	
+	length 17
+	piece as 2*sp 3*ps sp ae
+	end
+	
+	length 18
+	piece as 2*sp 3*ps 2*sp ae
+	end
+	
+	length 19
+	piece as sp 4*ps ae
+	end
+	
+	length 20
+	piece as 2*sp 4*ps ae
+	end
+	
+	length 21
+	piece as 2*sp 4*ps sp ae
+	end
+	
+	length 22
+	piece as 2*sp 4*ps 2*sp ae
+	end
+	
+	length 23
+	piece as sp 5*ps ae
+	end
+
+	length 24
+	piece as 2*sp 5*ps ae
+	end
+
+	length 25
+	piece as 2*sp 5*ps sp ae
+	end
+
+	length 26
+	piece as 2*sp 5*ps 2*sp ae
+	end
+
+	length 27
+	piece as sp 6*ps ae
+	end
+
+	length 28
+	piece as 2*sp 6*ps ae
+	end
+
+	length 29
+	piece as 2*sp 6*ps sp ae
+	end
+
+	length 30
+	piece as 2*sp 6*ps 2*sp ae
+	end
+
+	length 31
+	piece as sp 7*ps ae
+	end
+
+	length 32
+	piece as 2*sp 7*ps ae
+	end
+
+	length 33
+	piece as 2*sp 7*ps sp ae
+	end
+
+	length 34
+	piece as 2*sp 7*ps 2*sp ae
+	end
+
+	length 35
+	piece as sp 8*ps ae
+	end
+
+	length 36
+	piece as 2*sp 8*ps ae
+	end
+
+	length 37
+	piece as 2*sp 8*ps sp ae
+	end
+
+	length 38
+	piece as 2*sp 8*ps 2*sp ae
+	end
+
+	length 39
+	piece as sp 9*ps ae
+	end
+
+	length 40
+	piece as 2*sp 9*ps ae
+	end
+
+	length 41
+	piece as 2*sp 9*ps sp ae
+	end
+
+	length 42
+	piece as 2*sp 9*ps 2*sp ae
+	end
+
+	length 43
+	piece as sp 10*ps ae
+	end
+
+	length 44
+	piece as 2*sp 10*ps ae
+	end
+
+	length 45
+	piece as 2*sp 10*ps sp ae
+	end
+
+	length 46
+	piece as 2*sp 10*ps 2*sp ae
+	end
+
+	length 47
+	piece as sp 11*ps ae
+	end
+
+	length 48
+	piece as 2*sp 11*ps ae
+	end
+
+	length 49
+	piece as 2*sp 11*ps sp ae
+	end
+
+	length 50
+	piece as 2*sp 11*ps 2*sp ae
+	end
+
+	length 51
+	piece as sp 12*ps ae
+	end
+
+	length 52
+	piece as 2*sp 12*ps ae
+	end
+
+	length 53
+	piece as 2*sp 12*ps sp ae
+	end
+
+	length 54
+	piece as 2*sp 12*ps 2*sp ae
+	end
+
+	length 55
+	piece as sp 13*ps ae
+	end
+
+	length 56
+	piece as 2*sp 13*ps ae
+	end
+
+	length 57
+	piece as 2*sp 13*ps sp ae
+	end
+
+	length 58
+	piece as 2*sp 13*ps 2*sp ae
+	end
+
+	length 59
+	piece as sp 14*ps ae
+	end
+
+	length 60
+	piece as 2*sp 14*ps ae
+	end
+
+	length 61
+	piece as 2*sp 14*ps sp ae
+	end
+
+	length 62
+	piece as 2*sp 14*ps 2*sp ae
+	end
+
+	length 63
+	piece as sp 15*ps ae
+	end
+
+	length 64
+	piece as 2*sp 15*ps ae
+	end
+
+	length 65
+	piece as 2*sp 15*ps sp ae
+	end
+
+	length 66
+	piece as 2*sp 15*ps 2*sp ae
+	end
+
+	length 67
+	piece as sp 16*ps ae
+	end
+
+	length 68
+	piece as 2*sp 16*ps ae
+	end
+
+	length 69
+	piece as 2*sp 16*ps sp ae
+	end
+
+	length 70
+	piece as 2*sp 16*ps 2*sp ae
+	end
+
+	length 71
+	piece as sp 17*ps ae
+	end
+
+	length 72
+	piece as 2*sp 17*ps ae
+	end
+
+	length 73
+	piece as 2*sp 17*ps sp ae
+	end
+
+	length 74
+	piece as 2*sp 17*ps 2*sp ae
+	end
+
+	length 75
+	piece as sp 18*ps ae
+	end
+
+	length 76
+	piece as 2*sp 18*ps ae
+	end
+
+	length 77
+	piece as 2*sp 18*ps sp ae
+	end
+
+	length 78
+	piece as 2*sp 18*ps 2*sp ae
+	end
+
+	length 79
+	piece as sp 19*ps ae
+	end
+
+	length 80
+	piece as 2*sp 19*ps ae
+	end
+
+	length 81
+	piece as 2*sp 19*ps sp ae
+	end
+
+	length 82
+	piece as 2*sp 19*ps 2*sp ae
+	end
+
+	length 83
+	piece as sp 20*ps ae
+	end
+
+	length 84
+	piece as 2*sp 20*ps ae
+	end
+
+	length 85
+	piece as 2*sp 20*ps sp ae
+	end
+
+	length 86
+	piece as 2*sp 20*ps 2*sp ae
+	end
+
+	length 87
+	piece as sp 21*ps ae
+	end
+
+	length 88
+	piece as 2*sp 21*ps ae
+	end
+
+	length 89
+	piece as 2*sp 21*ps sp ae
+	end
+
+	length 90
+	piece as 2*sp 21*ps 2*sp ae
+	end
+
+	length 91
+	piece as sp 22*ps ae
+	end
+
+	length 92
+	piece as 2*sp 22*ps ae
+	end
+
+	length 93
+	piece as 2*sp 22*ps sp ae
+	end
+
+	length 94
+	piece as 2*sp 22*ps 2*sp ae
+	end
+
+	length 95
+	piece as sp 23*ps ae
+	end
+
+	length 96
+	piece as 2*sp 23*ps ae
+	end
+
+	length 97
+	piece as 2*sp 23*ps sp ae
+	end
+
+	length 98
+	piece as 2*sp 23*ps 2*sp ae
+	end
+
+	length 99
+	piece as sp 24*ps ae
+	end
+
+	length 100
+	piece as 2*sp 24*ps ae
+	end
+
+	length 101
+	piece as 2*sp 24*ps sp ae
+	end
+
+	length 102
+	piece as 2*sp 24*ps 2*sp ae
+	end
+
+	length 103
+	piece as sp 25*ps ae
+	end
+
+	length 104
+	piece as 2*sp 25*ps ae
+	end
+
+	length 105
+	piece as 2*sp 25*ps sp ae
+	end
+
+	length 106
+	piece as 2*sp 25*ps 2*sp ae
+	end
+
+	length 107
+	piece as sp 26*ps ae
+	end
+
+	length 108
+	piece as 2*sp 26*ps ae
+	end
+
+	length 109
+	piece as 2*sp 26*ps sp ae
+	end
+
+	length 110
+	piece as 2*sp 26*ps 2*sp ae
+	end
+
+	length 111
+	piece as sp 27*ps ae
+	end
+
+	length 112
+	piece as 2*sp 27*ps ae
+	end
+
+	length 113
+	piece as 2*sp 27*ps sp ae
+	end
+
+	length 114
+	piece as 2*sp 27*ps 2*sp ae
+	end
+
+	length 115
+	piece as sp 28*ps ae
+	end
+
+	length 116
+	piece as 2*sp 28*ps ae
+	end
+
+	length 117
+	piece as 2*sp 28*ps sp ae
+	end
+
+	length 118
+	piece as 2*sp 28*ps 2*sp ae
+	end
+
+	length 119
+	piece as sp 29*ps ae
+	end
+
+	length 120
+	piece as 2*sp 29*ps ae
+	end
+
+	length 121
+	piece as 2*sp 29*ps sp ae
+	end
+
+	length 122
+	piece as 2*sp 29*ps 2*sp ae
+	end
+
+	length 123
+	piece as sp 30*ps ae
+	end
+
+	length 124
+	piece as 2*sp 30*ps ae
+	end
+
+	length 125
+	piece as 2*sp 30*ps sp ae
+	end
+
+	length 126
+	piece as 2*sp 30*ps 2*sp ae
+	end
+
+	length 127
+	piece as sp 31*ps ae
+	end
+
+	length 128
+	piece as 2*sp 31*ps ae
+	end
+
+	length 129
+	piece as 2*sp 31*ps sp ae
+	end
+
+	length 130
+	piece as 2*sp 31*ps 2*sp ae
+	end
+
+	length 131
+	piece as sp 32*ps ae
+	end
+
+	length 132
+	piece as 2*sp 32*ps ae
+	end
+
+	length 133
+	piece as 2*sp 32*ps sp ae
+	end
+
+	length 134
+	piece as 2*sp 32*ps 2*sp ae
+	end
+
+	length 135
+	piece as sp 33*ps ae
+	end
+
+	length 136
+	piece as 2*sp 33*ps ae
+	end
+
+	length 137
+	piece as 2*sp 33*ps sp ae
+	end
+
+	length 138
+	piece as 2*sp 33*ps 2*sp ae
+	end
+
+	length 139
+	piece as sp 34*ps ae
+	end
+
+	length 140
+	piece as 2*sp 34*ps ae
+	end
+
+	length 141
+	piece as 2*sp 34*ps sp ae
+	end
+
+	length 142
+	piece as 2*sp 34*ps 2*sp ae
+	end
+
+	length 143
+	piece as sp 35*ps ae
+	end
+
+	length 144
+	piece as 2*sp 35*ps ae
+	end
+
+	length 145
+	piece as 2*sp 35*ps sp ae
+	end
+
+	length 146
+	piece as 2*sp 35*ps 2*sp ae
+	end
+
+	length 147
+	piece as sp 36*ps ae
+	end
+
+	length 148
+	piece as 2*sp 36*ps ae
+	end
+
+	length 149
+	piece as 2*sp 36*ps sp ae
+	end
+
+	length 150
+	piece as 2*sp 36*ps 2*sp ae
+	end
+
+	length 151
+	piece as sp 37*ps ae
+	end
+
+	length 152
+	piece as 2*sp 37*ps ae
+	end
+
+	length 153
+	piece as 2*sp 37*ps sp ae
+	end
+
+	length 154
+	piece as 2*sp 37*ps 2*sp ae
+	end
+
+	length 155
+	piece as sp 38*ps ae
+	end
+
+	length 156
+	piece as 2*sp 38*ps ae
+	end
+
+	length 157
+	piece as 2*sp 38*ps sp ae
+	end
+
+	length 158
+	piece as 2*sp 38*ps 2*sp ae
+	end
+
+	length 159
+	piece as sp 39*ps ae
+	end
+
+	length 160
+	piece as 2*sp 39*ps ae
+	end
+
+	length 161
+	piece as 2*sp 39*ps sp ae
+	end
+
+	length 162
+	piece as 2*sp 39*ps 2*sp ae
+	end
+
+	length 163
+	piece as sp 40*ps ae
+	end
+
+	length 164
+	piece as 2*sp 40*ps ae
+	end
+
+	length 165
+	piece as 2*sp 40*ps sp ae
+	end
+
+	length 166
+	piece as 2*sp 40*ps 2*sp ae
+	end
+
+	length 167
+	piece as sp 41*ps ae
+	end
+
+	length 168
+	piece as 2*sp 41*ps ae
+	end
+
+	length 169
+	piece as 2*sp 41*ps sp ae
+	end
+
+	length 170
+	piece as 2*sp 41*ps 2*sp ae
+	end
+
+	length 171
+	piece as sp 42*ps ae
+	end
+
+	length 172
+	piece as 2*sp 42*ps ae
+	end
+
+	length 173
+	piece as 2*sp 42*ps sp ae
+	end
+
+	length 174
+	piece as 2*sp 42*ps 2*sp ae
+	end
+
+	length 175
+	piece as sp 43*ps ae
+	end
+
+	length 176
+	piece as 2*sp 43*ps ae
+	end
+
+	length 177
+	piece as 2*sp 43*ps sp ae
+	end
+
+	length 178
+	piece as 2*sp 43*ps 2*sp ae
+	end
+
+	length 179
+	piece as sp 44*ps ae
+	end
+
+	length 180
+
+	piece as 2*sp 44*ps ae
+	end
+
+	length 181
+	piece as 2*sp 44*ps sp ae
+	end
+
+	length 182
+	piece as 2*sp 44*ps 2*sp ae
+	end
+
+	length 183
+	piece as sp 45*ps ae
+	end
+
+	length 184
+	piece as 2*sp 45*ps ae
+	end
+
+	length 185
+	piece as 2*sp 45*ps sp ae
+	end
+
+	length 186
+	piece as 2*sp 45*ps 2*sp ae
+	end
+
+	length 187
+	piece as sp 46*ps ae
+	end
+
+	length 188
+	piece as 2*sp 46*ps ae
+	end
+
+	length 189
+	piece as 2*sp 46*ps sp ae
+	end
+
+	length 190
+	piece as 2*sp 46*ps 2*sp ae
+	end
+
+	length 191
+	piece as sp 47*ps ae
+	end
+
+	length 192
+	piece as 2*sp 47*ps ae
+	end
+
+	length 193
+	piece as 2*sp 47*ps sp ae
+	end
+
+	length 194
+	piece as 2*sp 47*ps 2*sp ae
+	end
+
+	length 195
+	piece as sp 48*ps ae
+	end
+
+	length 196
+	piece as 2*sp 48*ps ae
+	end
+
+	length 197
+	piece as 2*sp 48*ps sp ae
+	end
+
+	length 198
+	piece as 2*sp 48*ps 2*sp ae
+	end
+
+	length 199
+	piece as sp 49*ps ae
+	end
+
+	length 200
+	piece as 2*sp 49*ps ae
+	end
+
+	length 201
+	piece as 2*sp 49*ps sp ae
+	end
+
+	length 202
+	piece as 2*sp 49*ps 2*sp ae
+	end
+
+	length 203
+	piece as sp 50*ps ae
+	end
+
+	length 204
+	piece as 2*sp 50*ps ae
+	end
+
+	length 205
+	piece as 2*sp 50*ps sp ae
+	end
+
+	length 206
+	piece as 2*sp 50*ps 2*sp ae
+	end
+
+	length 207
+	piece as sp 51*ps ae
+	end
+
+	length 208
+	piece as 2*sp 51*ps ae
+	end
+
+	length 209
+	piece as 2*sp 51*ps sp ae
+	end
+
+	length 210
+	piece as 2*sp 51*ps 2*sp ae
+	end
+
+	length 211
+	piece as sp 52*ps ae
+	end
+
+	length 212
+	piece as 2*sp 52*ps ae
+	end
+
+	length 213
+	piece as 2*sp 52*ps sp ae
+	end
+
+	length 214
+	piece as 2*sp 52*ps 2*sp ae
+	end
+
+	length 215
+	piece as sp 53*ps ae
+	end
+
+	length 216
+	piece as 2*sp 53*ps ae
+	end
+
+	length 217
+	piece as 2*sp 53*ps sp ae
+	end
+
+	length 218
+	piece as 2*sp 53*ps 2*sp ae
+	end
+
+	length 219
+	piece as sp 54*ps ae
+	end
+
+	length 220
+	piece as 2*sp 54*ps ae
+	end
+
+	length 221
+	piece as 2*sp 54*ps sp ae
+	end
+
+	length 222
+	piece as 2*sp 54*ps 2*sp ae
+	end
+
+	length 223
+	piece as sp 55*ps ae
+	end
+
+	length 224
+	piece as 2*sp 55*ps ae
+	end
+
+	length 225
+	piece as 2*sp 55*ps sp ae
+	end
+
+	length 226
+	piece as 2*sp 55*ps 2*sp ae
+	end
+
+	length 227
+	piece as sp 56*ps ae
+	end
+
+	length 228
+	piece as 2*sp 56*ps ae
+	end
+
+	length 229
+	piece as 2*sp 56*ps sp ae
+	end
+
+	length 230
+	piece as 2*sp 56*ps 2*sp ae
+	end
+
+	length 231
+	piece as sp 57*ps ae
+	end
+
+	length 232
+	piece as 2*sp 57*ps ae
+	end
+
+	length 233
+	piece as 2*sp 57*ps sp ae
+	end
+
+	length 234
+	piece as 2*sp 57*ps 2*sp ae
+	end
+
+	length 235
+	piece as sp 58*ps ae
+	end
+
+	length 236
+	piece as 2*sp 58*ps ae
+	end
+
+	length 237
+	piece as 2*sp 58*ps sp ae
+	end
+
+	length 238
+	piece as 2*sp 58*ps 2*sp ae
+	end
+
+	length 239
+	piece as sp 59*ps ae
+	end
+
+	length 240
+	piece as 2*sp 59*ps ae
+	end
+
+	length 241
+	piece as 2*sp 59*ps sp ae
+	end
+
+	length 242
+	piece as 2*sp 59*ps 2*sp ae
+	end
+
+	length 243
+	piece as sp 60*ps ae
+	end
+
+	length 244
+	piece as 2*sp 60*ps ae
+	end
+
+	length 245
+	piece as 2*sp 60*ps sp ae
+	end
+
+	length 246
+	piece as 2*sp 60*ps 2*sp ae
+	end
+
+	length 247
+	piece as sp 61*ps ae
+	end
+
+	length 248
+	piece as 2*sp 61*ps ae
+	end
+
+	length 249
+	piece as 2*sp 61*ps sp ae
+	end
+
+	length 250
+	piece as 2*sp 61*ps 2*sp ae
+	end
+
+	length 251
+	piece as sp 62*ps ae
+	end
+
+	length 252
+	piece as 2*sp 62*ps ae
+	end
+
+	length 253
+	piece as 2*sp 62*ps sp ae
+	end
+
+	length 254
+	piece as 2*sp 62*ps 2*sp ae
+	end
+end
+
+
+# Yellow Steel Girder (AVE-2) by IDS2 (09/23)
+
+bridge 27
+
+# abutment start - 1 tile
+section as
+	piece <0x403A0000, 0>
+end 
+
+# pillar section - 3 tiles
+section pi
+	piece <0x403A1000, 0>
+	piece <0x403A2000, 0>
+	piece <0x403A1000, 0>
+end 
+
+# span only - 1 tile
+section sp
+	piece <0x403A3000, 0>
+end 
+
+# combined repeat segment - 4 tiles
+section ps
+	piece pi sp
+end
+
+#abutment end - 1 tile
+section ae
+	piece <0x403A0000, 2>
+end
+
+	length 5
+	piece as 3*sp ae
+	end
+	
+	length 6
+	piece as 4*sp ae
+	end
+	
+	length 7
+	piece as sp ps ae
+	end
+	
+	length 8
+	piece as sp ps sp ae
+	end
+	
+	length 9
+	piece as 2*sp ps sp ae
+	end
+	
+	length 10
+	piece as 2*sp ps 2*sp ae
+	end
+	
+	length 11
+	piece as sp 2*ps ae
+	end
+	
+	length 12
+	piece as 2*sp 2*ps ae
+	end
+	
+	length 13
+	piece as 2*sp 2*ps sp ae
+	end
+	
+	length 14
+	piece as 2*sp ps sp ps sp ae
+	end
+	
+	length 15
+	piece as sp 3*ps ae
+	end
+	
+	length 16
+	piece as 2*sp 3*ps ae
+	end
+	
+	length 17
+	piece as 2*sp 3*ps sp ae
+	end
+	
+	length 18
+	piece as 2*sp 3*ps 2*sp ae
+	end
+	
+	length 19
+	piece as sp 4*ps ae
+	end
+	
+	length 20
+	piece as 2*sp 4*ps ae
+	end
+	
+	length 21
+	piece as 2*sp 4*ps sp ae
+	end
+	
+	length 22
+	piece as 2*sp 4*ps 2*sp ae
+	end
+	
+	length 23
+	piece as sp 5*ps ae
+	end
+
+	length 24
+	piece as 2*sp 5*ps ae
+	end
+
+	length 25
+	piece as 2*sp 5*ps sp ae
+	end
+
+	length 26
+	piece as 2*sp 5*ps 2*sp ae
+	end
+
+	length 27
+	piece as sp 6*ps ae
+	end
+
+	length 28
+	piece as 2*sp 6*ps ae
+	end
+
+	length 29
+	piece as 2*sp 6*ps sp ae
+	end
+
+	length 30
+	piece as 2*sp 6*ps 2*sp ae
+	end
+
+	length 31
+	piece as sp 7*ps ae
+	end
+
+	length 32
+	piece as 2*sp 7*ps ae
+	end
+
+	length 33
+	piece as 2*sp 7*ps sp ae
+	end
+
+	length 34
+	piece as 2*sp 7*ps 2*sp ae
+	end
+
+	length 35
+	piece as sp 8*ps ae
+	end
+
+	length 36
+	piece as 2*sp 8*ps ae
+	end
+
+	length 37
+	piece as 2*sp 8*ps sp ae
+	end
+
+	length 38
+	piece as 2*sp 8*ps 2*sp ae
+	end
+
+	length 39
+	piece as sp 9*ps ae
+	end
+
+	length 40
+	piece as 2*sp 9*ps ae
+	end
+
+	length 41
+	piece as 2*sp 9*ps sp ae
+	end
+
+	length 42
+	piece as 2*sp 9*ps 2*sp ae
+	end
+
+	length 43
+	piece as sp 10*ps ae
+	end
+
+	length 44
+	piece as 2*sp 10*ps ae
+	end
+
+	length 45
+	piece as 2*sp 10*ps sp ae
+	end
+
+	length 46
+	piece as 2*sp 10*ps 2*sp ae
+	end
+
+	length 47
+	piece as sp 11*ps ae
+	end
+
+	length 48
+	piece as 2*sp 11*ps ae
+	end
+
+	length 49
+	piece as 2*sp 11*ps sp ae
+	end
+
+	length 50
+	piece as 2*sp 11*ps 2*sp ae
+	end
+
+	length 51
+	piece as sp 12*ps ae
+	end
+
+	length 52
+	piece as 2*sp 12*ps ae
+	end
+
+	length 53
+	piece as 2*sp 12*ps sp ae
+	end
+
+	length 54
+	piece as 2*sp 12*ps 2*sp ae
+	end
+
+	length 55
+	piece as sp 13*ps ae
+	end
+
+	length 56
+	piece as 2*sp 13*ps ae
+	end
+
+	length 57
+	piece as 2*sp 13*ps sp ae
+	end
+
+	length 58
+	piece as 2*sp 13*ps 2*sp ae
+	end
+
+	length 59
+	piece as sp 14*ps ae
+	end
+
+	length 60
+	piece as 2*sp 14*ps ae
+	end
+
+	length 61
+	piece as 2*sp 14*ps sp ae
+	end
+
+	length 62
+	piece as 2*sp 14*ps 2*sp ae
+	end
+
+	length 63
+	piece as sp 15*ps ae
+	end
+
+	length 64
+	piece as 2*sp 15*ps ae
+	end
+
+	length 65
+	piece as 2*sp 15*ps sp ae
+	end
+
+	length 66
+	piece as 2*sp 15*ps 2*sp ae
+	end
+
+	length 67
+	piece as sp 16*ps ae
+	end
+
+	length 68
+	piece as 2*sp 16*ps ae
+	end
+
+	length 69
+	piece as 2*sp 16*ps sp ae
+	end
+
+	length 70
+	piece as 2*sp 16*ps 2*sp ae
+	end
+
+	length 71
+	piece as sp 17*ps ae
+	end
+
+	length 72
+	piece as 2*sp 17*ps ae
+	end
+
+	length 73
+	piece as 2*sp 17*ps sp ae
+	end
+
+	length 74
+	piece as 2*sp 17*ps 2*sp ae
+	end
+
+	length 75
+	piece as sp 18*ps ae
+	end
+
+	length 76
+	piece as 2*sp 18*ps ae
+	end
+
+	length 77
+	piece as 2*sp 18*ps sp ae
+	end
+
+	length 78
+	piece as 2*sp 18*ps 2*sp ae
+	end
+
+	length 79
+	piece as sp 19*ps ae
+	end
+
+	length 80
+	piece as 2*sp 19*ps ae
+	end
+
+	length 81
+	piece as 2*sp 19*ps sp ae
+	end
+
+	length 82
+	piece as 2*sp 19*ps 2*sp ae
+	end
+
+	length 83
+	piece as sp 20*ps ae
+	end
+
+	length 84
+	piece as 2*sp 20*ps ae
+	end
+
+	length 85
+	piece as 2*sp 20*ps sp ae
+	end
+
+	length 86
+	piece as 2*sp 20*ps 2*sp ae
+	end
+
+	length 87
+	piece as sp 21*ps ae
+	end
+
+	length 88
+	piece as 2*sp 21*ps ae
+	end
+
+	length 89
+	piece as 2*sp 21*ps sp ae
+	end
+
+	length 90
+	piece as 2*sp 21*ps 2*sp ae
+	end
+
+	length 91
+	piece as sp 22*ps ae
+	end
+
+	length 92
+	piece as 2*sp 22*ps ae
+	end
+
+	length 93
+	piece as 2*sp 22*ps sp ae
+	end
+
+	length 94
+	piece as 2*sp 22*ps 2*sp ae
+	end
+
+	length 95
+	piece as sp 23*ps ae
+	end
+
+	length 96
+	piece as 2*sp 23*ps ae
+	end
+
+	length 97
+	piece as 2*sp 23*ps sp ae
+	end
+
+	length 98
+	piece as 2*sp 23*ps 2*sp ae
+	end
+
+	length 99
+	piece as sp 24*ps ae
+	end
+
+	length 100
+	piece as 2*sp 24*ps ae
+	end
+
+	length 101
+	piece as 2*sp 24*ps sp ae
+	end
+
+	length 102
+	piece as 2*sp 24*ps 2*sp ae
+	end
+
+	length 103
+	piece as sp 25*ps ae
+	end
+
+	length 104
+	piece as 2*sp 25*ps ae
+	end
+
+	length 105
+	piece as 2*sp 25*ps sp ae
+	end
+
+	length 106
+	piece as 2*sp 25*ps 2*sp ae
+	end
+
+	length 107
+	piece as sp 26*ps ae
+	end
+
+	length 108
+	piece as 2*sp 26*ps ae
+	end
+
+	length 109
+	piece as 2*sp 26*ps sp ae
+	end
+
+	length 110
+	piece as 2*sp 26*ps 2*sp ae
+	end
+
+	length 111
+	piece as sp 27*ps ae
+	end
+
+	length 112
+	piece as 2*sp 27*ps ae
+	end
+
+	length 113
+	piece as 2*sp 27*ps sp ae
+	end
+
+	length 114
+	piece as 2*sp 27*ps 2*sp ae
+	end
+
+	length 115
+	piece as sp 28*ps ae
+	end
+
+	length 116
+	piece as 2*sp 28*ps ae
+	end
+
+	length 117
+	piece as 2*sp 28*ps sp ae
+	end
+
+	length 118
+	piece as 2*sp 28*ps 2*sp ae
+	end
+
+	length 119
+	piece as sp 29*ps ae
+	end
+
+	length 120
+	piece as 2*sp 29*ps ae
+	end
+
+	length 121
+	piece as 2*sp 29*ps sp ae
+	end
+
+	length 122
+	piece as 2*sp 29*ps 2*sp ae
+	end
+
+	length 123
+	piece as sp 30*ps ae
+	end
+
+	length 124
+	piece as 2*sp 30*ps ae
+	end
+
+	length 125
+	piece as 2*sp 30*ps sp ae
+	end
+
+	length 126
+	piece as 2*sp 30*ps 2*sp ae
+	end
+
+	length 127
+	piece as sp 31*ps ae
+	end
+
+	length 128
+	piece as 2*sp 31*ps ae
+	end
+
+	length 129
+	piece as 2*sp 31*ps sp ae
+	end
+
+	length 130
+	piece as 2*sp 31*ps 2*sp ae
+	end
+
+	length 131
+	piece as sp 32*ps ae
+	end
+
+	length 132
+	piece as 2*sp 32*ps ae
+	end
+
+	length 133
+	piece as 2*sp 32*ps sp ae
+	end
+
+	length 134
+	piece as 2*sp 32*ps 2*sp ae
+	end
+
+	length 135
+	piece as sp 33*ps ae
+	end
+
+	length 136
+	piece as 2*sp 33*ps ae
+	end
+
+	length 137
+	piece as 2*sp 33*ps sp ae
+	end
+
+	length 138
+	piece as 2*sp 33*ps 2*sp ae
+	end
+
+	length 139
+	piece as sp 34*ps ae
+	end
+
+	length 140
+	piece as 2*sp 34*ps ae
+	end
+
+	length 141
+	piece as 2*sp 34*ps sp ae
+	end
+
+	length 142
+	piece as 2*sp 34*ps 2*sp ae
+	end
+
+	length 143
+	piece as sp 35*ps ae
+	end
+
+	length 144
+	piece as 2*sp 35*ps ae
+	end
+
+	length 145
+	piece as 2*sp 35*ps sp ae
+	end
+
+	length 146
+	piece as 2*sp 35*ps 2*sp ae
+	end
+
+	length 147
+	piece as sp 36*ps ae
+	end
+
+	length 148
+	piece as 2*sp 36*ps ae
+	end
+
+	length 149
+	piece as 2*sp 36*ps sp ae
+	end
+
+	length 150
+	piece as 2*sp 36*ps 2*sp ae
+	end
+
+	length 151
+	piece as sp 37*ps ae
+	end
+
+	length 152
+	piece as 2*sp 37*ps ae
+	end
+
+	length 153
+	piece as 2*sp 37*ps sp ae
+	end
+
+	length 154
+	piece as 2*sp 37*ps 2*sp ae
+	end
+
+	length 155
+	piece as sp 38*ps ae
+	end
+
+	length 156
+	piece as 2*sp 38*ps ae
+	end
+
+	length 157
+	piece as 2*sp 38*ps sp ae
+	end
+
+	length 158
+	piece as 2*sp 38*ps 2*sp ae
+	end
+
+	length 159
+	piece as sp 39*ps ae
+	end
+
+	length 160
+	piece as 2*sp 39*ps ae
+	end
+
+	length 161
+	piece as 2*sp 39*ps sp ae
+	end
+
+	length 162
+	piece as 2*sp 39*ps 2*sp ae
+	end
+
+	length 163
+	piece as sp 40*ps ae
+	end
+
+	length 164
+	piece as 2*sp 40*ps ae
+	end
+
+	length 165
+	piece as 2*sp 40*ps sp ae
+	end
+
+	length 166
+	piece as 2*sp 40*ps 2*sp ae
+	end
+
+	length 167
+	piece as sp 41*ps ae
+	end
+
+	length 168
+	piece as 2*sp 41*ps ae
+	end
+
+	length 169
+	piece as 2*sp 41*ps sp ae
+	end
+
+	length 170
+	piece as 2*sp 41*ps 2*sp ae
+	end
+
+	length 171
+	piece as sp 42*ps ae
+	end
+
+	length 172
+	piece as 2*sp 42*ps ae
+	end
+
+	length 173
+	piece as 2*sp 42*ps sp ae
+	end
+
+	length 174
+	piece as 2*sp 42*ps 2*sp ae
+	end
+
+	length 175
+	piece as sp 43*ps ae
+	end
+
+	length 176
+	piece as 2*sp 43*ps ae
+	end
+
+	length 177
+	piece as 2*sp 43*ps sp ae
+	end
+
+	length 178
+	piece as 2*sp 43*ps 2*sp ae
+	end
+
+	length 179
+	piece as sp 44*ps ae
+	end
+
+	length 180
+
+	piece as 2*sp 44*ps ae
+	end
+
+	length 181
+	piece as 2*sp 44*ps sp ae
+	end
+
+	length 182
+	piece as 2*sp 44*ps 2*sp ae
+	end
+
+	length 183
+	piece as sp 45*ps ae
+	end
+
+	length 184
+	piece as 2*sp 45*ps ae
+	end
+
+	length 185
+	piece as 2*sp 45*ps sp ae
+	end
+
+	length 186
+	piece as 2*sp 45*ps 2*sp ae
+	end
+
+	length 187
+	piece as sp 46*ps ae
+	end
+
+	length 188
+	piece as 2*sp 46*ps ae
+	end
+
+	length 189
+	piece as 2*sp 46*ps sp ae
+	end
+
+	length 190
+	piece as 2*sp 46*ps 2*sp ae
+	end
+
+	length 191
+	piece as sp 47*ps ae
+	end
+
+	length 192
+	piece as 2*sp 47*ps ae
+	end
+
+	length 193
+	piece as 2*sp 47*ps sp ae
+	end
+
+	length 194
+	piece as 2*sp 47*ps 2*sp ae
+	end
+
+	length 195
+	piece as sp 48*ps ae
+	end
+
+	length 196
+	piece as 2*sp 48*ps ae
+	end
+
+	length 197
+	piece as 2*sp 48*ps sp ae
+	end
+
+	length 198
+	piece as 2*sp 48*ps 2*sp ae
+	end
+
+	length 199
+	piece as sp 49*ps ae
+	end
+
+	length 200
+	piece as 2*sp 49*ps ae
+	end
+
+	length 201
+	piece as 2*sp 49*ps sp ae
+	end
+
+	length 202
+	piece as 2*sp 49*ps 2*sp ae
+	end
+
+	length 203
+	piece as sp 50*ps ae
+	end
+
+	length 204
+	piece as 2*sp 50*ps ae
+	end
+
+	length 205
+	piece as 2*sp 50*ps sp ae
+	end
+
+	length 206
+	piece as 2*sp 50*ps 2*sp ae
+	end
+
+	length 207
+	piece as sp 51*ps ae
+	end
+
+	length 208
+	piece as 2*sp 51*ps ae
+	end
+
+	length 209
+	piece as 2*sp 51*ps sp ae
+	end
+
+	length 210
+	piece as 2*sp 51*ps 2*sp ae
+	end
+
+	length 211
+	piece as sp 52*ps ae
+	end
+
+	length 212
+	piece as 2*sp 52*ps ae
+	end
+
+	length 213
+	piece as 2*sp 52*ps sp ae
+	end
+
+	length 214
+	piece as 2*sp 52*ps 2*sp ae
+	end
+
+	length 215
+	piece as sp 53*ps ae
+	end
+
+	length 216
+	piece as 2*sp 53*ps ae
+	end
+
+	length 217
+	piece as 2*sp 53*ps sp ae
+	end
+
+	length 218
+	piece as 2*sp 53*ps 2*sp ae
+	end
+
+	length 219
+	piece as sp 54*ps ae
+	end
+
+	length 220
+	piece as 2*sp 54*ps ae
+	end
+
+	length 221
+	piece as 2*sp 54*ps sp ae
+	end
+
+	length 222
+	piece as 2*sp 54*ps 2*sp ae
+	end
+
+	length 223
+	piece as sp 55*ps ae
+	end
+
+	length 224
+	piece as 2*sp 55*ps ae
+	end
+
+	length 225
+	piece as 2*sp 55*ps sp ae
+	end
+
+	length 226
+	piece as 2*sp 55*ps 2*sp ae
+	end
+
+	length 227
+	piece as sp 56*ps ae
+	end
+
+	length 228
+	piece as 2*sp 56*ps ae
+	end
+
+	length 229
+	piece as 2*sp 56*ps sp ae
+	end
+
+	length 230
+	piece as 2*sp 56*ps 2*sp ae
+	end
+
+	length 231
+	piece as sp 57*ps ae
+	end
+
+	length 232
+	piece as 2*sp 57*ps ae
+	end
+
+	length 233
+	piece as 2*sp 57*ps sp ae
+	end
+
+	length 234
+	piece as 2*sp 57*ps 2*sp ae
+	end
+
+	length 235
+	piece as sp 58*ps ae
+	end
+
+	length 236
+	piece as 2*sp 58*ps ae
+	end
+
+	length 237
+	piece as 2*sp 58*ps sp ae
+	end
+
+	length 238
+	piece as 2*sp 58*ps 2*sp ae
+	end
+
+	length 239
+	piece as sp 59*ps ae
+	end
+
+	length 240
+	piece as 2*sp 59*ps ae
+	end
+
+	length 241
+	piece as 2*sp 59*ps sp ae
+	end
+
+	length 242
+	piece as 2*sp 59*ps 2*sp ae
+	end
+
+	length 243
+	piece as sp 60*ps ae
+	end
+
+	length 244
+	piece as 2*sp 60*ps ae
+	end
+
+	length 245
+	piece as 2*sp 60*ps sp ae
+	end
+
+	length 246
+	piece as 2*sp 60*ps 2*sp ae
+	end
+
+	length 247
+	piece as sp 61*ps ae
+	end
+
+	length 248
+	piece as 2*sp 61*ps ae
+	end
+
+	length 249
+	piece as 2*sp 61*ps sp ae
+	end
+
+	length 250
+	piece as 2*sp 61*ps 2*sp ae
+	end
+
+	length 251
+	piece as sp 62*ps ae
+	end
+
+	length 252
+	piece as 2*sp 62*ps ae
+	end
+
+	length 253
+	piece as 2*sp 62*ps sp ae
+	end
+
+	length 254
+	piece as 2*sp 62*ps 2*sp ae
+	end
+end
+
+
 # Yellow Steel Girder (ARD-3) by IDS2 (09/23)
 
 bridge 28
@@ -4444,6 +6512,1040 @@ end
 #abutment end - 1 tile
 section ae
 	piece <0x40367000, 0>
+end
+
+	length 5
+	piece as 3*sp ae
+	end
+	
+	length 6
+	piece as 4*sp ae
+	end
+	
+	length 7
+	piece as sp ps ae
+	end
+	
+	length 8
+	piece as sp ps sp ae
+	end
+	
+	length 9
+	piece as 2*sp ps sp ae
+	end
+	
+	length 10
+	piece as 2*sp ps 2*sp ae
+	end
+	
+	length 11
+	piece as sp 2*ps ae
+	end
+	
+	length 12
+	piece as 2*sp 2*ps ae
+	end
+	
+	length 13
+	piece as 2*sp 2*ps sp ae
+	end
+	
+	length 14
+	piece as 2*sp ps sp ps sp ae
+	end
+	
+	length 15
+	piece as sp 3*ps ae
+	end
+	
+	length 16
+	piece as 2*sp 3*ps ae
+	end
+	
+	length 17
+	piece as 2*sp 3*ps sp ae
+	end
+	
+	length 18
+	piece as 2*sp 3*ps 2*sp ae
+	end
+	
+	length 19
+	piece as sp 4*ps ae
+	end
+	
+	length 20
+	piece as 2*sp 4*ps ae
+	end
+	
+	length 21
+	piece as 2*sp 4*ps sp ae
+	end
+	
+	length 22
+	piece as 2*sp 4*ps 2*sp ae
+	end
+	
+	length 23
+	piece as sp 5*ps ae
+	end
+
+	length 24
+	piece as 2*sp 5*ps ae
+	end
+
+	length 25
+	piece as 2*sp 5*ps sp ae
+	end
+
+	length 26
+	piece as 2*sp 5*ps 2*sp ae
+	end
+
+	length 27
+	piece as sp 6*ps ae
+	end
+
+	length 28
+	piece as 2*sp 6*ps ae
+	end
+
+	length 29
+	piece as 2*sp 6*ps sp ae
+	end
+
+	length 30
+	piece as 2*sp 6*ps 2*sp ae
+	end
+
+	length 31
+	piece as sp 7*ps ae
+	end
+
+	length 32
+	piece as 2*sp 7*ps ae
+	end
+
+	length 33
+	piece as 2*sp 7*ps sp ae
+	end
+
+	length 34
+	piece as 2*sp 7*ps 2*sp ae
+	end
+
+	length 35
+	piece as sp 8*ps ae
+	end
+
+	length 36
+	piece as 2*sp 8*ps ae
+	end
+
+	length 37
+	piece as 2*sp 8*ps sp ae
+	end
+
+	length 38
+	piece as 2*sp 8*ps 2*sp ae
+	end
+
+	length 39
+	piece as sp 9*ps ae
+	end
+
+	length 40
+	piece as 2*sp 9*ps ae
+	end
+
+	length 41
+	piece as 2*sp 9*ps sp ae
+	end
+
+	length 42
+	piece as 2*sp 9*ps 2*sp ae
+	end
+
+	length 43
+	piece as sp 10*ps ae
+	end
+
+	length 44
+	piece as 2*sp 10*ps ae
+	end
+
+	length 45
+	piece as 2*sp 10*ps sp ae
+	end
+
+	length 46
+	piece as 2*sp 10*ps 2*sp ae
+	end
+
+	length 47
+	piece as sp 11*ps ae
+	end
+
+	length 48
+	piece as 2*sp 11*ps ae
+	end
+
+	length 49
+	piece as 2*sp 11*ps sp ae
+	end
+
+	length 50
+	piece as 2*sp 11*ps 2*sp ae
+	end
+
+	length 51
+	piece as sp 12*ps ae
+	end
+
+	length 52
+	piece as 2*sp 12*ps ae
+	end
+
+	length 53
+	piece as 2*sp 12*ps sp ae
+	end
+
+	length 54
+	piece as 2*sp 12*ps 2*sp ae
+	end
+
+	length 55
+	piece as sp 13*ps ae
+	end
+
+	length 56
+	piece as 2*sp 13*ps ae
+	end
+
+	length 57
+	piece as 2*sp 13*ps sp ae
+	end
+
+	length 58
+	piece as 2*sp 13*ps 2*sp ae
+	end
+
+	length 59
+	piece as sp 14*ps ae
+	end
+
+	length 60
+	piece as 2*sp 14*ps ae
+	end
+
+	length 61
+	piece as 2*sp 14*ps sp ae
+	end
+
+	length 62
+	piece as 2*sp 14*ps 2*sp ae
+	end
+
+	length 63
+	piece as sp 15*ps ae
+	end
+
+	length 64
+	piece as 2*sp 15*ps ae
+	end
+
+	length 65
+	piece as 2*sp 15*ps sp ae
+	end
+
+	length 66
+	piece as 2*sp 15*ps 2*sp ae
+	end
+
+	length 67
+	piece as sp 16*ps ae
+	end
+
+	length 68
+	piece as 2*sp 16*ps ae
+	end
+
+	length 69
+	piece as 2*sp 16*ps sp ae
+	end
+
+	length 70
+	piece as 2*sp 16*ps 2*sp ae
+	end
+
+	length 71
+	piece as sp 17*ps ae
+	end
+
+	length 72
+	piece as 2*sp 17*ps ae
+	end
+
+	length 73
+	piece as 2*sp 17*ps sp ae
+	end
+
+	length 74
+	piece as 2*sp 17*ps 2*sp ae
+	end
+
+	length 75
+	piece as sp 18*ps ae
+	end
+
+	length 76
+	piece as 2*sp 18*ps ae
+	end
+
+	length 77
+	piece as 2*sp 18*ps sp ae
+	end
+
+	length 78
+	piece as 2*sp 18*ps 2*sp ae
+	end
+
+	length 79
+	piece as sp 19*ps ae
+	end
+
+	length 80
+	piece as 2*sp 19*ps ae
+	end
+
+	length 81
+	piece as 2*sp 19*ps sp ae
+	end
+
+	length 82
+	piece as 2*sp 19*ps 2*sp ae
+	end
+
+	length 83
+	piece as sp 20*ps ae
+	end
+
+	length 84
+	piece as 2*sp 20*ps ae
+	end
+
+	length 85
+	piece as 2*sp 20*ps sp ae
+	end
+
+	length 86
+	piece as 2*sp 20*ps 2*sp ae
+	end
+
+	length 87
+	piece as sp 21*ps ae
+	end
+
+	length 88
+	piece as 2*sp 21*ps ae
+	end
+
+	length 89
+	piece as 2*sp 21*ps sp ae
+	end
+
+	length 90
+	piece as 2*sp 21*ps 2*sp ae
+	end
+
+	length 91
+	piece as sp 22*ps ae
+	end
+
+	length 92
+	piece as 2*sp 22*ps ae
+	end
+
+	length 93
+	piece as 2*sp 22*ps sp ae
+	end
+
+	length 94
+	piece as 2*sp 22*ps 2*sp ae
+	end
+
+	length 95
+	piece as sp 23*ps ae
+	end
+
+	length 96
+	piece as 2*sp 23*ps ae
+	end
+
+	length 97
+	piece as 2*sp 23*ps sp ae
+	end
+
+	length 98
+	piece as 2*sp 23*ps 2*sp ae
+	end
+
+	length 99
+	piece as sp 24*ps ae
+	end
+
+	length 100
+	piece as 2*sp 24*ps ae
+	end
+
+	length 101
+	piece as 2*sp 24*ps sp ae
+	end
+
+	length 102
+	piece as 2*sp 24*ps 2*sp ae
+	end
+
+	length 103
+	piece as sp 25*ps ae
+	end
+
+	length 104
+	piece as 2*sp 25*ps ae
+	end
+
+	length 105
+	piece as 2*sp 25*ps sp ae
+	end
+
+	length 106
+	piece as 2*sp 25*ps 2*sp ae
+	end
+
+	length 107
+	piece as sp 26*ps ae
+	end
+
+	length 108
+	piece as 2*sp 26*ps ae
+	end
+
+	length 109
+	piece as 2*sp 26*ps sp ae
+	end
+
+	length 110
+	piece as 2*sp 26*ps 2*sp ae
+	end
+
+	length 111
+	piece as sp 27*ps ae
+	end
+
+	length 112
+	piece as 2*sp 27*ps ae
+	end
+
+	length 113
+	piece as 2*sp 27*ps sp ae
+	end
+
+	length 114
+	piece as 2*sp 27*ps 2*sp ae
+	end
+
+	length 115
+	piece as sp 28*ps ae
+	end
+
+	length 116
+	piece as 2*sp 28*ps ae
+	end
+
+	length 117
+	piece as 2*sp 28*ps sp ae
+	end
+
+	length 118
+	piece as 2*sp 28*ps 2*sp ae
+	end
+
+	length 119
+	piece as sp 29*ps ae
+	end
+
+	length 120
+	piece as 2*sp 29*ps ae
+	end
+
+	length 121
+	piece as 2*sp 29*ps sp ae
+	end
+
+	length 122
+	piece as 2*sp 29*ps 2*sp ae
+	end
+
+	length 123
+	piece as sp 30*ps ae
+	end
+
+	length 124
+	piece as 2*sp 30*ps ae
+	end
+
+	length 125
+	piece as 2*sp 30*ps sp ae
+	end
+
+	length 126
+	piece as 2*sp 30*ps 2*sp ae
+	end
+
+	length 127
+	piece as sp 31*ps ae
+	end
+
+	length 128
+	piece as 2*sp 31*ps ae
+	end
+
+	length 129
+	piece as 2*sp 31*ps sp ae
+	end
+
+	length 130
+	piece as 2*sp 31*ps 2*sp ae
+	end
+
+	length 131
+	piece as sp 32*ps ae
+	end
+
+	length 132
+	piece as 2*sp 32*ps ae
+	end
+
+	length 133
+	piece as 2*sp 32*ps sp ae
+	end
+
+	length 134
+	piece as 2*sp 32*ps 2*sp ae
+	end
+
+	length 135
+	piece as sp 33*ps ae
+	end
+
+	length 136
+	piece as 2*sp 33*ps ae
+	end
+
+	length 137
+	piece as 2*sp 33*ps sp ae
+	end
+
+	length 138
+	piece as 2*sp 33*ps 2*sp ae
+	end
+
+	length 139
+	piece as sp 34*ps ae
+	end
+
+	length 140
+	piece as 2*sp 34*ps ae
+	end
+
+	length 141
+	piece as 2*sp 34*ps sp ae
+	end
+
+	length 142
+	piece as 2*sp 34*ps 2*sp ae
+	end
+
+	length 143
+	piece as sp 35*ps ae
+	end
+
+	length 144
+	piece as 2*sp 35*ps ae
+	end
+
+	length 145
+	piece as 2*sp 35*ps sp ae
+	end
+
+	length 146
+	piece as 2*sp 35*ps 2*sp ae
+	end
+
+	length 147
+	piece as sp 36*ps ae
+	end
+
+	length 148
+	piece as 2*sp 36*ps ae
+	end
+
+	length 149
+	piece as 2*sp 36*ps sp ae
+	end
+
+	length 150
+	piece as 2*sp 36*ps 2*sp ae
+	end
+
+	length 151
+	piece as sp 37*ps ae
+	end
+
+	length 152
+	piece as 2*sp 37*ps ae
+	end
+
+	length 153
+	piece as 2*sp 37*ps sp ae
+	end
+
+	length 154
+	piece as 2*sp 37*ps 2*sp ae
+	end
+
+	length 155
+	piece as sp 38*ps ae
+	end
+
+	length 156
+	piece as 2*sp 38*ps ae
+	end
+
+	length 157
+	piece as 2*sp 38*ps sp ae
+	end
+
+	length 158
+	piece as 2*sp 38*ps 2*sp ae
+	end
+
+	length 159
+	piece as sp 39*ps ae
+	end
+
+	length 160
+	piece as 2*sp 39*ps ae
+	end
+
+	length 161
+	piece as 2*sp 39*ps sp ae
+	end
+
+	length 162
+	piece as 2*sp 39*ps 2*sp ae
+	end
+
+	length 163
+	piece as sp 40*ps ae
+	end
+
+	length 164
+	piece as 2*sp 40*ps ae
+	end
+
+	length 165
+	piece as 2*sp 40*ps sp ae
+	end
+
+	length 166
+	piece as 2*sp 40*ps 2*sp ae
+	end
+
+	length 167
+	piece as sp 41*ps ae
+	end
+
+	length 168
+	piece as 2*sp 41*ps ae
+	end
+
+	length 169
+	piece as 2*sp 41*ps sp ae
+	end
+
+	length 170
+	piece as 2*sp 41*ps 2*sp ae
+	end
+
+	length 171
+	piece as sp 42*ps ae
+	end
+
+	length 172
+	piece as 2*sp 42*ps ae
+	end
+
+	length 173
+	piece as 2*sp 42*ps sp ae
+	end
+
+	length 174
+	piece as 2*sp 42*ps 2*sp ae
+	end
+
+	length 175
+	piece as sp 43*ps ae
+	end
+
+	length 176
+	piece as 2*sp 43*ps ae
+	end
+
+	length 177
+	piece as 2*sp 43*ps sp ae
+	end
+
+	length 178
+	piece as 2*sp 43*ps 2*sp ae
+	end
+
+	length 179
+	piece as sp 44*ps ae
+	end
+
+	length 180
+
+	piece as 2*sp 44*ps ae
+	end
+
+	length 181
+	piece as 2*sp 44*ps sp ae
+	end
+
+	length 182
+	piece as 2*sp 44*ps 2*sp ae
+	end
+
+	length 183
+	piece as sp 45*ps ae
+	end
+
+	length 184
+	piece as 2*sp 45*ps ae
+	end
+
+	length 185
+	piece as 2*sp 45*ps sp ae
+	end
+
+	length 186
+	piece as 2*sp 45*ps 2*sp ae
+	end
+
+	length 187
+	piece as sp 46*ps ae
+	end
+
+	length 188
+	piece as 2*sp 46*ps ae
+	end
+
+	length 189
+	piece as 2*sp 46*ps sp ae
+	end
+
+	length 190
+	piece as 2*sp 46*ps 2*sp ae
+	end
+
+	length 191
+	piece as sp 47*ps ae
+	end
+
+	length 192
+	piece as 2*sp 47*ps ae
+	end
+
+	length 193
+	piece as 2*sp 47*ps sp ae
+	end
+
+	length 194
+	piece as 2*sp 47*ps 2*sp ae
+	end
+
+	length 195
+	piece as sp 48*ps ae
+	end
+
+	length 196
+	piece as 2*sp 48*ps ae
+	end
+
+	length 197
+	piece as 2*sp 48*ps sp ae
+	end
+
+	length 198
+	piece as 2*sp 48*ps 2*sp ae
+	end
+
+	length 199
+	piece as sp 49*ps ae
+	end
+
+	length 200
+	piece as 2*sp 49*ps ae
+	end
+
+	length 201
+	piece as 2*sp 49*ps sp ae
+	end
+
+	length 202
+	piece as 2*sp 49*ps 2*sp ae
+	end
+
+	length 203
+	piece as sp 50*ps ae
+	end
+
+	length 204
+	piece as 2*sp 50*ps ae
+	end
+
+	length 205
+	piece as 2*sp 50*ps sp ae
+	end
+
+	length 206
+	piece as 2*sp 50*ps 2*sp ae
+	end
+
+	length 207
+	piece as sp 51*ps ae
+	end
+
+	length 208
+	piece as 2*sp 51*ps ae
+	end
+
+	length 209
+	piece as 2*sp 51*ps sp ae
+	end
+
+	length 210
+	piece as 2*sp 51*ps 2*sp ae
+	end
+
+	length 211
+	piece as sp 52*ps ae
+	end
+
+	length 212
+	piece as 2*sp 52*ps ae
+	end
+
+	length 213
+	piece as 2*sp 52*ps sp ae
+	end
+
+	length 214
+	piece as 2*sp 52*ps 2*sp ae
+	end
+
+	length 215
+	piece as sp 53*ps ae
+	end
+
+	length 216
+	piece as 2*sp 53*ps ae
+	end
+
+	length 217
+	piece as 2*sp 53*ps sp ae
+	end
+
+	length 218
+	piece as 2*sp 53*ps 2*sp ae
+	end
+
+	length 219
+	piece as sp 54*ps ae
+	end
+
+	length 220
+	piece as 2*sp 54*ps ae
+	end
+
+	length 221
+	piece as 2*sp 54*ps sp ae
+	end
+
+	length 222
+	piece as 2*sp 54*ps 2*sp ae
+	end
+
+	length 223
+	piece as sp 55*ps ae
+	end
+
+	length 224
+	piece as 2*sp 55*ps ae
+	end
+
+	length 225
+	piece as 2*sp 55*ps sp ae
+	end
+
+	length 226
+	piece as 2*sp 55*ps 2*sp ae
+	end
+
+	length 227
+	piece as sp 56*ps ae
+	end
+
+	length 228
+	piece as 2*sp 56*ps ae
+	end
+
+	length 229
+	piece as 2*sp 56*ps sp ae
+	end
+
+	length 230
+	piece as 2*sp 56*ps 2*sp ae
+	end
+
+	length 231
+	piece as sp 57*ps ae
+	end
+
+	length 232
+	piece as 2*sp 57*ps ae
+	end
+
+	length 233
+	piece as 2*sp 57*ps sp ae
+	end
+
+	length 234
+	piece as 2*sp 57*ps 2*sp ae
+	end
+
+	length 235
+	piece as sp 58*ps ae
+	end
+
+	length 236
+	piece as 2*sp 58*ps ae
+	end
+
+	length 237
+	piece as 2*sp 58*ps sp ae
+	end
+
+	length 238
+	piece as 2*sp 58*ps 2*sp ae
+	end
+
+	length 239
+	piece as sp 59*ps ae
+	end
+
+	length 240
+	piece as 2*sp 59*ps ae
+	end
+
+	length 241
+	piece as 2*sp 59*ps sp ae
+	end
+
+	length 242
+	piece as 2*sp 59*ps 2*sp ae
+	end
+
+	length 243
+	piece as sp 60*ps ae
+	end
+
+	length 244
+	piece as 2*sp 60*ps ae
+	end
+
+	length 245
+	piece as 2*sp 60*ps sp ae
+	end
+
+	length 246
+	piece as 2*sp 60*ps 2*sp ae
+	end
+
+	length 247
+	piece as sp 61*ps ae
+	end
+
+	length 248
+	piece as 2*sp 61*ps ae
+	end
+
+	length 249
+	piece as 2*sp 61*ps sp ae
+	end
+
+	length 250
+	piece as 2*sp 61*ps 2*sp ae
+	end
+
+	length 251
+	piece as sp 62*ps ae
+	end
+
+	length 252
+	piece as 2*sp 62*ps ae
+	end
+
+	length 253
+	piece as 2*sp 62*ps sp ae
+	end
+
+	length 254
+	piece as 2*sp 62*ps 2*sp ae
+	end
+end
+
+
+# Yellow Steel Girder (NRD-4) by IDS2 (09/23)
+
+bridge 29
+
+# abutment start - 1 tile
+section as
+	piece <0x403C0000, 0>
+end 
+
+# pillar section - 3 tiles
+section pi
+	piece <0x403C1000, 0>
+	piece <0x403C2000, 0>
+	piece <0x403C1000, 0>
+end 
+
+# span only - 1 tile
+section sp
+	piece <0x403C3000, 0>
+end 
+
+# combined repeat segment - 4 tiles
+section ps
+	piece pi sp
+end
+
+#abutment end - 1 tile
+section ae
+	piece <0x403C0000, 2>
 end
 
 	length 5
@@ -13408,4 +16510,3819 @@ end
 	length 254
 	piece sp pi sp ep 18*mp rev(ep) rev(sp) rev(pi) rev(sp)
 	end
+end
+
+
+# Blue Suspension (RD-2) by IDS2 (03/2024)
+
+bridge 38
+
+# abutment - 1 tile
+section ab
+	piece <0x40600000, 0>
+end
+
+# girder - 1 tile
+section gi
+	piece <0x40601000, 0>
+end
+
+# pillar - 1 tile
+section pi
+	piece <0x40602000, 0>
+end
+
+# girder pillar - 4 tiles
+section gp
+	piece <0x40602000, 0>
+	piece <0x40601000, 0>
+	piece <0x40601000, 0>
+	piece <0x40601000, 0>
+end
+
+# middle tower - 25 tiles
+section mt
+	piece <0x40605000, 0>
+	piece <0x40605000, 0>
+	piece <0x40605000, 0>
+	piece <0x40605000, 0>
+	piece <0x40605000, 0>
+	piece <0x40605000, 0>
+	piece <0x40605000, 0>
+	piece <0x40605000, 0>
+	piece <0x40605000, 0>
+	piece <0x40605000, 0>
+	piece <0x40607000, 0>
+	piece <0x40607000, 0>
+	piece <0x40606000, 0>
+	piece <0x40607000, 0>
+	piece <0x40607000, 0>
+	piece <0x40605000, 0>
+	piece <0x40605000, 0>
+	piece <0x40605000, 0>
+	piece <0x40605000, 0>
+	piece <0x40605000, 0>
+	piece <0x40605000, 0>
+	piece <0x40605000, 0>
+	piece <0x40605000, 0>
+	piece <0x40605000, 0>
+	piece <0x40605000, 0>
+end
+
+# end tower - 19 tiles
+section et
+	piece <0x40603000, 0>
+	piece <0x40601000, 0>
+	piece <0x40602000, 0>
+	piece <0x40601000, 0>
+	piece <0x40607000, 0>
+	piece <0x40607000, 0>
+	piece <0x40604000, 0>
+	piece <0x40607000, 0>
+	piece <0x40607000, 0>
+	piece <0x40605000, 0>
+	piece <0x40605000, 0>
+	piece <0x40605000, 0>
+	piece <0x40605000, 0>
+	piece <0x40605000, 0>
+	piece <0x40605000, 0>
+	piece <0x40605000, 0>
+	piece <0x40605000, 0>
+	piece <0x40605000, 0>
+	piece <0x40605000, 0>
+end 
+
+	length 40
+	piece ab et rev(et) rev(ab)
+	end
+
+	length 41
+	piece ab gi et rev(et) rev(ab)
+	end
+	
+	length 42
+	piece ab gi et rev(et) rev(gi) rev(ab)
+	end
+	
+	length 43
+	piece ab pi gi et rev(et) rev(gi) rev(ab)
+	end
+	
+	length 44
+	piece ab pi gi et rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 45
+	piece ab gi pi gi et rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 46
+	piece ab gi pi gi et rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 47
+	piece ab 2*gi pi gi et rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 48
+	piece ab 2*gi pi gi et rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 49
+	piece ab 3*gi pi gi et rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 50
+	piece ab 3*gi pi gi et rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 51
+	piece ab gp pi gi et rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 52
+	piece ab gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 53
+	piece ab gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 54
+	piece ab gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 55
+	piece ab 2*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 56
+	piece ab 2*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 57
+	piece ab 3*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 58
+	piece ab 3*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 59
+	piece ab 2*gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 60
+	piece ab 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 61
+	piece ab gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 62
+	piece ab gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 63
+	piece ab 2*gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 64
+	piece ab 2*gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+
+	length 65
+	piece ab et mt rev(et) rev(ab)
+	end
+	
+	length 66
+	piece ab gi et mt rev(et) rev(ab)
+	end
+	
+	length 67
+	piece ab gi et mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 68
+	piece ab pi gi et mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 69
+	piece ab pi gi et mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 70
+	piece ab gi pi gi et mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 71
+	piece ab gi pi gi et mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 72
+	piece ab 2*gi pi gi et mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 73
+	piece ab 2*gi pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 74
+	piece ab 3*gi pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 75
+	piece ab 3*gi pi gi et mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 76
+	piece ab gp pi gi et mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 77
+	piece ab gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 78
+	piece ab gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 79
+	piece ab gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 80
+	piece ab 2*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 81
+	piece ab 2*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 82
+	piece ab 3*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 83
+	piece ab 3*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 84
+	piece ab 2*gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 85
+	piece ab 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 86
+	piece ab gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 87
+	piece ab gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 88
+	piece ab 2*gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 89
+	piece ab 2*gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 90
+	piece ab et 2*mt rev(et) rev(ab)
+	end
+	
+	length 91
+	piece ab gi et 2*mt rev(et) rev(ab)
+	end
+	
+	length 92
+	piece ab gi et 2*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 93
+	piece ab pi gi et 2*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 94
+	piece ab pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 95
+	piece ab gi pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 96
+	piece ab gi pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 97
+	piece ab 2*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 98
+	piece ab 2*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 99
+	piece ab 3*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 100
+	piece ab 3*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 101
+	piece ab gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 102
+	piece ab gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 103
+	piece ab gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 104
+	piece ab gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 105
+	piece ab 2*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 106
+	piece ab 2*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 107
+	piece ab 3*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 108
+	piece ab 3*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 109
+	piece ab 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 110
+	piece ab 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 111
+	piece ab gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 112
+	piece ab gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 113
+	piece ab 2*gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 114
+	piece ab 2*gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 115
+	piece ab et 3*mt rev(et) rev(ab)
+	end
+	
+	length 116
+	piece ab gi et 3*mt rev(et) rev(ab)
+	end
+	
+	length 117
+	piece ab gi et 3*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 118
+	piece ab pi gi et 3*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 119
+	piece ab pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 120
+	piece ab gi pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 121
+	piece ab gi pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 122
+	piece ab 2*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 123
+	piece ab 2*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 124
+	piece ab 3*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 125
+	piece ab 3*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 126
+	piece ab gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 127
+	piece ab gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 128
+	piece ab gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 129
+	piece ab gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 130
+	piece ab 2*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 131
+	piece ab 2*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 132
+	piece ab 3*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 133
+	piece ab 3*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 134
+	piece ab 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 135
+	piece ab 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 136
+	piece ab gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 137
+	piece ab gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 138
+	piece ab 2*gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 139
+	piece ab 2*gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 140
+	piece ab et 4*mt rev(et) rev(ab)
+	end
+	
+	length 141
+	piece ab gi et 4*mt rev(et) rev(ab)
+	end
+	
+	length 142
+	piece ab gi et 4*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 143
+	piece ab pi gi et 4*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 144
+	piece ab pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 145
+	piece ab gi pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 146
+	piece ab gi pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 147
+	piece ab 2*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 148
+	piece ab 2*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 149
+	piece ab 3*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 150
+	piece ab 3*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 151
+	piece ab gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 152
+	piece ab gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 153
+	piece ab gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 154
+	piece ab gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 155
+	piece ab 2*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 156
+	piece ab 2*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 157
+	piece ab 3*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 158
+	piece ab 3*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 159
+	piece ab 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 160
+	piece ab 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 161
+	piece ab gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 162
+	piece ab gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 163
+	piece ab 2*gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 164
+	piece ab 2*gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 165
+	piece ab et 5*mt rev(et) rev(ab)
+	end
+	
+	length 166
+	piece ab gi et 5*mt rev(et) rev(ab)
+	end
+	
+	length 167
+	piece ab gi et 5*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 168
+	piece ab pi gi et 5*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 169
+	piece ab pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 170
+	piece ab gi pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 171
+	piece ab gi pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 172
+	piece ab 2*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 173
+	piece ab 2*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 174
+	piece ab 3*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 175
+	piece ab 3*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 176
+	piece ab gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 177
+	piece ab gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 178
+	piece ab gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 179
+	piece ab gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 180
+	piece ab 2*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 181
+	piece ab 2*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 182
+	piece ab 3*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 183
+	piece ab 3*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 184
+	piece ab 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 185
+	piece ab 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 186
+	piece ab gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 187
+	piece ab gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 188
+	piece ab 2*gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 189
+	piece ab 2*gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 190
+	piece ab et 6*mt rev(et) rev(ab)
+	end
+	
+	length 191
+	piece ab gi et 6*mt rev(et) rev(ab)
+	end
+	
+	length 192
+	piece ab gi et 6*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 193
+	piece ab pi gi et 6*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 194
+	piece ab pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 195
+	piece ab gi pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 196
+	piece ab gi pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 197
+	piece ab 2*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 198
+	piece ab 2*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 199
+	piece ab 3*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 200
+	piece ab 3*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 201
+	piece ab gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 202
+	piece ab gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 203
+	piece ab gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 204
+	piece ab gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 205
+	piece ab 2*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 206
+	piece ab 2*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 207
+	piece ab 3*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 208
+	piece ab 3*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 209
+	piece ab 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 210
+	piece ab 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 211
+	piece ab gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 212
+	piece ab gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 213
+	piece ab 2*gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 214
+	piece ab 2*gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 215
+	piece ab et 7*mt rev(et) rev(ab)
+	end
+	
+	length 216
+	piece ab gi et 7*mt rev(et) rev(ab)
+	end
+	
+	length 217
+	piece ab gi et 7*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 218
+	piece ab pi gi et 7*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 219
+	piece ab pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 220
+	piece ab gi pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 221
+	piece ab gi pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 222
+	piece ab 2*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 223
+	piece ab 2*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 224
+	piece ab 3*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 225
+	piece ab 3*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 226
+	piece ab gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 227
+	piece ab gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 228
+	piece ab gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 229
+	piece ab gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 230
+	piece ab 2*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 231
+	piece ab 2*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 232
+	piece ab 3*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 233
+	piece ab 3*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 234
+	piece ab 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 235
+	piece ab 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 236
+	piece ab gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 237
+	piece ab gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 238
+	piece ab 2*gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 239
+	piece ab 2*gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 240
+	piece ab et 8*mt rev(et) rev(ab)
+	end
+
+	length 241
+	piece ab gi et 8*mt rev(et) rev(ab)
+	end
+	
+	length 242
+	piece ab gi et 8*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 243
+	piece ab pi gi et 8*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 244
+	piece ab pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 245
+	piece ab gi pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 246
+	piece ab gi pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 247
+	piece ab 2*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 248
+	piece ab 2*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 249
+	piece ab 3*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 250
+	piece ab 3*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 251
+	piece ab gp pi gi et 8*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 252
+	piece ab gp pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 253
+	piece ab gi gp pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 254
+	piece ab gi gp pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+end
+
+
+# Blue Suspension (AVE-2) by IDS2 (03/2024)
+
+bridge 39
+
+# abutment - 1 tile
+section ab
+	piece <0x40610000, 0>
+end
+
+# girder - 1 tile
+section gi
+	piece <0x40611000, 0>
+end
+
+# pillar - 1 tile
+section pi
+	piece <0x40612000, 0>
+end
+
+# girder pillar - 4 tiles
+section gp
+	piece <0x40612000, 0>
+	piece <0x40611000, 0>
+	piece <0x40611000, 0>
+	piece <0x40611000, 0>
+end
+
+# middle tower - 25 tiles
+section mt
+	piece <0x40615000, 0>
+	piece <0x40615000, 0>
+	piece <0x40615000, 0>
+	piece <0x40615000, 0>
+	piece <0x40615000, 0>
+	piece <0x40615000, 0>
+	piece <0x40615000, 0>
+	piece <0x40615000, 0>
+	piece <0x40615000, 0>
+	piece <0x40615000, 0>
+	piece <0x40617000, 0>
+	piece <0x40617000, 0>
+	piece <0x40616000, 0>
+	piece <0x40617000, 0>
+	piece <0x40617000, 0>
+	piece <0x40615000, 0>
+	piece <0x40615000, 0>
+	piece <0x40615000, 0>
+	piece <0x40615000, 0>
+	piece <0x40615000, 0>
+	piece <0x40615000, 0>
+	piece <0x40615000, 0>
+	piece <0x40615000, 0>
+	piece <0x40615000, 0>
+	piece <0x40615000, 0>
+end
+
+# end tower - 19 tiles
+section et
+	piece <0x40613000, 0>
+	piece <0x40611000, 0>
+	piece <0x40612000, 0>
+	piece <0x40611000, 0>
+	piece <0x40617000, 0>
+	piece <0x40617000, 0>
+	piece <0x40614000, 0>
+	piece <0x40617000, 0>
+	piece <0x40617000, 0>
+	piece <0x40615000, 0>
+	piece <0x40615000, 0>
+	piece <0x40615000, 0>
+	piece <0x40615000, 0>
+	piece <0x40615000, 0>
+	piece <0x40615000, 0>
+	piece <0x40615000, 0>
+	piece <0x40615000, 0>
+	piece <0x40615000, 0>
+	piece <0x40615000, 0>
+end 
+
+	length 40
+	piece ab et rev(et) rev(ab)
+	end
+
+	length 41
+	piece ab gi et rev(et) rev(ab)
+	end
+	
+	length 42
+	piece ab gi et rev(et) rev(gi) rev(ab)
+	end
+	
+	length 43
+	piece ab pi gi et rev(et) rev(gi) rev(ab)
+	end
+	
+	length 44
+	piece ab pi gi et rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 45
+	piece ab gi pi gi et rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 46
+	piece ab gi pi gi et rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 47
+	piece ab 2*gi pi gi et rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 48
+	piece ab 2*gi pi gi et rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 49
+	piece ab 3*gi pi gi et rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 50
+	piece ab 3*gi pi gi et rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 51
+	piece ab gp pi gi et rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 52
+	piece ab gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 53
+	piece ab gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 54
+	piece ab gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 55
+	piece ab 2*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 56
+	piece ab 2*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 57
+	piece ab 3*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 58
+	piece ab 3*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 59
+	piece ab 2*gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 60
+	piece ab 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 61
+	piece ab gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 62
+	piece ab gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 63
+	piece ab 2*gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 64
+	piece ab 2*gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+
+	length 65
+	piece ab et mt rev(et) rev(ab)
+	end
+	
+	length 66
+	piece ab gi et mt rev(et) rev(ab)
+	end
+	
+	length 67
+	piece ab gi et mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 68
+	piece ab pi gi et mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 69
+	piece ab pi gi et mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 70
+	piece ab gi pi gi et mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 71
+	piece ab gi pi gi et mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 72
+	piece ab 2*gi pi gi et mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 73
+	piece ab 2*gi pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 74
+	piece ab 3*gi pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 75
+	piece ab 3*gi pi gi et mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 76
+	piece ab gp pi gi et mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 77
+	piece ab gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 78
+	piece ab gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 79
+	piece ab gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 80
+	piece ab 2*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 81
+	piece ab 2*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 82
+	piece ab 3*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 83
+	piece ab 3*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 84
+	piece ab 2*gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 85
+	piece ab 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 86
+	piece ab gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 87
+	piece ab gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 88
+	piece ab 2*gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 89
+	piece ab 2*gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 90
+	piece ab et 2*mt rev(et) rev(ab)
+	end
+	
+	length 91
+	piece ab gi et 2*mt rev(et) rev(ab)
+	end
+	
+	length 92
+	piece ab gi et 2*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 93
+	piece ab pi gi et 2*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 94
+	piece ab pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 95
+	piece ab gi pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 96
+	piece ab gi pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 97
+	piece ab 2*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 98
+	piece ab 2*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 99
+	piece ab 3*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 100
+	piece ab 3*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 101
+	piece ab gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 102
+	piece ab gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 103
+	piece ab gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 104
+	piece ab gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 105
+	piece ab 2*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 106
+	piece ab 2*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 107
+	piece ab 3*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 108
+	piece ab 3*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 109
+	piece ab 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 110
+	piece ab 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 111
+	piece ab gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 112
+	piece ab gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 113
+	piece ab 2*gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 114
+	piece ab 2*gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 115
+	piece ab et 3*mt rev(et) rev(ab)
+	end
+	
+	length 116
+	piece ab gi et 3*mt rev(et) rev(ab)
+	end
+	
+	length 117
+	piece ab gi et 3*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 118
+	piece ab pi gi et 3*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 119
+	piece ab pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 120
+	piece ab gi pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 121
+	piece ab gi pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 122
+	piece ab 2*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 123
+	piece ab 2*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 124
+	piece ab 3*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 125
+	piece ab 3*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 126
+	piece ab gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 127
+	piece ab gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 128
+	piece ab gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 129
+	piece ab gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 130
+	piece ab 2*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 131
+	piece ab 2*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 132
+	piece ab 3*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 133
+	piece ab 3*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 134
+	piece ab 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 135
+	piece ab 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 136
+	piece ab gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 137
+	piece ab gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 138
+	piece ab 2*gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 139
+	piece ab 2*gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 140
+	piece ab et 4*mt rev(et) rev(ab)
+	end
+	
+	length 141
+	piece ab gi et 4*mt rev(et) rev(ab)
+	end
+	
+	length 142
+	piece ab gi et 4*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 143
+	piece ab pi gi et 4*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 144
+	piece ab pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 145
+	piece ab gi pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 146
+	piece ab gi pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 147
+	piece ab 2*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 148
+	piece ab 2*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 149
+	piece ab 3*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 150
+	piece ab 3*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 151
+	piece ab gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 152
+	piece ab gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 153
+	piece ab gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 154
+	piece ab gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 155
+	piece ab 2*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 156
+	piece ab 2*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 157
+	piece ab 3*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 158
+	piece ab 3*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 159
+	piece ab 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 160
+	piece ab 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 161
+	piece ab gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 162
+	piece ab gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 163
+	piece ab 2*gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 164
+	piece ab 2*gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 165
+	piece ab et 5*mt rev(et) rev(ab)
+	end
+	
+	length 166
+	piece ab gi et 5*mt rev(et) rev(ab)
+	end
+	
+	length 167
+	piece ab gi et 5*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 168
+	piece ab pi gi et 5*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 169
+	piece ab pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 170
+	piece ab gi pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 171
+	piece ab gi pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 172
+	piece ab 2*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 173
+	piece ab 2*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 174
+	piece ab 3*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 175
+	piece ab 3*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 176
+	piece ab gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 177
+	piece ab gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 178
+	piece ab gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 179
+	piece ab gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 180
+	piece ab 2*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 181
+	piece ab 2*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 182
+	piece ab 3*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 183
+	piece ab 3*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 184
+	piece ab 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 185
+	piece ab 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 186
+	piece ab gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 187
+	piece ab gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 188
+	piece ab 2*gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 189
+	piece ab 2*gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 190
+	piece ab et 6*mt rev(et) rev(ab)
+	end
+	
+	length 191
+	piece ab gi et 6*mt rev(et) rev(ab)
+	end
+	
+	length 192
+	piece ab gi et 6*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 193
+	piece ab pi gi et 6*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 194
+	piece ab pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 195
+	piece ab gi pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 196
+	piece ab gi pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 197
+	piece ab 2*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 198
+	piece ab 2*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 199
+	piece ab 3*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 200
+	piece ab 3*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 201
+	piece ab gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 202
+	piece ab gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 203
+	piece ab gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 204
+	piece ab gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 205
+	piece ab 2*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 206
+	piece ab 2*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 207
+	piece ab 3*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 208
+	piece ab 3*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 209
+	piece ab 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 210
+	piece ab 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 211
+	piece ab gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 212
+	piece ab gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 213
+	piece ab 2*gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 214
+	piece ab 2*gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 215
+	piece ab et 7*mt rev(et) rev(ab)
+	end
+	
+	length 216
+	piece ab gi et 7*mt rev(et) rev(ab)
+	end
+	
+	length 217
+	piece ab gi et 7*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 218
+	piece ab pi gi et 7*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 219
+	piece ab pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 220
+	piece ab gi pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 221
+	piece ab gi pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 222
+	piece ab 2*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 223
+	piece ab 2*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 224
+	piece ab 3*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 225
+	piece ab 3*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 226
+	piece ab gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 227
+	piece ab gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 228
+	piece ab gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 229
+	piece ab gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 230
+	piece ab 2*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 231
+	piece ab 2*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 232
+	piece ab 3*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 233
+	piece ab 3*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 234
+	piece ab 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 235
+	piece ab 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 236
+	piece ab gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 237
+	piece ab gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 238
+	piece ab 2*gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 239
+	piece ab 2*gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 240
+	piece ab et 8*mt rev(et) rev(ab)
+	end
+
+	length 241
+	piece ab gi et 8*mt rev(et) rev(ab)
+	end
+	
+	length 242
+	piece ab gi et 8*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 243
+	piece ab pi gi et 8*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 244
+	piece ab pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 245
+	piece ab gi pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 246
+	piece ab gi pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 247
+	piece ab 2*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 248
+	piece ab 2*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 249
+	piece ab 3*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 250
+	piece ab 3*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 251
+	piece ab gp pi gi et 8*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 252
+	piece ab gp pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 253
+	piece ab gi gp pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 254
+	piece ab gi gp pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+end
+
+
+# Blue Suspension (ARD-3) by IDS2 (03/2024)
+
+bridge 40
+
+# abutment - 1 tile
+section ab
+	piece <0x40620000, 0>
+end
+
+# girder - 1 tile
+section gi
+	piece <0x40621000, 0>
+end
+
+# pillar - 1 tile
+section pi
+	piece <0x40622000, 0>
+end
+
+# girder pillar - 4 tiles
+section gp
+	piece <0x40622000, 0>
+	piece <0x40621000, 0>
+	piece <0x40621000, 0>
+	piece <0x40621000, 0>
+end
+
+# middle tower - 25 tiles
+section mt
+	piece <0x40625000, 0>
+	piece <0x40625000, 0>
+	piece <0x40625000, 0>
+	piece <0x40625000, 0>
+	piece <0x40625000, 0>
+	piece <0x40625000, 0>
+	piece <0x40625000, 0>
+	piece <0x40625000, 0>
+	piece <0x40625000, 0>
+	piece <0x40625000, 0>
+	piece <0x40627000, 0>
+	piece <0x40627000, 0>
+	piece <0x40626000, 0>
+	piece <0x40627000, 0>
+	piece <0x40627000, 0>
+	piece <0x40625000, 0>
+	piece <0x40625000, 0>
+	piece <0x40625000, 0>
+	piece <0x40625000, 0>
+	piece <0x40625000, 0>
+	piece <0x40625000, 0>
+	piece <0x40625000, 0>
+	piece <0x40625000, 0>
+	piece <0x40625000, 0>
+	piece <0x40625000, 0>
+end
+
+# end tower - 19 tiles
+section et
+	piece <0x40623000, 0>
+	piece <0x40621000, 0>
+	piece <0x40622000, 0>
+	piece <0x40621000, 0>
+	piece <0x40627000, 0>
+	piece <0x40627000, 0>
+	piece <0x40624000, 0>
+	piece <0x40627000, 0>
+	piece <0x40627000, 0>
+	piece <0x40625000, 0>
+	piece <0x40625000, 0>
+	piece <0x40625000, 0>
+	piece <0x40625000, 0>
+	piece <0x40625000, 0>
+	piece <0x40625000, 0>
+	piece <0x40625000, 0>
+	piece <0x40625000, 0>
+	piece <0x40625000, 0>
+	piece <0x40625000, 0>
+end 
+
+# abutment reversed - 1 tile
+section abr
+	piece <0x405C0000, 0>
+end
+
+# girder reversed - 1 tile
+section gir
+	piece <0x405C1000, 0>
+end
+
+# pillar reversed - 1 tile
+section pir
+	piece <0x405C2000, 0>
+end
+
+# girder pillar reversed - 4 tiles
+section gpr
+	piece <0x405C1000, 0>
+	piece <0x405C1000, 0>
+	piece <0x405C1000, 0>
+	piece <0x405C2000, 0>
+end
+
+# end tower reversed - 19 tiles
+section etr
+	piece <0x405C5000, 0>
+	piece <0x405C5000, 0>
+	piece <0x405C5000, 0>
+	piece <0x405C5000, 0>
+	piece <0x405C5000, 0>
+	piece <0x405C5000, 0>
+	piece <0x405C5000, 0>
+	piece <0x405C5000, 0>
+	piece <0x405C5000, 0>
+	piece <0x405C5000, 0>
+	piece <0x405C6000, 0>
+	piece <0x405C6000, 0>
+	piece <0x405C4000, 0>
+	piece <0x405C6000, 0>
+	piece <0x405C6000, 0>
+	piece <0x405C1000, 0>
+	piece <0x405C2000, 0>
+	piece <0x405C1000, 0>
+	piece <0x405C3000, 0>
+end 
+
+	length 40
+	piece ab et etr abr
+	end
+
+	length 41
+	piece ab gi et etr abr
+	end
+	
+	length 42
+	piece ab gi et etr gir abr
+	end
+	
+	length 43
+	piece ab pi gi et etr gir abr
+	end
+	
+	length 44
+	piece ab pi gi et etr gir pir abr
+	end	
+	
+	length 45
+	piece ab gi pi gi et etr gir pir abr
+	end	
+	
+	length 46
+	piece ab gi pi gi et etr gir pir gir abr
+	end	
+	
+	length 47
+	piece ab 2*gi pi gi et etr gir pir gir abr
+	end	
+	
+	length 48
+	piece ab 2*gi pi gi et etr gir pir 2*gir abr
+	end	
+	
+	length 49
+	piece ab 3*gi pi gi et etr gir pir 2*gir abr
+	end	
+	
+	length 50
+	piece ab 3*gi pi gi et etr gir pir 3*gir abr
+	end	
+	
+	length 51
+	piece ab gp pi gi et etr gir pir 3*gir abr
+	end	
+	
+	length 52
+	piece ab gp pi gi et etr gir pir gpr abr
+	end	
+	
+	length 53
+	piece ab gi gp pi gi et etr gir pir gpr abr
+	end
+	
+	length 54
+	piece ab gi gp pi gi et etr gir pir gpr gir abr
+	end
+	
+	length 55
+	piece ab 2*gi gp pi gi et etr gir pir gpr gir abr
+	end
+	
+	length 56
+	piece ab 2*gi gp pi gi et etr gir pir gpr 2*gir abr
+	end
+	
+	length 57
+	piece ab 3*gi gp pi gi et etr gir pir gpr 2*gir abr
+	end
+	
+	length 58
+	piece ab 3*gi gp pi gi et etr gir pir gpr 3*gir abr
+	end
+	
+	length 59
+	piece ab 2*gp pi gi et etr gir pir gpr 3*gir abr
+	end
+	
+	length 60
+	piece ab 2*gp pi gi et etr gir pir 2*gpr abr
+	end
+	
+	length 61
+	piece ab gi 2*gp pi gi et etr gir pir 2*gpr abr
+	end
+	
+	length 62
+	piece ab gi 2*gp pi gi et etr gir pir 2*gpr gir abr
+	end
+	
+	length 63
+	piece ab 2*gi 2*gp pi gi et etr gir pir 2*gpr gir abr
+	end
+	
+	length 64
+	piece ab 2*gi 2*gp pi gi et etr gir pir 2*gpr 2*gir abr
+	end
+
+	length 65
+	piece ab et mt etr abr
+	end
+	
+	length 66
+	piece ab gi et mt etr abr
+	end
+	
+	length 67
+	piece ab gi et mt etr gir abr
+	end
+	
+	length 68
+	piece ab pi gi et mt etr gir abr
+	end
+	
+	length 69
+	piece ab pi gi et mt etr gir pir abr
+	end	
+	
+	length 70
+	piece ab gi pi gi et mt etr gir pir abr
+	end	
+	
+	length 71
+	piece ab gi pi gi et mt etr gir pir gir abr
+	end	
+	
+	length 72
+	piece ab 2*gi pi gi et mt etr gir pir gir abr
+	end	
+	
+	length 73
+	piece ab 2*gi pi gi et mt etr gir pir 2*gir abr
+	end	
+	
+	length 74
+	piece ab 3*gi pi gi et mt etr gir pir 2*gir abr
+	end	
+	
+	length 75
+	piece ab 3*gi pi gi et mt etr gir pir 3*gir abr
+	end	
+	
+	length 76
+	piece ab gp pi gi et mt etr gir pir 3*gir abr
+	end	
+	
+	length 77
+	piece ab gp pi gi et mt etr gir pir gpr abr
+	end	
+	
+	length 78
+	piece ab gi gp pi gi et mt etr gir pir gpr abr
+	end
+	
+	length 79
+	piece ab gi gp pi gi et mt etr gir pir gpr gir abr
+	end
+	
+	length 80
+	piece ab 2*gi gp pi gi et mt etr gir pir gpr gir abr
+	end
+	
+	length 81
+	piece ab 2*gi gp pi gi et mt etr gir pir gpr 2*gir abr
+	end
+	
+	length 82
+	piece ab 3*gi gp pi gi et mt etr gir pir gpr 2*gir abr
+	end
+	
+	length 83
+	piece ab 3*gi gp pi gi et mt etr gir pir gpr 3*gir abr
+	end
+	
+	length 84
+	piece ab 2*gp pi gi et mt etr gir pir gpr 3*gir abr
+	end
+	
+	length 85
+	piece ab 2*gp pi gi et mt etr gir pir 2*gpr abr
+	end
+	
+	length 86
+	piece ab gi 2*gp pi gi et mt etr gir pir 2*gpr abr
+	end
+	
+	length 87
+	piece ab gi 2*gp pi gi et mt etr gir pir 2*gpr gir abr
+	end
+	
+	length 88
+	piece ab 2*gi 2*gp pi gi et mt etr gir pir 2*gpr gir abr
+	end
+	
+	length 89
+	piece ab 2*gi 2*gp pi gi et mt etr gir pir 2*gpr 2*gir abr
+	end
+	
+	length 90
+	piece ab et 2*mt etr abr
+	end
+	
+	length 91
+	piece ab gi et 2*mt etr abr
+	end
+	
+	length 92
+	piece ab gi et 2*mt etr gir abr
+	end
+	
+	length 93
+	piece ab pi gi et 2*mt etr gir abr
+	end
+	
+	length 94
+	piece ab pi gi et 2*mt etr gir pir abr
+	end	
+	
+	length 95
+	piece ab gi pi gi et 2*mt etr gir pir abr
+	end	
+	
+	length 96
+	piece ab gi pi gi et 2*mt etr gir pir gir abr
+	end	
+	
+	length 97
+	piece ab 2*gi pi gi et 2*mt etr gir pir gir abr
+	end	
+	
+	length 98
+	piece ab 2*gi pi gi et 2*mt etr gir pir 2*gir abr
+	end	
+	
+	length 99
+	piece ab 3*gi pi gi et 2*mt etr gir pir 2*gir abr
+	end	
+	
+	length 100
+	piece ab 3*gi pi gi et 2*mt etr gir pir 3*gir abr
+	end	
+	
+	length 101
+	piece ab gp pi gi et 2*mt etr gir pir 3*gir abr
+	end	
+	
+	length 102
+	piece ab gp pi gi et 2*mt etr gir pir gpr abr
+	end	
+	
+	length 103
+	piece ab gi gp pi gi et 2*mt etr gir pir gpr abr
+	end
+	
+	length 104
+	piece ab gi gp pi gi et 2*mt etr gir pir gpr gir abr
+	end
+	
+	length 105
+	piece ab 2*gi gp pi gi et 2*mt etr gir pir gpr gir abr
+	end
+	
+	length 106
+	piece ab 2*gi gp pi gi et 2*mt etr gir pir gpr 2*gir abr
+	end
+	
+	length 107
+	piece ab 3*gi gp pi gi et 2*mt etr gir pir gpr 2*gir abr
+	end
+	
+	length 108
+	piece ab 3*gi gp pi gi et 2*mt etr gir pir gpr 3*gir abr
+	end
+	
+	length 109
+	piece ab 2*gp pi gi et 2*mt etr gir pir gpr 3*gir abr
+	end
+	
+	length 110
+	piece ab 2*gp pi gi et 2*mt etr gir pir 2*gpr abr
+	end
+	
+	length 111
+	piece ab gi 2*gp pi gi et 2*mt etr gir pir 2*gpr abr
+	end
+	
+	length 112
+	piece ab gi 2*gp pi gi et 2*mt etr gir pir 2*gpr gir abr
+	end
+	
+	length 113
+	piece ab 2*gi 2*gp pi gi et 2*mt etr gir pir 2*gpr gir abr
+	end
+	
+	length 114
+	piece ab 2*gi 2*gp pi gi et 2*mt etr gir pir 2*gpr 2*gir abr
+	end
+	
+	length 115
+	piece ab et 3*mt etr abr
+	end
+	
+	length 116
+	piece ab gi et 3*mt etr abr
+	end
+	
+	length 117
+	piece ab gi et 3*mt etr gir abr
+	end
+	
+	length 118
+	piece ab pi gi et 3*mt etr gir abr
+	end
+	
+	length 119
+	piece ab pi gi et 3*mt etr gir pir abr
+	end	
+	
+	length 120
+	piece ab gi pi gi et 3*mt etr gir pir abr
+	end	
+	
+	length 121
+	piece ab gi pi gi et 3*mt etr gir pir gir abr
+	end	
+	
+	length 122
+	piece ab 2*gi pi gi et 3*mt etr gir pir gir abr
+	end	
+	
+	length 123
+	piece ab 2*gi pi gi et 3*mt etr gir pir 2*gir abr
+	end	
+	
+	length 124
+	piece ab 3*gi pi gi et 3*mt etr gir pir 2*gir abr
+	end	
+	
+	length 125
+	piece ab 3*gi pi gi et 3*mt etr gir pir 3*gir abr
+	end	
+	
+	length 126
+	piece ab gp pi gi et 3*mt etr gir pir 3*gir abr
+	end	
+	
+	length 127
+	piece ab gp pi gi et 3*mt etr gir pir gpr abr
+	end	
+	
+	length 128
+	piece ab gi gp pi gi et 3*mt etr gir pir gpr abr
+	end
+	
+	length 129
+	piece ab gi gp pi gi et 3*mt etr gir pir gpr gir abr
+	end
+	
+	length 130
+	piece ab 2*gi gp pi gi et 3*mt etr gir pir gpr gir abr
+	end
+	
+	length 131
+	piece ab 2*gi gp pi gi et 3*mt etr gir pir gpr 2*gir abr
+	end
+	
+	length 132
+	piece ab 3*gi gp pi gi et 3*mt etr gir pir gpr 2*gir abr
+	end
+	
+	length 133
+	piece ab 3*gi gp pi gi et 3*mt etr gir pir gpr 3*gir abr
+	end
+	
+	length 134
+	piece ab 2*gp pi gi et 3*mt etr gir pir gpr 3*gir abr
+	end
+	
+	length 135
+	piece ab 2*gp pi gi et 3*mt etr gir pir 2*gpr abr
+	end
+	
+	length 136
+	piece ab gi 2*gp pi gi et 3*mt etr gir pir 2*gpr abr
+	end
+	
+	length 137
+	piece ab gi 2*gp pi gi et 3*mt etr gir pir 2*gpr gir abr
+	end
+	
+	length 138
+	piece ab 2*gi 2*gp pi gi et 3*mt etr gir pir 2*gpr gir abr
+	end
+	
+	length 139
+	piece ab 2*gi 2*gp pi gi et 3*mt etr gir pir 2*gpr 2*gir abr
+	end
+	
+	length 140
+	piece ab et 4*mt etr abr
+	end
+	
+	length 141
+	piece ab gi et 4*mt etr abr
+	end
+	
+	length 142
+	piece ab gi et 4*mt etr gir abr
+	end
+	
+	length 143
+	piece ab pi gi et 4*mt etr gir abr
+	end
+	
+	length 144
+	piece ab pi gi et 4*mt etr gir pir abr
+	end	
+	
+	length 145
+	piece ab gi pi gi et 4*mt etr gir pir abr
+	end	
+	
+	length 146
+	piece ab gi pi gi et 4*mt etr gir pir gir abr
+	end	
+	
+	length 147
+	piece ab 2*gi pi gi et 4*mt etr gir pir gir abr
+	end	
+	
+	length 148
+	piece ab 2*gi pi gi et 4*mt etr gir pir 2*gir abr
+	end	
+	
+	length 149
+	piece ab 3*gi pi gi et 4*mt etr gir pir 2*gir abr
+	end	
+	
+	length 150
+	piece ab 3*gi pi gi et 4*mt etr gir pir 3*gir abr
+	end	
+	
+	length 151
+	piece ab gp pi gi et 4*mt etr gir pir 3*gir abr
+	end	
+	
+	length 152
+	piece ab gp pi gi et 4*mt etr gir pir gpr abr
+	end	
+	
+	length 153
+	piece ab gi gp pi gi et 4*mt etr gir pir gpr abr
+	end
+	
+	length 154
+	piece ab gi gp pi gi et 4*mt etr gir pir gpr gir abr
+	end
+	
+	length 155
+	piece ab 2*gi gp pi gi et 4*mt etr gir pir gpr gir abr
+	end
+	
+	length 156
+	piece ab 2*gi gp pi gi et 4*mt etr gir pir gpr 2*gir abr
+	end
+	
+	length 157
+	piece ab 3*gi gp pi gi et 4*mt etr gir pir gpr 2*gir abr
+	end
+	
+	length 158
+	piece ab 3*gi gp pi gi et 4*mt etr gir pir gpr 3*gir abr
+	end
+	
+	length 159
+	piece ab 2*gp pi gi et 4*mt etr gir pir gpr 3*gir abr
+	end
+	
+	length 160
+
+	piece ab 2*gp pi gi et 4*mt etr gir pir 2*gpr abr
+	end
+	
+	length 161
+	piece ab gi 2*gp pi gi et 4*mt etr gir pir 2*gpr abr
+	end
+	
+	length 162
+	piece ab gi 2*gp pi gi et 4*mt etr gir pir 2*gpr gir abr
+	end
+	
+	length 163
+	piece ab 2*gi 2*gp pi gi et 4*mt etr gir pir 2*gpr gir abr
+	end
+	
+	length 164
+	piece ab 2*gi 2*gp pi gi et 4*mt etr gir pir 2*gpr 2*gir abr
+	end
+	
+	length 165
+	piece ab et 5*mt etr abr
+	end
+	
+	length 166
+	piece ab gi et 5*mt etr abr
+	end
+	
+	length 167
+	piece ab gi et 5*mt etr gir abr
+	end
+	
+	length 168
+	piece ab pi gi et 5*mt etr gir abr
+	end
+	
+	length 169
+	piece ab pi gi et 5*mt etr gir pir abr
+	end	
+	
+	length 170
+	piece ab gi pi gi et 5*mt etr gir pir abr
+	end	
+	
+	length 171
+	piece ab gi pi gi et 5*mt etr gir pir gir abr
+	end	
+	
+	length 172
+	piece ab 2*gi pi gi et 5*mt etr gir pir gir abr
+	end	
+	
+	length 173
+	piece ab 2*gi pi gi et 5*mt etr gir pir 2*gir abr
+	end	
+	
+	length 174
+	piece ab 3*gi pi gi et 5*mt etr gir pir 2*gir abr
+	end	
+	
+	length 175
+	piece ab 3*gi pi gi et 5*mt etr gir pir 3*gir abr
+	end	
+	
+	length 176
+	piece ab gp pi gi et 5*mt etr gir pir 3*gir abr
+	end	
+	
+	length 177
+	piece ab gp pi gi et 5*mt etr gir pir gpr abr
+	end	
+	
+	length 178
+	piece ab gi gp pi gi et 5*mt etr gir pir gpr abr
+	end
+	
+	length 179
+	piece ab gi gp pi gi et 5*mt etr gir pir gpr gir abr
+	end
+	
+	length 180
+	piece ab 2*gi gp pi gi et 5*mt etr gir pir gpr gir abr
+	end
+	
+	length 181
+	piece ab 2*gi gp pi gi et 5*mt etr gir pir gpr 2*gir abr
+	end
+	
+	length 182
+	piece ab 3*gi gp pi gi et 5*mt etr gir pir gpr 2*gir abr
+	end
+	
+	length 183
+	piece ab 3*gi gp pi gi et 5*mt etr gir pir gpr 3*gir abr
+	end
+	
+	length 184
+	piece ab 2*gp pi gi et 5*mt etr gir pir gpr 3*gir abr
+	end
+	
+	length 185
+	piece ab 2*gp pi gi et 5*mt etr gir pir 2*gpr abr
+	end
+	
+	length 186
+	piece ab gi 2*gp pi gi et 5*mt etr gir pir 2*gpr abr
+	end
+	
+	length 187
+	piece ab gi 2*gp pi gi et 5*mt etr gir pir 2*gpr gir abr
+	end
+	
+	length 188
+	piece ab 2*gi 2*gp pi gi et 5*mt etr gir pir 2*gpr gir abr
+	end
+	
+	length 189
+	piece ab 2*gi 2*gp pi gi et 5*mt etr gir pir 2*gpr 2*gir abr
+	end
+	
+	length 190
+	piece ab et 6*mt etr abr
+	end
+	
+	length 191
+	piece ab gi et 6*mt etr abr
+	end
+	
+	length 192
+	piece ab gi et 6*mt etr gir abr
+	end
+	
+	length 193
+	piece ab pi gi et 6*mt etr gir abr
+	end
+	
+	length 194
+	piece ab pi gi et 6*mt etr gir pir abr
+	end	
+	
+	length 195
+	piece ab gi pi gi et 6*mt etr gir pir abr
+	end	
+	
+	length 196
+	piece ab gi pi gi et 6*mt etr gir pir gir abr
+	end	
+	
+	length 197
+	piece ab 2*gi pi gi et 6*mt etr gir pir gir abr
+	end	
+	
+	length 198
+	piece ab 2*gi pi gi et 6*mt etr gir pir 2*gir abr
+	end	
+	
+	length 199
+	piece ab 3*gi pi gi et 6*mt etr gir pir 2*gir abr
+	end	
+	
+	length 200
+	piece ab 3*gi pi gi et 6*mt etr gir pir 3*gir abr
+	end	
+	
+	length 201
+	piece ab gp pi gi et 6*mt etr gir pir 3*gir abr
+	end	
+	
+	length 202
+	piece ab gp pi gi et 6*mt etr gir pir gpr abr
+	end	
+	
+	length 203
+	piece ab gi gp pi gi et 6*mt etr gir pir gpr abr
+	end
+	
+	length 204
+	piece ab gi gp pi gi et 6*mt etr gir pir gpr gir abr
+	end
+	
+	length 205
+	piece ab 2*gi gp pi gi et 6*mt etr gir pir gpr gir abr
+	end
+	
+	length 206
+	piece ab 2*gi gp pi gi et 6*mt etr gir pir gpr 2*gir abr
+	end
+	
+	length 207
+	piece ab 3*gi gp pi gi et 6*mt etr gir pir gpr 2*gir abr
+	end
+	
+	length 208
+	piece ab 3*gi gp pi gi et 6*mt etr gir pir gpr 3*gir abr
+	end
+	
+	length 209
+	piece ab 2*gp pi gi et 6*mt etr gir pir gpr 3*gir abr
+	end
+	
+	length 210
+	piece ab 2*gp pi gi et 6*mt etr gir pir 2*gpr abr
+	end
+	
+	length 211
+	piece ab gi 2*gp pi gi et 6*mt etr gir pir 2*gpr abr
+	end
+	
+	length 212
+	piece ab gi 2*gp pi gi et 6*mt etr gir pir 2*gpr gir abr
+	end
+	
+	length 213
+	piece ab 2*gi 2*gp pi gi et 6*mt etr gir pir 2*gpr gir abr
+	end
+	
+	length 214
+	piece ab 2*gi 2*gp pi gi et 6*mt etr gir pir 2*gpr 2*gir abr
+	end
+	
+	length 215
+	piece ab et 7*mt etr abr
+	end
+	
+	length 216
+	piece ab gi et 7*mt etr abr
+	end
+	
+	length 217
+	piece ab gi et 7*mt etr gir abr
+	end
+	
+	length 218
+	piece ab pi gi et 7*mt etr gir abr
+	end
+	
+	length 219
+	piece ab pi gi et 7*mt etr gir pir abr
+	end	
+	
+	length 220
+	piece ab gi pi gi et 7*mt etr gir pir abr
+	end	
+	
+	length 221
+	piece ab gi pi gi et 7*mt etr gir pir gir abr
+	end	
+	
+	length 222
+	piece ab 2*gi pi gi et 7*mt etr gir pir gir abr
+	end	
+	
+	length 223
+	piece ab 2*gi pi gi et 7*mt etr gir pir 2*gir abr
+	end	
+	
+	length 224
+	piece ab 3*gi pi gi et 7*mt etr gir pir 2*gir abr
+	end	
+	
+	length 225
+	piece ab 3*gi pi gi et 7*mt etr gir pir 3*gir abr
+	end	
+	
+	length 226
+	piece ab gp pi gi et 7*mt etr gir pir 3*gir abr
+	end	
+	
+	length 227
+	piece ab gp pi gi et 7*mt etr gir pir gpr abr
+	end	
+	
+	length 228
+	piece ab gi gp pi gi et 7*mt etr gir pir gpr abr
+	end
+	
+	length 229
+	piece ab gi gp pi gi et 7*mt etr gir pir gpr gir abr
+	end
+	
+	length 230
+	piece ab 2*gi gp pi gi et 7*mt etr gir pir gpr gir abr
+	end
+	
+	length 231
+	piece ab 2*gi gp pi gi et 7*mt etr gir pir gpr 2*gir abr
+	end
+	
+	length 232
+	piece ab 3*gi gp pi gi et 7*mt etr gir pir gpr 2*gir abr
+	end
+	
+	length 233
+	piece ab 3*gi gp pi gi et 7*mt etr gir pir gpr 3*gir abr
+	end
+	
+	length 234
+	piece ab 2*gp pi gi et 7*mt etr gir pir gpr 3*gir abr
+	end
+	
+	length 235
+	piece ab 2*gp pi gi et 7*mt etr gir pir 2*gpr abr
+	end
+	
+	length 236
+	piece ab gi 2*gp pi gi et 7*mt etr gir pir 2*gpr abr
+	end
+	
+	length 237
+	piece ab gi 2*gp pi gi et 7*mt etr gir pir 2*gpr gir abr
+	end
+	
+	length 238
+	piece ab 2*gi 2*gp pi gi et 7*mt etr gir pir 2*gpr gir abr
+	end
+	
+	length 239
+	piece ab 2*gi 2*gp pi gi et 7*mt etr gir pir 2*gpr 2*gir abr
+	end
+	
+	length 240
+	piece ab et 8*mt etr abr
+	end
+
+	length 241
+	piece ab gi et 8*mt etr abr
+	end
+	
+	length 242
+	piece ab gi et 8*mt etr gir abr
+	end
+	
+	length 243
+	piece ab pi gi et 8*mt etr gir abr
+	end
+	
+	length 244
+	piece ab pi gi et 8*mt etr gir pir abr
+	end	
+	
+	length 245
+	piece ab gi pi gi et 8*mt etr gir pir abr
+	end	
+	
+	length 246
+	piece ab gi pi gi et 8*mt etr gir pir gir abr
+	end	
+	
+	length 247
+	piece ab 2*gi pi gi et 8*mt etr gir pir gir abr
+	end	
+	
+	length 248
+	piece ab 2*gi pi gi et 8*mt etr gir pir 2*gir abr
+	end	
+	
+	length 249
+	piece ab 3*gi pi gi et 8*mt etr gir pir 2*gir abr
+	end	
+	
+	length 250
+	piece ab 3*gi pi gi et 8*mt etr gir pir 3*gir abr
+	end	
+	
+	length 251
+	piece ab gp pi gi et 8*mt etr gir pir 3*gir abr
+	end	
+	
+	length 252
+	piece ab gp pi gi et 8*mt etr gir pir gpr abr
+	end	
+	
+	length 253
+	piece ab gi gp pi gi et 8*mt etr gir pir gpr abr
+	end
+	
+	length 254
+	piece ab gi gp pi gi et 8*mt etr gir pir gpr gir abr
+	end
+	
+end
+
+
+# Blue Suspension (NRD-4) by IDS2 (03/2024)
+
+bridge 41
+
+# abutment - 1 tile
+section ab
+	piece <0x40630000, 0>
+end
+
+# girder - 1 tile
+section gi
+	piece <0x40631000, 0>
+end
+
+# pillar - 1 tile
+section pi
+	piece <0x40632000, 0>
+end
+
+# girder pillar - 4 tiles
+section gp
+	piece <0x40632000, 0>
+	piece <0x40631000, 0>
+	piece <0x40631000, 0>
+	piece <0x40631000, 0>
+end
+
+# middle tower - 25 tiles
+section mt
+	piece <0x40635000, 0>
+	piece <0x40635000, 0>
+	piece <0x40635000, 0>
+	piece <0x40635000, 0>
+	piece <0x40635000, 0>
+	piece <0x40635000, 0>
+	piece <0x40635000, 0>
+	piece <0x40635000, 0>
+	piece <0x40635000, 0>
+	piece <0x40635000, 0>
+	piece <0x40637000, 0>
+	piece <0x40637000, 0>
+	piece <0x40636000, 0>
+	piece <0x40637000, 0>
+	piece <0x40637000, 0>
+	piece <0x40635000, 0>
+	piece <0x40635000, 0>
+	piece <0x40635000, 0>
+	piece <0x40635000, 0>
+	piece <0x40635000, 0>
+	piece <0x40635000, 0>
+	piece <0x40635000, 0>
+	piece <0x40635000, 0>
+	piece <0x40635000, 0>
+	piece <0x40635000, 0>
+end
+
+# end tower - 19 tiles
+section et
+	piece <0x40633000, 0>
+	piece <0x40631000, 0>
+	piece <0x40632000, 0>
+	piece <0x40631000, 0>
+	piece <0x40637000, 0>
+	piece <0x40637000, 0>
+	piece <0x40634000, 0>
+	piece <0x40637000, 0>
+	piece <0x40637000, 0>
+	piece <0x40635000, 0>
+	piece <0x40635000, 0>
+	piece <0x40635000, 0>
+	piece <0x40635000, 0>
+	piece <0x40635000, 0>
+	piece <0x40635000, 0>
+	piece <0x40635000, 0>
+	piece <0x40635000, 0>
+	piece <0x40635000, 0>
+	piece <0x40635000, 0>
+end 
+
+	length 40
+	piece ab et rev(et) rev(ab)
+	end
+
+	length 41
+	piece ab gi et rev(et) rev(ab)
+	end
+	
+	length 42
+	piece ab gi et rev(et) rev(gi) rev(ab)
+	end
+	
+	length 43
+	piece ab pi gi et rev(et) rev(gi) rev(ab)
+	end
+	
+	length 44
+	piece ab pi gi et rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 45
+	piece ab gi pi gi et rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 46
+	piece ab gi pi gi et rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 47
+	piece ab 2*gi pi gi et rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 48
+	piece ab 2*gi pi gi et rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 49
+	piece ab 3*gi pi gi et rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 50
+	piece ab 3*gi pi gi et rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 51
+	piece ab gp pi gi et rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 52
+	piece ab gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 53
+	piece ab gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 54
+	piece ab gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 55
+	piece ab 2*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 56
+	piece ab 2*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 57
+	piece ab 3*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 58
+	piece ab 3*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 59
+	piece ab 2*gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 60
+	piece ab 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 61
+	piece ab gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 62
+	piece ab gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 63
+	piece ab 2*gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 64
+	piece ab 2*gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+
+	length 65
+	piece ab et mt rev(et) rev(ab)
+	end
+	
+	length 66
+	piece ab gi et mt rev(et) rev(ab)
+	end
+	
+	length 67
+	piece ab gi et mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 68
+	piece ab pi gi et mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 69
+	piece ab pi gi et mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 70
+	piece ab gi pi gi et mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 71
+	piece ab gi pi gi et mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 72
+	piece ab 2*gi pi gi et mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 73
+	piece ab 2*gi pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 74
+	piece ab 3*gi pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 75
+	piece ab 3*gi pi gi et mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 76
+	piece ab gp pi gi et mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 77
+	piece ab gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 78
+	piece ab gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 79
+	piece ab gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 80
+	piece ab 2*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 81
+	piece ab 2*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 82
+	piece ab 3*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 83
+	piece ab 3*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 84
+	piece ab 2*gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 85
+	piece ab 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 86
+	piece ab gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 87
+	piece ab gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 88
+	piece ab 2*gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 89
+	piece ab 2*gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 90
+	piece ab et 2*mt rev(et) rev(ab)
+	end
+	
+	length 91
+	piece ab gi et 2*mt rev(et) rev(ab)
+	end
+	
+	length 92
+	piece ab gi et 2*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 93
+	piece ab pi gi et 2*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 94
+	piece ab pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 95
+	piece ab gi pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 96
+	piece ab gi pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 97
+	piece ab 2*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 98
+	piece ab 2*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 99
+	piece ab 3*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 100
+	piece ab 3*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 101
+	piece ab gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 102
+	piece ab gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 103
+	piece ab gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 104
+	piece ab gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 105
+	piece ab 2*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 106
+	piece ab 2*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 107
+	piece ab 3*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 108
+	piece ab 3*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 109
+	piece ab 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 110
+	piece ab 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 111
+	piece ab gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 112
+	piece ab gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 113
+	piece ab 2*gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 114
+	piece ab 2*gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 115
+	piece ab et 3*mt rev(et) rev(ab)
+	end
+	
+	length 116
+	piece ab gi et 3*mt rev(et) rev(ab)
+	end
+	
+	length 117
+	piece ab gi et 3*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 118
+	piece ab pi gi et 3*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 119
+	piece ab pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 120
+	piece ab gi pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 121
+	piece ab gi pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 122
+	piece ab 2*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 123
+	piece ab 2*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 124
+	piece ab 3*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 125
+	piece ab 3*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 126
+	piece ab gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 127
+	piece ab gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 128
+	piece ab gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 129
+	piece ab gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 130
+	piece ab 2*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 131
+	piece ab 2*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 132
+	piece ab 3*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 133
+	piece ab 3*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 134
+	piece ab 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 135
+	piece ab 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 136
+	piece ab gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 137
+	piece ab gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 138
+	piece ab 2*gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 139
+	piece ab 2*gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 140
+	piece ab et 4*mt rev(et) rev(ab)
+	end
+	
+	length 141
+	piece ab gi et 4*mt rev(et) rev(ab)
+	end
+	
+	length 142
+	piece ab gi et 4*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 143
+	piece ab pi gi et 4*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 144
+	piece ab pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 145
+	piece ab gi pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 146
+	piece ab gi pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 147
+	piece ab 2*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 148
+	piece ab 2*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 149
+	piece ab 3*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 150
+	piece ab 3*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 151
+	piece ab gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 152
+	piece ab gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 153
+	piece ab gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 154
+	piece ab gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 155
+	piece ab 2*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 156
+	piece ab 2*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 157
+	piece ab 3*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 158
+	piece ab 3*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 159
+	piece ab 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 160
+	piece ab 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 161
+	piece ab gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 162
+	piece ab gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 163
+	piece ab 2*gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 164
+	piece ab 2*gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 165
+	piece ab et 5*mt rev(et) rev(ab)
+	end
+	
+	length 166
+	piece ab gi et 5*mt rev(et) rev(ab)
+	end
+	
+	length 167
+	piece ab gi et 5*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 168
+	piece ab pi gi et 5*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 169
+	piece ab pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 170
+	piece ab gi pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 171
+	piece ab gi pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 172
+	piece ab 2*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 173
+	piece ab 2*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 174
+	piece ab 3*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 175
+	piece ab 3*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 176
+	piece ab gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 177
+	piece ab gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 178
+	piece ab gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 179
+	piece ab gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 180
+	piece ab 2*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 181
+	piece ab 2*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 182
+	piece ab 3*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 183
+	piece ab 3*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 184
+	piece ab 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 185
+	piece ab 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 186
+	piece ab gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 187
+	piece ab gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 188
+	piece ab 2*gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 189
+	piece ab 2*gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 190
+	piece ab et 6*mt rev(et) rev(ab)
+	end
+	
+	length 191
+	piece ab gi et 6*mt rev(et) rev(ab)
+	end
+	
+	length 192
+	piece ab gi et 6*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 193
+	piece ab pi gi et 6*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 194
+	piece ab pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 195
+	piece ab gi pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 196
+	piece ab gi pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 197
+	piece ab 2*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 198
+	piece ab 2*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 199
+	piece ab 3*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 200
+	piece ab 3*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 201
+	piece ab gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 202
+	piece ab gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 203
+	piece ab gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 204
+	piece ab gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 205
+	piece ab 2*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 206
+	piece ab 2*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 207
+	piece ab 3*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 208
+	piece ab 3*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 209
+	piece ab 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 210
+	piece ab 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 211
+	piece ab gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 212
+	piece ab gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 213
+	piece ab 2*gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 214
+	piece ab 2*gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 215
+	piece ab et 7*mt rev(et) rev(ab)
+	end
+	
+	length 216
+	piece ab gi et 7*mt rev(et) rev(ab)
+	end
+	
+	length 217
+	piece ab gi et 7*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 218
+	piece ab pi gi et 7*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 219
+	piece ab pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 220
+	piece ab gi pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 221
+	piece ab gi pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 222
+	piece ab 2*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 223
+	piece ab 2*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 224
+	piece ab 3*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 225
+	piece ab 3*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 226
+	piece ab gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 227
+	piece ab gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 228
+	piece ab gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 229
+	piece ab gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 230
+	piece ab 2*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 231
+	piece ab 2*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 232
+	piece ab 3*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 233
+	piece ab 3*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 234
+	piece ab 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 235
+	piece ab 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 236
+	piece ab gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 237
+	piece ab gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 238
+	piece ab 2*gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 239
+	piece ab 2*gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 240
+	piece ab et 8*mt rev(et) rev(ab)
+	end
+
+	length 241
+	piece ab gi et 8*mt rev(et) rev(ab)
+	end
+	
+	length 242
+	piece ab gi et 8*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 243
+	piece ab pi gi et 8*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 244
+	piece ab pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 245
+	piece ab gi pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 246
+	piece ab gi pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 247
+	piece ab 2*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 248
+	piece ab 2*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 249
+	piece ab 3*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 250
+	piece ab 3*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 251
+	piece ab gp pi gi et 8*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 252
+	piece ab gp pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 253
+	piece ab gi gp pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 254
+	piece ab gi gp pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
 end

--- a/Controller/Bridge Controller/00001003.rul
+++ b/Controller/Bridge Controller/00001003.rul
@@ -18,6 +18,8278 @@
 #    piece rev(foobar)
 
 
+# Yellow Steel Girder (street) by IDS2 (09/23)
+
+bridge 30
+
+# abutment start - 1 tile
+section as
+	piece <0x40394000, 0>
+end 
+
+# pillar section - 3 tiles
+section pi
+	piece <0x40395000, 0>
+	piece <0x40396000, 0>
+	piece <0x40395000, 0>
+end 
+
+# span only - 1 tile
+section sp
+	piece <0x40397000, 0>
+end 
+
+# combined repeat segment - 4 tiles
+section ps
+	piece pi sp
+end
+
+#abutment end - 1 tile
+section ae
+	piece <0x40394000, 2>
+end
+
+	length 5
+	piece as 3*sp ae
+	end
+	
+	length 6
+	piece as 4*sp ae
+	end
+	
+	length 7
+	piece as sp ps ae
+	end
+	
+	length 8
+	piece as sp ps sp ae
+	end
+	
+	length 9
+	piece as 2*sp ps sp ae
+	end
+	
+	length 10
+	piece as 2*sp ps 2*sp ae
+	end
+	
+	length 11
+	piece as sp 2*ps ae
+	end
+	
+	length 12
+	piece as 2*sp 2*ps ae
+	end
+	
+	length 13
+	piece as 2*sp 2*ps sp ae
+	end
+	
+	length 14
+	piece as 2*sp ps sp ps sp ae
+	end
+	
+	length 15
+	piece as sp 3*ps ae
+	end
+	
+	length 16
+	piece as 2*sp 3*ps ae
+	end
+	
+	length 17
+	piece as 2*sp 3*ps sp ae
+	end
+	
+	length 18
+	piece as 2*sp 3*ps 2*sp ae
+	end
+	
+	length 19
+	piece as sp 4*ps ae
+	end
+	
+	length 20
+	piece as 2*sp 4*ps ae
+	end
+	
+	length 21
+	piece as 2*sp 4*ps sp ae
+	end
+	
+	length 22
+	piece as 2*sp 4*ps 2*sp ae
+	end
+	
+	length 23
+	piece as sp 5*ps ae
+	end
+
+	length 24
+	piece as 2*sp 5*ps ae
+	end
+
+	length 25
+	piece as 2*sp 5*ps sp ae
+	end
+
+	length 26
+	piece as 2*sp 5*ps 2*sp ae
+	end
+
+	length 27
+	piece as sp 6*ps ae
+	end
+
+	length 28
+	piece as 2*sp 6*ps ae
+	end
+
+	length 29
+	piece as 2*sp 6*ps sp ae
+	end
+
+	length 30
+	piece as 2*sp 6*ps 2*sp ae
+	end
+
+	length 31
+	piece as sp 7*ps ae
+	end
+
+	length 32
+	piece as 2*sp 7*ps ae
+	end
+
+	length 33
+	piece as 2*sp 7*ps sp ae
+	end
+
+	length 34
+	piece as 2*sp 7*ps 2*sp ae
+	end
+
+	length 35
+	piece as sp 8*ps ae
+	end
+
+	length 36
+	piece as 2*sp 8*ps ae
+	end
+
+	length 37
+	piece as 2*sp 8*ps sp ae
+	end
+
+	length 38
+	piece as 2*sp 8*ps 2*sp ae
+	end
+
+	length 39
+	piece as sp 9*ps ae
+	end
+
+	length 40
+	piece as 2*sp 9*ps ae
+	end
+
+	length 41
+	piece as 2*sp 9*ps sp ae
+	end
+
+	length 42
+	piece as 2*sp 9*ps 2*sp ae
+	end
+
+	length 43
+	piece as sp 10*ps ae
+	end
+
+	length 44
+	piece as 2*sp 10*ps ae
+	end
+
+	length 45
+	piece as 2*sp 10*ps sp ae
+	end
+
+	length 46
+	piece as 2*sp 10*ps 2*sp ae
+	end
+
+	length 47
+	piece as sp 11*ps ae
+	end
+
+	length 48
+	piece as 2*sp 11*ps ae
+	end
+
+	length 49
+	piece as 2*sp 11*ps sp ae
+	end
+
+	length 50
+	piece as 2*sp 11*ps 2*sp ae
+	end
+
+	length 51
+	piece as sp 12*ps ae
+	end
+
+	length 52
+	piece as 2*sp 12*ps ae
+	end
+
+	length 53
+	piece as 2*sp 12*ps sp ae
+	end
+
+	length 54
+	piece as 2*sp 12*ps 2*sp ae
+	end
+
+	length 55
+	piece as sp 13*ps ae
+	end
+
+	length 56
+	piece as 2*sp 13*ps ae
+	end
+
+	length 57
+	piece as 2*sp 13*ps sp ae
+	end
+
+	length 58
+	piece as 2*sp 13*ps 2*sp ae
+	end
+
+	length 59
+	piece as sp 14*ps ae
+	end
+
+	length 60
+	piece as 2*sp 14*ps ae
+	end
+
+	length 61
+	piece as 2*sp 14*ps sp ae
+	end
+
+	length 62
+	piece as 2*sp 14*ps 2*sp ae
+	end
+
+	length 63
+	piece as sp 15*ps ae
+	end
+
+	length 64
+	piece as 2*sp 15*ps ae
+	end
+
+	length 65
+	piece as 2*sp 15*ps sp ae
+	end
+
+	length 66
+	piece as 2*sp 15*ps 2*sp ae
+	end
+
+	length 67
+	piece as sp 16*ps ae
+	end
+
+	length 68
+	piece as 2*sp 16*ps ae
+	end
+
+	length 69
+	piece as 2*sp 16*ps sp ae
+	end
+
+	length 70
+	piece as 2*sp 16*ps 2*sp ae
+	end
+
+	length 71
+	piece as sp 17*ps ae
+	end
+
+	length 72
+	piece as 2*sp 17*ps ae
+	end
+
+	length 73
+	piece as 2*sp 17*ps sp ae
+	end
+
+	length 74
+	piece as 2*sp 17*ps 2*sp ae
+	end
+
+	length 75
+	piece as sp 18*ps ae
+	end
+
+	length 76
+	piece as 2*sp 18*ps ae
+	end
+
+	length 77
+	piece as 2*sp 18*ps sp ae
+	end
+
+	length 78
+	piece as 2*sp 18*ps 2*sp ae
+	end
+
+	length 79
+	piece as sp 19*ps ae
+	end
+
+	length 80
+	piece as 2*sp 19*ps ae
+	end
+
+	length 81
+	piece as 2*sp 19*ps sp ae
+	end
+
+	length 82
+	piece as 2*sp 19*ps 2*sp ae
+	end
+
+	length 83
+	piece as sp 20*ps ae
+	end
+
+	length 84
+	piece as 2*sp 20*ps ae
+	end
+
+	length 85
+	piece as 2*sp 20*ps sp ae
+	end
+
+	length 86
+	piece as 2*sp 20*ps 2*sp ae
+	end
+
+	length 87
+	piece as sp 21*ps ae
+	end
+
+	length 88
+	piece as 2*sp 21*ps ae
+	end
+
+	length 89
+	piece as 2*sp 21*ps sp ae
+	end
+
+	length 90
+	piece as 2*sp 21*ps 2*sp ae
+	end
+
+	length 91
+	piece as sp 22*ps ae
+	end
+
+	length 92
+	piece as 2*sp 22*ps ae
+	end
+
+	length 93
+	piece as 2*sp 22*ps sp ae
+	end
+
+	length 94
+	piece as 2*sp 22*ps 2*sp ae
+	end
+
+	length 95
+	piece as sp 23*ps ae
+	end
+
+	length 96
+	piece as 2*sp 23*ps ae
+	end
+
+	length 97
+	piece as 2*sp 23*ps sp ae
+	end
+
+	length 98
+	piece as 2*sp 23*ps 2*sp ae
+	end
+
+	length 99
+	piece as sp 24*ps ae
+	end
+
+	length 100
+	piece as 2*sp 24*ps ae
+	end
+
+	length 101
+	piece as 2*sp 24*ps sp ae
+	end
+
+	length 102
+	piece as 2*sp 24*ps 2*sp ae
+	end
+
+	length 103
+	piece as sp 25*ps ae
+	end
+
+	length 104
+	piece as 2*sp 25*ps ae
+	end
+
+	length 105
+	piece as 2*sp 25*ps sp ae
+	end
+
+	length 106
+	piece as 2*sp 25*ps 2*sp ae
+	end
+
+	length 107
+	piece as sp 26*ps ae
+	end
+
+	length 108
+	piece as 2*sp 26*ps ae
+	end
+
+	length 109
+	piece as 2*sp 26*ps sp ae
+	end
+
+	length 110
+	piece as 2*sp 26*ps 2*sp ae
+	end
+
+	length 111
+	piece as sp 27*ps ae
+	end
+
+	length 112
+	piece as 2*sp 27*ps ae
+	end
+
+	length 113
+	piece as 2*sp 27*ps sp ae
+	end
+
+	length 114
+	piece as 2*sp 27*ps 2*sp ae
+	end
+
+	length 115
+	piece as sp 28*ps ae
+	end
+
+	length 116
+	piece as 2*sp 28*ps ae
+	end
+
+	length 117
+	piece as 2*sp 28*ps sp ae
+	end
+
+	length 118
+	piece as 2*sp 28*ps 2*sp ae
+	end
+
+	length 119
+	piece as sp 29*ps ae
+	end
+
+	length 120
+	piece as 2*sp 29*ps ae
+	end
+
+	length 121
+	piece as 2*sp 29*ps sp ae
+	end
+
+	length 122
+	piece as 2*sp 29*ps 2*sp ae
+	end
+
+	length 123
+	piece as sp 30*ps ae
+	end
+
+	length 124
+	piece as 2*sp 30*ps ae
+	end
+
+	length 125
+	piece as 2*sp 30*ps sp ae
+	end
+
+	length 126
+	piece as 2*sp 30*ps 2*sp ae
+	end
+
+	length 127
+	piece as sp 31*ps ae
+	end
+
+	length 128
+	piece as 2*sp 31*ps ae
+	end
+
+	length 129
+	piece as 2*sp 31*ps sp ae
+	end
+
+	length 130
+	piece as 2*sp 31*ps 2*sp ae
+	end
+
+	length 131
+	piece as sp 32*ps ae
+	end
+
+	length 132
+	piece as 2*sp 32*ps ae
+	end
+
+	length 133
+	piece as 2*sp 32*ps sp ae
+	end
+
+	length 134
+	piece as 2*sp 32*ps 2*sp ae
+	end
+
+	length 135
+	piece as sp 33*ps ae
+	end
+
+	length 136
+	piece as 2*sp 33*ps ae
+	end
+
+	length 137
+	piece as 2*sp 33*ps sp ae
+	end
+
+	length 138
+	piece as 2*sp 33*ps 2*sp ae
+	end
+
+	length 139
+	piece as sp 34*ps ae
+	end
+
+	length 140
+	piece as 2*sp 34*ps ae
+	end
+
+	length 141
+	piece as 2*sp 34*ps sp ae
+	end
+
+	length 142
+	piece as 2*sp 34*ps 2*sp ae
+	end
+
+	length 143
+	piece as sp 35*ps ae
+	end
+
+	length 144
+	piece as 2*sp 35*ps ae
+	end
+
+	length 145
+	piece as 2*sp 35*ps sp ae
+	end
+
+	length 146
+	piece as 2*sp 35*ps 2*sp ae
+	end
+
+	length 147
+	piece as sp 36*ps ae
+	end
+
+	length 148
+	piece as 2*sp 36*ps ae
+	end
+
+	length 149
+	piece as 2*sp 36*ps sp ae
+	end
+
+	length 150
+	piece as 2*sp 36*ps 2*sp ae
+	end
+
+	length 151
+	piece as sp 37*ps ae
+	end
+
+	length 152
+	piece as 2*sp 37*ps ae
+	end
+
+	length 153
+	piece as 2*sp 37*ps sp ae
+	end
+
+	length 154
+	piece as 2*sp 37*ps 2*sp ae
+	end
+
+	length 155
+	piece as sp 38*ps ae
+	end
+
+	length 156
+	piece as 2*sp 38*ps ae
+	end
+
+	length 157
+	piece as 2*sp 38*ps sp ae
+	end
+
+	length 158
+	piece as 2*sp 38*ps 2*sp ae
+	end
+
+	length 159
+	piece as sp 39*ps ae
+	end
+
+	length 160
+	piece as 2*sp 39*ps ae
+	end
+
+	length 161
+	piece as 2*sp 39*ps sp ae
+	end
+
+	length 162
+	piece as 2*sp 39*ps 2*sp ae
+	end
+
+	length 163
+	piece as sp 40*ps ae
+	end
+
+	length 164
+	piece as 2*sp 40*ps ae
+	end
+
+	length 165
+	piece as 2*sp 40*ps sp ae
+	end
+
+	length 166
+	piece as 2*sp 40*ps 2*sp ae
+	end
+
+	length 167
+	piece as sp 41*ps ae
+	end
+
+	length 168
+	piece as 2*sp 41*ps ae
+	end
+
+	length 169
+	piece as 2*sp 41*ps sp ae
+	end
+
+	length 170
+	piece as 2*sp 41*ps 2*sp ae
+	end
+
+	length 171
+	piece as sp 42*ps ae
+	end
+
+	length 172
+	piece as 2*sp 42*ps ae
+	end
+
+	length 173
+	piece as 2*sp 42*ps sp ae
+	end
+
+	length 174
+	piece as 2*sp 42*ps 2*sp ae
+	end
+
+	length 175
+	piece as sp 43*ps ae
+	end
+
+	length 176
+	piece as 2*sp 43*ps ae
+	end
+
+	length 177
+	piece as 2*sp 43*ps sp ae
+	end
+
+	length 178
+	piece as 2*sp 43*ps 2*sp ae
+	end
+
+	length 179
+	piece as sp 44*ps ae
+	end
+
+	length 180
+
+	piece as 2*sp 44*ps ae
+	end
+
+	length 181
+	piece as 2*sp 44*ps sp ae
+	end
+
+	length 182
+	piece as 2*sp 44*ps 2*sp ae
+	end
+
+	length 183
+	piece as sp 45*ps ae
+	end
+
+	length 184
+	piece as 2*sp 45*ps ae
+	end
+
+	length 185
+	piece as 2*sp 45*ps sp ae
+	end
+
+	length 186
+	piece as 2*sp 45*ps 2*sp ae
+	end
+
+	length 187
+	piece as sp 46*ps ae
+	end
+
+	length 188
+	piece as 2*sp 46*ps ae
+	end
+
+	length 189
+	piece as 2*sp 46*ps sp ae
+	end
+
+	length 190
+	piece as 2*sp 46*ps 2*sp ae
+	end
+
+	length 191
+	piece as sp 47*ps ae
+	end
+
+	length 192
+	piece as 2*sp 47*ps ae
+	end
+
+	length 193
+	piece as 2*sp 47*ps sp ae
+	end
+
+	length 194
+	piece as 2*sp 47*ps 2*sp ae
+	end
+
+	length 195
+	piece as sp 48*ps ae
+	end
+
+	length 196
+	piece as 2*sp 48*ps ae
+	end
+
+	length 197
+	piece as 2*sp 48*ps sp ae
+	end
+
+	length 198
+	piece as 2*sp 48*ps 2*sp ae
+	end
+
+	length 199
+	piece as sp 49*ps ae
+	end
+
+	length 200
+	piece as 2*sp 49*ps ae
+	end
+
+	length 201
+	piece as 2*sp 49*ps sp ae
+	end
+
+	length 202
+	piece as 2*sp 49*ps 2*sp ae
+	end
+
+	length 203
+	piece as sp 50*ps ae
+	end
+
+	length 204
+	piece as 2*sp 50*ps ae
+	end
+
+	length 205
+	piece as 2*sp 50*ps sp ae
+	end
+
+	length 206
+	piece as 2*sp 50*ps 2*sp ae
+	end
+
+	length 207
+	piece as sp 51*ps ae
+	end
+
+	length 208
+	piece as 2*sp 51*ps ae
+	end
+
+	length 209
+	piece as 2*sp 51*ps sp ae
+	end
+
+	length 210
+	piece as 2*sp 51*ps 2*sp ae
+	end
+
+	length 211
+	piece as sp 52*ps ae
+	end
+
+	length 212
+	piece as 2*sp 52*ps ae
+	end
+
+	length 213
+	piece as 2*sp 52*ps sp ae
+	end
+
+	length 214
+	piece as 2*sp 52*ps 2*sp ae
+	end
+
+	length 215
+	piece as sp 53*ps ae
+	end
+
+	length 216
+	piece as 2*sp 53*ps ae
+	end
+
+	length 217
+	piece as 2*sp 53*ps sp ae
+	end
+
+	length 218
+	piece as 2*sp 53*ps 2*sp ae
+	end
+
+	length 219
+	piece as sp 54*ps ae
+	end
+
+	length 220
+	piece as 2*sp 54*ps ae
+	end
+
+	length 221
+	piece as 2*sp 54*ps sp ae
+	end
+
+	length 222
+	piece as 2*sp 54*ps 2*sp ae
+	end
+
+	length 223
+	piece as sp 55*ps ae
+	end
+
+	length 224
+	piece as 2*sp 55*ps ae
+	end
+
+	length 225
+	piece as 2*sp 55*ps sp ae
+	end
+
+	length 226
+	piece as 2*sp 55*ps 2*sp ae
+	end
+
+	length 227
+	piece as sp 56*ps ae
+	end
+
+	length 228
+	piece as 2*sp 56*ps ae
+	end
+
+	length 229
+	piece as 2*sp 56*ps sp ae
+	end
+
+	length 230
+	piece as 2*sp 56*ps 2*sp ae
+	end
+
+	length 231
+	piece as sp 57*ps ae
+	end
+
+	length 232
+	piece as 2*sp 57*ps ae
+	end
+
+	length 233
+	piece as 2*sp 57*ps sp ae
+	end
+
+	length 234
+	piece as 2*sp 57*ps 2*sp ae
+	end
+
+	length 235
+	piece as sp 58*ps ae
+	end
+
+	length 236
+	piece as 2*sp 58*ps ae
+	end
+
+	length 237
+	piece as 2*sp 58*ps sp ae
+	end
+
+	length 238
+	piece as 2*sp 58*ps 2*sp ae
+	end
+
+	length 239
+	piece as sp 59*ps ae
+	end
+
+	length 240
+	piece as 2*sp 59*ps ae
+	end
+
+	length 241
+	piece as 2*sp 59*ps sp ae
+	end
+
+	length 242
+	piece as 2*sp 59*ps 2*sp ae
+	end
+
+	length 243
+	piece as sp 60*ps ae
+	end
+
+	length 244
+	piece as 2*sp 60*ps ae
+	end
+
+	length 245
+	piece as 2*sp 60*ps sp ae
+	end
+
+	length 246
+	piece as 2*sp 60*ps 2*sp ae
+	end
+
+	length 247
+	piece as sp 61*ps ae
+	end
+
+	length 248
+	piece as 2*sp 61*ps ae
+	end
+
+	length 249
+	piece as 2*sp 61*ps sp ae
+	end
+
+	length 250
+	piece as 2*sp 61*ps 2*sp ae
+	end
+
+	length 251
+	piece as sp 62*ps ae
+	end
+
+	length 252
+	piece as 2*sp 62*ps ae
+	end
+
+	length 253
+	piece as 2*sp 62*ps sp ae
+	end
+
+	length 254
+	piece as 2*sp 62*ps 2*sp ae
+	end
+end
+
+
+# Yellow Steel Girder (SAM-2) by IDS2 (09/23)
+
+bridge 31
+
+# abutment start - 1 tile
+section as
+	piece <0x403A4000, 0>
+end 
+
+# pillar section - 3 tiles
+section pi
+	piece <0x403A5000, 0>
+	piece <0x403A6000, 0>
+	piece <0x403A5000, 0>
+end 
+
+# span only - 1 tile
+section sp
+	piece <0x403A7000, 0>
+end 
+
+# combined repeat segment - 4 tiles
+section ps
+	piece pi sp
+end
+
+#abutment end - 1 tile
+section ae
+	piece <0x403A4000, 2>
+end
+
+	length 5
+	piece as 3*sp ae
+	end
+	
+	length 6
+	piece as 4*sp ae
+	end
+	
+	length 7
+	piece as sp ps ae
+	end
+	
+	length 8
+	piece as sp ps sp ae
+	end
+	
+	length 9
+	piece as 2*sp ps sp ae
+	end
+	
+	length 10
+	piece as 2*sp ps 2*sp ae
+	end
+	
+	length 11
+	piece as sp 2*ps ae
+	end
+	
+	length 12
+	piece as 2*sp 2*ps ae
+	end
+	
+	length 13
+	piece as 2*sp 2*ps sp ae
+	end
+	
+	length 14
+	piece as 2*sp ps sp ps sp ae
+	end
+	
+	length 15
+	piece as sp 3*ps ae
+	end
+	
+	length 16
+	piece as 2*sp 3*ps ae
+	end
+	
+	length 17
+	piece as 2*sp 3*ps sp ae
+	end
+	
+	length 18
+	piece as 2*sp 3*ps 2*sp ae
+	end
+	
+	length 19
+	piece as sp 4*ps ae
+	end
+	
+	length 20
+	piece as 2*sp 4*ps ae
+	end
+	
+	length 21
+	piece as 2*sp 4*ps sp ae
+	end
+	
+	length 22
+	piece as 2*sp 4*ps 2*sp ae
+	end
+	
+	length 23
+	piece as sp 5*ps ae
+	end
+
+	length 24
+	piece as 2*sp 5*ps ae
+	end
+
+	length 25
+	piece as 2*sp 5*ps sp ae
+	end
+
+	length 26
+	piece as 2*sp 5*ps 2*sp ae
+	end
+
+	length 27
+	piece as sp 6*ps ae
+	end
+
+	length 28
+	piece as 2*sp 6*ps ae
+	end
+
+	length 29
+	piece as 2*sp 6*ps sp ae
+	end
+
+	length 30
+	piece as 2*sp 6*ps 2*sp ae
+	end
+
+	length 31
+	piece as sp 7*ps ae
+	end
+
+	length 32
+	piece as 2*sp 7*ps ae
+	end
+
+	length 33
+	piece as 2*sp 7*ps sp ae
+	end
+
+	length 34
+	piece as 2*sp 7*ps 2*sp ae
+	end
+
+	length 35
+	piece as sp 8*ps ae
+	end
+
+	length 36
+	piece as 2*sp 8*ps ae
+	end
+
+	length 37
+	piece as 2*sp 8*ps sp ae
+	end
+
+	length 38
+	piece as 2*sp 8*ps 2*sp ae
+	end
+
+	length 39
+	piece as sp 9*ps ae
+	end
+
+	length 40
+	piece as 2*sp 9*ps ae
+	end
+
+	length 41
+	piece as 2*sp 9*ps sp ae
+	end
+
+	length 42
+	piece as 2*sp 9*ps 2*sp ae
+	end
+
+	length 43
+	piece as sp 10*ps ae
+	end
+
+	length 44
+	piece as 2*sp 10*ps ae
+	end
+
+	length 45
+	piece as 2*sp 10*ps sp ae
+	end
+
+	length 46
+	piece as 2*sp 10*ps 2*sp ae
+	end
+
+	length 47
+	piece as sp 11*ps ae
+	end
+
+	length 48
+	piece as 2*sp 11*ps ae
+	end
+
+	length 49
+	piece as 2*sp 11*ps sp ae
+	end
+
+	length 50
+	piece as 2*sp 11*ps 2*sp ae
+	end
+
+	length 51
+	piece as sp 12*ps ae
+	end
+
+	length 52
+	piece as 2*sp 12*ps ae
+	end
+
+	length 53
+	piece as 2*sp 12*ps sp ae
+	end
+
+	length 54
+	piece as 2*sp 12*ps 2*sp ae
+	end
+
+	length 55
+	piece as sp 13*ps ae
+	end
+
+	length 56
+	piece as 2*sp 13*ps ae
+	end
+
+	length 57
+	piece as 2*sp 13*ps sp ae
+	end
+
+	length 58
+	piece as 2*sp 13*ps 2*sp ae
+	end
+
+	length 59
+	piece as sp 14*ps ae
+	end
+
+	length 60
+	piece as 2*sp 14*ps ae
+	end
+
+	length 61
+	piece as 2*sp 14*ps sp ae
+	end
+
+	length 62
+	piece as 2*sp 14*ps 2*sp ae
+	end
+
+	length 63
+	piece as sp 15*ps ae
+	end
+
+	length 64
+	piece as 2*sp 15*ps ae
+	end
+
+	length 65
+	piece as 2*sp 15*ps sp ae
+	end
+
+	length 66
+	piece as 2*sp 15*ps 2*sp ae
+	end
+
+	length 67
+	piece as sp 16*ps ae
+	end
+
+	length 68
+	piece as 2*sp 16*ps ae
+	end
+
+	length 69
+	piece as 2*sp 16*ps sp ae
+	end
+
+	length 70
+	piece as 2*sp 16*ps 2*sp ae
+	end
+
+	length 71
+	piece as sp 17*ps ae
+	end
+
+	length 72
+	piece as 2*sp 17*ps ae
+	end
+
+	length 73
+	piece as 2*sp 17*ps sp ae
+	end
+
+	length 74
+	piece as 2*sp 17*ps 2*sp ae
+	end
+
+	length 75
+	piece as sp 18*ps ae
+	end
+
+	length 76
+	piece as 2*sp 18*ps ae
+	end
+
+	length 77
+	piece as 2*sp 18*ps sp ae
+	end
+
+	length 78
+	piece as 2*sp 18*ps 2*sp ae
+	end
+
+	length 79
+	piece as sp 19*ps ae
+	end
+
+	length 80
+	piece as 2*sp 19*ps ae
+	end
+
+	length 81
+	piece as 2*sp 19*ps sp ae
+	end
+
+	length 82
+	piece as 2*sp 19*ps 2*sp ae
+	end
+
+	length 83
+	piece as sp 20*ps ae
+	end
+
+	length 84
+	piece as 2*sp 20*ps ae
+	end
+
+	length 85
+	piece as 2*sp 20*ps sp ae
+	end
+
+	length 86
+	piece as 2*sp 20*ps 2*sp ae
+	end
+
+	length 87
+	piece as sp 21*ps ae
+	end
+
+	length 88
+	piece as 2*sp 21*ps ae
+	end
+
+	length 89
+	piece as 2*sp 21*ps sp ae
+	end
+
+	length 90
+	piece as 2*sp 21*ps 2*sp ae
+	end
+
+	length 91
+	piece as sp 22*ps ae
+	end
+
+	length 92
+	piece as 2*sp 22*ps ae
+	end
+
+	length 93
+	piece as 2*sp 22*ps sp ae
+	end
+
+	length 94
+	piece as 2*sp 22*ps 2*sp ae
+	end
+
+	length 95
+	piece as sp 23*ps ae
+	end
+
+	length 96
+	piece as 2*sp 23*ps ae
+	end
+
+	length 97
+	piece as 2*sp 23*ps sp ae
+	end
+
+	length 98
+	piece as 2*sp 23*ps 2*sp ae
+	end
+
+	length 99
+	piece as sp 24*ps ae
+	end
+
+	length 100
+	piece as 2*sp 24*ps ae
+	end
+
+	length 101
+	piece as 2*sp 24*ps sp ae
+	end
+
+	length 102
+	piece as 2*sp 24*ps 2*sp ae
+	end
+
+	length 103
+	piece as sp 25*ps ae
+	end
+
+	length 104
+	piece as 2*sp 25*ps ae
+	end
+
+	length 105
+	piece as 2*sp 25*ps sp ae
+	end
+
+	length 106
+	piece as 2*sp 25*ps 2*sp ae
+	end
+
+	length 107
+	piece as sp 26*ps ae
+	end
+
+	length 108
+	piece as 2*sp 26*ps ae
+	end
+
+	length 109
+	piece as 2*sp 26*ps sp ae
+	end
+
+	length 110
+	piece as 2*sp 26*ps 2*sp ae
+	end
+
+	length 111
+	piece as sp 27*ps ae
+	end
+
+	length 112
+	piece as 2*sp 27*ps ae
+	end
+
+	length 113
+	piece as 2*sp 27*ps sp ae
+	end
+
+	length 114
+	piece as 2*sp 27*ps 2*sp ae
+	end
+
+	length 115
+	piece as sp 28*ps ae
+	end
+
+	length 116
+	piece as 2*sp 28*ps ae
+	end
+
+	length 117
+	piece as 2*sp 28*ps sp ae
+	end
+
+	length 118
+	piece as 2*sp 28*ps 2*sp ae
+	end
+
+	length 119
+	piece as sp 29*ps ae
+	end
+
+	length 120
+	piece as 2*sp 29*ps ae
+	end
+
+	length 121
+	piece as 2*sp 29*ps sp ae
+	end
+
+	length 122
+	piece as 2*sp 29*ps 2*sp ae
+	end
+
+	length 123
+	piece as sp 30*ps ae
+	end
+
+	length 124
+	piece as 2*sp 30*ps ae
+	end
+
+	length 125
+	piece as 2*sp 30*ps sp ae
+	end
+
+	length 126
+	piece as 2*sp 30*ps 2*sp ae
+	end
+
+	length 127
+	piece as sp 31*ps ae
+	end
+
+	length 128
+	piece as 2*sp 31*ps ae
+	end
+
+	length 129
+	piece as 2*sp 31*ps sp ae
+	end
+
+	length 130
+	piece as 2*sp 31*ps 2*sp ae
+	end
+
+	length 131
+	piece as sp 32*ps ae
+	end
+
+	length 132
+	piece as 2*sp 32*ps ae
+	end
+
+	length 133
+	piece as 2*sp 32*ps sp ae
+	end
+
+	length 134
+	piece as 2*sp 32*ps 2*sp ae
+	end
+
+	length 135
+	piece as sp 33*ps ae
+	end
+
+	length 136
+	piece as 2*sp 33*ps ae
+	end
+
+	length 137
+	piece as 2*sp 33*ps sp ae
+	end
+
+	length 138
+	piece as 2*sp 33*ps 2*sp ae
+	end
+
+	length 139
+	piece as sp 34*ps ae
+	end
+
+	length 140
+	piece as 2*sp 34*ps ae
+	end
+
+	length 141
+	piece as 2*sp 34*ps sp ae
+	end
+
+	length 142
+	piece as 2*sp 34*ps 2*sp ae
+	end
+
+	length 143
+	piece as sp 35*ps ae
+	end
+
+	length 144
+	piece as 2*sp 35*ps ae
+	end
+
+	length 145
+	piece as 2*sp 35*ps sp ae
+	end
+
+	length 146
+	piece as 2*sp 35*ps 2*sp ae
+	end
+
+	length 147
+	piece as sp 36*ps ae
+	end
+
+	length 148
+	piece as 2*sp 36*ps ae
+	end
+
+	length 149
+	piece as 2*sp 36*ps sp ae
+	end
+
+	length 150
+	piece as 2*sp 36*ps 2*sp ae
+	end
+
+	length 151
+	piece as sp 37*ps ae
+	end
+
+	length 152
+	piece as 2*sp 37*ps ae
+	end
+
+	length 153
+	piece as 2*sp 37*ps sp ae
+	end
+
+	length 154
+	piece as 2*sp 37*ps 2*sp ae
+	end
+
+	length 155
+	piece as sp 38*ps ae
+	end
+
+	length 156
+	piece as 2*sp 38*ps ae
+	end
+
+	length 157
+	piece as 2*sp 38*ps sp ae
+	end
+
+	length 158
+	piece as 2*sp 38*ps 2*sp ae
+	end
+
+	length 159
+	piece as sp 39*ps ae
+	end
+
+	length 160
+	piece as 2*sp 39*ps ae
+	end
+
+	length 161
+	piece as 2*sp 39*ps sp ae
+	end
+
+	length 162
+	piece as 2*sp 39*ps 2*sp ae
+	end
+
+	length 163
+	piece as sp 40*ps ae
+	end
+
+	length 164
+	piece as 2*sp 40*ps ae
+	end
+
+	length 165
+	piece as 2*sp 40*ps sp ae
+	end
+
+	length 166
+	piece as 2*sp 40*ps 2*sp ae
+	end
+
+	length 167
+	piece as sp 41*ps ae
+	end
+
+	length 168
+	piece as 2*sp 41*ps ae
+	end
+
+	length 169
+	piece as 2*sp 41*ps sp ae
+	end
+
+	length 170
+	piece as 2*sp 41*ps 2*sp ae
+	end
+
+	length 171
+	piece as sp 42*ps ae
+	end
+
+	length 172
+	piece as 2*sp 42*ps ae
+	end
+
+	length 173
+	piece as 2*sp 42*ps sp ae
+	end
+
+	length 174
+	piece as 2*sp 42*ps 2*sp ae
+	end
+
+	length 175
+	piece as sp 43*ps ae
+	end
+
+	length 176
+	piece as 2*sp 43*ps ae
+	end
+
+	length 177
+	piece as 2*sp 43*ps sp ae
+	end
+
+	length 178
+	piece as 2*sp 43*ps 2*sp ae
+	end
+
+	length 179
+	piece as sp 44*ps ae
+	end
+
+	length 180
+
+	piece as 2*sp 44*ps ae
+	end
+
+	length 181
+	piece as 2*sp 44*ps sp ae
+	end
+
+	length 182
+	piece as 2*sp 44*ps 2*sp ae
+	end
+
+	length 183
+	piece as sp 45*ps ae
+	end
+
+	length 184
+	piece as 2*sp 45*ps ae
+	end
+
+	length 185
+	piece as 2*sp 45*ps sp ae
+	end
+
+	length 186
+	piece as 2*sp 45*ps 2*sp ae
+	end
+
+	length 187
+	piece as sp 46*ps ae
+	end
+
+	length 188
+	piece as 2*sp 46*ps ae
+	end
+
+	length 189
+	piece as 2*sp 46*ps sp ae
+	end
+
+	length 190
+	piece as 2*sp 46*ps 2*sp ae
+	end
+
+	length 191
+	piece as sp 47*ps ae
+	end
+
+	length 192
+	piece as 2*sp 47*ps ae
+	end
+
+	length 193
+	piece as 2*sp 47*ps sp ae
+	end
+
+	length 194
+	piece as 2*sp 47*ps 2*sp ae
+	end
+
+	length 195
+	piece as sp 48*ps ae
+	end
+
+	length 196
+	piece as 2*sp 48*ps ae
+	end
+
+	length 197
+	piece as 2*sp 48*ps sp ae
+	end
+
+	length 198
+	piece as 2*sp 48*ps 2*sp ae
+	end
+
+	length 199
+	piece as sp 49*ps ae
+	end
+
+	length 200
+	piece as 2*sp 49*ps ae
+	end
+
+	length 201
+	piece as 2*sp 49*ps sp ae
+	end
+
+	length 202
+	piece as 2*sp 49*ps 2*sp ae
+	end
+
+	length 203
+	piece as sp 50*ps ae
+	end
+
+	length 204
+	piece as 2*sp 50*ps ae
+	end
+
+	length 205
+	piece as 2*sp 50*ps sp ae
+	end
+
+	length 206
+	piece as 2*sp 50*ps 2*sp ae
+	end
+
+	length 207
+	piece as sp 51*ps ae
+	end
+
+	length 208
+	piece as 2*sp 51*ps ae
+	end
+
+	length 209
+	piece as 2*sp 51*ps sp ae
+	end
+
+	length 210
+	piece as 2*sp 51*ps 2*sp ae
+	end
+
+	length 211
+	piece as sp 52*ps ae
+	end
+
+	length 212
+	piece as 2*sp 52*ps ae
+	end
+
+	length 213
+	piece as 2*sp 52*ps sp ae
+	end
+
+	length 214
+	piece as 2*sp 52*ps 2*sp ae
+	end
+
+	length 215
+	piece as sp 53*ps ae
+	end
+
+	length 216
+	piece as 2*sp 53*ps ae
+	end
+
+	length 217
+	piece as 2*sp 53*ps sp ae
+	end
+
+	length 218
+	piece as 2*sp 53*ps 2*sp ae
+	end
+
+	length 219
+	piece as sp 54*ps ae
+	end
+
+	length 220
+	piece as 2*sp 54*ps ae
+	end
+
+	length 221
+	piece as 2*sp 54*ps sp ae
+	end
+
+	length 222
+	piece as 2*sp 54*ps 2*sp ae
+	end
+
+	length 223
+	piece as sp 55*ps ae
+	end
+
+	length 224
+	piece as 2*sp 55*ps ae
+	end
+
+	length 225
+	piece as 2*sp 55*ps sp ae
+	end
+
+	length 226
+	piece as 2*sp 55*ps 2*sp ae
+	end
+
+	length 227
+	piece as sp 56*ps ae
+	end
+
+	length 228
+	piece as 2*sp 56*ps ae
+	end
+
+	length 229
+	piece as 2*sp 56*ps sp ae
+	end
+
+	length 230
+	piece as 2*sp 56*ps 2*sp ae
+	end
+
+	length 231
+	piece as sp 57*ps ae
+	end
+
+	length 232
+	piece as 2*sp 57*ps ae
+	end
+
+	length 233
+	piece as 2*sp 57*ps sp ae
+	end
+
+	length 234
+	piece as 2*sp 57*ps 2*sp ae
+	end
+
+	length 235
+	piece as sp 58*ps ae
+	end
+
+	length 236
+	piece as 2*sp 58*ps ae
+	end
+
+	length 237
+	piece as 2*sp 58*ps sp ae
+	end
+
+	length 238
+	piece as 2*sp 58*ps 2*sp ae
+	end
+
+	length 239
+	piece as sp 59*ps ae
+	end
+
+	length 240
+	piece as 2*sp 59*ps ae
+	end
+
+	length 241
+	piece as 2*sp 59*ps sp ae
+	end
+
+	length 242
+	piece as 2*sp 59*ps 2*sp ae
+	end
+
+	length 243
+	piece as sp 60*ps ae
+	end
+
+	length 244
+	piece as 2*sp 60*ps ae
+	end
+
+	length 245
+	piece as 2*sp 60*ps sp ae
+	end
+
+	length 246
+	piece as 2*sp 60*ps 2*sp ae
+	end
+
+	length 247
+	piece as sp 61*ps ae
+	end
+
+	length 248
+	piece as 2*sp 61*ps ae
+	end
+
+	length 249
+	piece as 2*sp 61*ps sp ae
+	end
+
+	length 250
+	piece as 2*sp 61*ps 2*sp ae
+	end
+
+	length 251
+	piece as sp 62*ps ae
+	end
+
+	length 252
+	piece as 2*sp 62*ps ae
+	end
+
+	length 253
+	piece as 2*sp 62*ps sp ae
+	end
+
+	length 254
+	piece as 2*sp 62*ps 2*sp ae
+	end
+end
+
+
+# Yellow Steel Girder (SAM-6) by IDS2 (09/23)
+
+bridge 32
+
+# abutment start - 1 tile
+section as
+	piece <0x403B4000, 0>
+end 
+
+# pillar section - 3 tiles
+section pi
+	piece <0x403B5000, 0>
+	piece <0x403B6000, 0>
+	piece <0x403B5000, 0>
+end 
+
+# span only - 1 tile
+section sp
+	piece <0x403B7000, 0>
+end 
+
+# combined repeat segment - 4 tiles
+section ps
+	piece pi sp
+end
+
+#abutment end - 1 tile
+section ae
+	piece <0x403B4000, 2>
+end
+
+	length 5
+	piece as 3*sp ae
+	end
+	
+	length 6
+	piece as 4*sp ae
+	end
+	
+	length 7
+	piece as sp ps ae
+	end
+	
+	length 8
+	piece as sp ps sp ae
+	end
+	
+	length 9
+	piece as 2*sp ps sp ae
+	end
+	
+	length 10
+	piece as 2*sp ps 2*sp ae
+	end
+	
+	length 11
+	piece as sp 2*ps ae
+	end
+	
+	length 12
+	piece as 2*sp 2*ps ae
+	end
+	
+	length 13
+	piece as 2*sp 2*ps sp ae
+	end
+	
+	length 14
+	piece as 2*sp ps sp ps sp ae
+	end
+	
+	length 15
+	piece as sp 3*ps ae
+	end
+	
+	length 16
+	piece as 2*sp 3*ps ae
+	end
+	
+	length 17
+	piece as 2*sp 3*ps sp ae
+	end
+	
+	length 18
+	piece as 2*sp 3*ps 2*sp ae
+	end
+	
+	length 19
+	piece as sp 4*ps ae
+	end
+	
+	length 20
+	piece as 2*sp 4*ps ae
+	end
+	
+	length 21
+	piece as 2*sp 4*ps sp ae
+	end
+	
+	length 22
+	piece as 2*sp 4*ps 2*sp ae
+	end
+	
+	length 23
+	piece as sp 5*ps ae
+	end
+
+	length 24
+	piece as 2*sp 5*ps ae
+	end
+
+	length 25
+	piece as 2*sp 5*ps sp ae
+	end
+
+	length 26
+	piece as 2*sp 5*ps 2*sp ae
+	end
+
+	length 27
+	piece as sp 6*ps ae
+	end
+
+	length 28
+	piece as 2*sp 6*ps ae
+	end
+
+	length 29
+	piece as 2*sp 6*ps sp ae
+	end
+
+	length 30
+	piece as 2*sp 6*ps 2*sp ae
+	end
+
+	length 31
+	piece as sp 7*ps ae
+	end
+
+	length 32
+	piece as 2*sp 7*ps ae
+	end
+
+	length 33
+	piece as 2*sp 7*ps sp ae
+	end
+
+	length 34
+	piece as 2*sp 7*ps 2*sp ae
+	end
+
+	length 35
+	piece as sp 8*ps ae
+	end
+
+	length 36
+	piece as 2*sp 8*ps ae
+	end
+
+	length 37
+	piece as 2*sp 8*ps sp ae
+	end
+
+	length 38
+	piece as 2*sp 8*ps 2*sp ae
+	end
+
+	length 39
+	piece as sp 9*ps ae
+	end
+
+	length 40
+	piece as 2*sp 9*ps ae
+	end
+
+	length 41
+	piece as 2*sp 9*ps sp ae
+	end
+
+	length 42
+	piece as 2*sp 9*ps 2*sp ae
+	end
+
+	length 43
+	piece as sp 10*ps ae
+	end
+
+	length 44
+	piece as 2*sp 10*ps ae
+	end
+
+	length 45
+	piece as 2*sp 10*ps sp ae
+	end
+
+	length 46
+	piece as 2*sp 10*ps 2*sp ae
+	end
+
+	length 47
+	piece as sp 11*ps ae
+	end
+
+	length 48
+	piece as 2*sp 11*ps ae
+	end
+
+	length 49
+	piece as 2*sp 11*ps sp ae
+	end
+
+	length 50
+	piece as 2*sp 11*ps 2*sp ae
+	end
+
+	length 51
+	piece as sp 12*ps ae
+	end
+
+	length 52
+	piece as 2*sp 12*ps ae
+	end
+
+	length 53
+	piece as 2*sp 12*ps sp ae
+	end
+
+	length 54
+	piece as 2*sp 12*ps 2*sp ae
+	end
+
+	length 55
+	piece as sp 13*ps ae
+	end
+
+	length 56
+	piece as 2*sp 13*ps ae
+	end
+
+	length 57
+	piece as 2*sp 13*ps sp ae
+	end
+
+	length 58
+	piece as 2*sp 13*ps 2*sp ae
+	end
+
+	length 59
+	piece as sp 14*ps ae
+	end
+
+	length 60
+	piece as 2*sp 14*ps ae
+	end
+
+	length 61
+	piece as 2*sp 14*ps sp ae
+	end
+
+	length 62
+	piece as 2*sp 14*ps 2*sp ae
+	end
+
+	length 63
+	piece as sp 15*ps ae
+	end
+
+	length 64
+	piece as 2*sp 15*ps ae
+	end
+
+	length 65
+	piece as 2*sp 15*ps sp ae
+	end
+
+	length 66
+	piece as 2*sp 15*ps 2*sp ae
+	end
+
+	length 67
+	piece as sp 16*ps ae
+	end
+
+	length 68
+	piece as 2*sp 16*ps ae
+	end
+
+	length 69
+	piece as 2*sp 16*ps sp ae
+	end
+
+	length 70
+	piece as 2*sp 16*ps 2*sp ae
+	end
+
+	length 71
+	piece as sp 17*ps ae
+	end
+
+	length 72
+	piece as 2*sp 17*ps ae
+	end
+
+	length 73
+	piece as 2*sp 17*ps sp ae
+	end
+
+	length 74
+	piece as 2*sp 17*ps 2*sp ae
+	end
+
+	length 75
+	piece as sp 18*ps ae
+	end
+
+	length 76
+	piece as 2*sp 18*ps ae
+	end
+
+	length 77
+	piece as 2*sp 18*ps sp ae
+	end
+
+	length 78
+	piece as 2*sp 18*ps 2*sp ae
+	end
+
+	length 79
+	piece as sp 19*ps ae
+	end
+
+	length 80
+	piece as 2*sp 19*ps ae
+	end
+
+	length 81
+	piece as 2*sp 19*ps sp ae
+	end
+
+	length 82
+	piece as 2*sp 19*ps 2*sp ae
+	end
+
+	length 83
+	piece as sp 20*ps ae
+	end
+
+	length 84
+	piece as 2*sp 20*ps ae
+	end
+
+	length 85
+	piece as 2*sp 20*ps sp ae
+	end
+
+	length 86
+	piece as 2*sp 20*ps 2*sp ae
+	end
+
+	length 87
+	piece as sp 21*ps ae
+	end
+
+	length 88
+	piece as 2*sp 21*ps ae
+	end
+
+	length 89
+	piece as 2*sp 21*ps sp ae
+	end
+
+	length 90
+	piece as 2*sp 21*ps 2*sp ae
+	end
+
+	length 91
+	piece as sp 22*ps ae
+	end
+
+	length 92
+	piece as 2*sp 22*ps ae
+	end
+
+	length 93
+	piece as 2*sp 22*ps sp ae
+	end
+
+	length 94
+	piece as 2*sp 22*ps 2*sp ae
+	end
+
+	length 95
+	piece as sp 23*ps ae
+	end
+
+	length 96
+	piece as 2*sp 23*ps ae
+	end
+
+	length 97
+	piece as 2*sp 23*ps sp ae
+	end
+
+	length 98
+	piece as 2*sp 23*ps 2*sp ae
+	end
+
+	length 99
+	piece as sp 24*ps ae
+	end
+
+	length 100
+	piece as 2*sp 24*ps ae
+	end
+
+	length 101
+	piece as 2*sp 24*ps sp ae
+	end
+
+	length 102
+	piece as 2*sp 24*ps 2*sp ae
+	end
+
+	length 103
+	piece as sp 25*ps ae
+	end
+
+	length 104
+	piece as 2*sp 25*ps ae
+	end
+
+	length 105
+	piece as 2*sp 25*ps sp ae
+	end
+
+	length 106
+	piece as 2*sp 25*ps 2*sp ae
+	end
+
+	length 107
+	piece as sp 26*ps ae
+	end
+
+	length 108
+	piece as 2*sp 26*ps ae
+	end
+
+	length 109
+	piece as 2*sp 26*ps sp ae
+	end
+
+	length 110
+	piece as 2*sp 26*ps 2*sp ae
+	end
+
+	length 111
+	piece as sp 27*ps ae
+	end
+
+	length 112
+	piece as 2*sp 27*ps ae
+	end
+
+	length 113
+	piece as 2*sp 27*ps sp ae
+	end
+
+	length 114
+	piece as 2*sp 27*ps 2*sp ae
+	end
+
+	length 115
+	piece as sp 28*ps ae
+	end
+
+	length 116
+	piece as 2*sp 28*ps ae
+	end
+
+	length 117
+	piece as 2*sp 28*ps sp ae
+	end
+
+	length 118
+	piece as 2*sp 28*ps 2*sp ae
+	end
+
+	length 119
+	piece as sp 29*ps ae
+	end
+
+	length 120
+	piece as 2*sp 29*ps ae
+	end
+
+	length 121
+	piece as 2*sp 29*ps sp ae
+	end
+
+	length 122
+	piece as 2*sp 29*ps 2*sp ae
+	end
+
+	length 123
+	piece as sp 30*ps ae
+	end
+
+	length 124
+	piece as 2*sp 30*ps ae
+	end
+
+	length 125
+	piece as 2*sp 30*ps sp ae
+	end
+
+	length 126
+	piece as 2*sp 30*ps 2*sp ae
+	end
+
+	length 127
+	piece as sp 31*ps ae
+	end
+
+	length 128
+	piece as 2*sp 31*ps ae
+	end
+
+	length 129
+	piece as 2*sp 31*ps sp ae
+	end
+
+	length 130
+	piece as 2*sp 31*ps 2*sp ae
+	end
+
+	length 131
+	piece as sp 32*ps ae
+	end
+
+	length 132
+	piece as 2*sp 32*ps ae
+	end
+
+	length 133
+	piece as 2*sp 32*ps sp ae
+	end
+
+	length 134
+	piece as 2*sp 32*ps 2*sp ae
+	end
+
+	length 135
+	piece as sp 33*ps ae
+	end
+
+	length 136
+	piece as 2*sp 33*ps ae
+	end
+
+	length 137
+	piece as 2*sp 33*ps sp ae
+	end
+
+	length 138
+	piece as 2*sp 33*ps 2*sp ae
+	end
+
+	length 139
+	piece as sp 34*ps ae
+	end
+
+	length 140
+	piece as 2*sp 34*ps ae
+	end
+
+	length 141
+	piece as 2*sp 34*ps sp ae
+	end
+
+	length 142
+	piece as 2*sp 34*ps 2*sp ae
+	end
+
+	length 143
+	piece as sp 35*ps ae
+	end
+
+	length 144
+	piece as 2*sp 35*ps ae
+	end
+
+	length 145
+	piece as 2*sp 35*ps sp ae
+	end
+
+	length 146
+	piece as 2*sp 35*ps 2*sp ae
+	end
+
+	length 147
+	piece as sp 36*ps ae
+	end
+
+	length 148
+	piece as 2*sp 36*ps ae
+	end
+
+	length 149
+	piece as 2*sp 36*ps sp ae
+	end
+
+	length 150
+	piece as 2*sp 36*ps 2*sp ae
+	end
+
+	length 151
+	piece as sp 37*ps ae
+	end
+
+	length 152
+	piece as 2*sp 37*ps ae
+	end
+
+	length 153
+	piece as 2*sp 37*ps sp ae
+	end
+
+	length 154
+	piece as 2*sp 37*ps 2*sp ae
+	end
+
+	length 155
+	piece as sp 38*ps ae
+	end
+
+	length 156
+	piece as 2*sp 38*ps ae
+	end
+
+	length 157
+	piece as 2*sp 38*ps sp ae
+	end
+
+	length 158
+	piece as 2*sp 38*ps 2*sp ae
+	end
+
+	length 159
+	piece as sp 39*ps ae
+	end
+
+	length 160
+	piece as 2*sp 39*ps ae
+	end
+
+	length 161
+	piece as 2*sp 39*ps sp ae
+	end
+
+	length 162
+	piece as 2*sp 39*ps 2*sp ae
+	end
+
+	length 163
+	piece as sp 40*ps ae
+	end
+
+	length 164
+	piece as 2*sp 40*ps ae
+	end
+
+	length 165
+	piece as 2*sp 40*ps sp ae
+	end
+
+	length 166
+	piece as 2*sp 40*ps 2*sp ae
+	end
+
+	length 167
+	piece as sp 41*ps ae
+	end
+
+	length 168
+	piece as 2*sp 41*ps ae
+	end
+
+	length 169
+	piece as 2*sp 41*ps sp ae
+	end
+
+	length 170
+	piece as 2*sp 41*ps 2*sp ae
+	end
+
+	length 171
+	piece as sp 42*ps ae
+	end
+
+	length 172
+	piece as 2*sp 42*ps ae
+	end
+
+	length 173
+	piece as 2*sp 42*ps sp ae
+	end
+
+	length 174
+	piece as 2*sp 42*ps 2*sp ae
+	end
+
+	length 175
+	piece as sp 43*ps ae
+	end
+
+	length 176
+	piece as 2*sp 43*ps ae
+	end
+
+	length 177
+	piece as 2*sp 43*ps sp ae
+	end
+
+	length 178
+	piece as 2*sp 43*ps 2*sp ae
+	end
+
+	length 179
+	piece as sp 44*ps ae
+	end
+
+	length 180
+
+	piece as 2*sp 44*ps ae
+	end
+
+	length 181
+	piece as 2*sp 44*ps sp ae
+	end
+
+	length 182
+	piece as 2*sp 44*ps 2*sp ae
+	end
+
+	length 183
+	piece as sp 45*ps ae
+	end
+
+	length 184
+	piece as 2*sp 45*ps ae
+	end
+
+	length 185
+	piece as 2*sp 45*ps sp ae
+	end
+
+	length 186
+	piece as 2*sp 45*ps 2*sp ae
+	end
+
+	length 187
+	piece as sp 46*ps ae
+	end
+
+	length 188
+	piece as 2*sp 46*ps ae
+	end
+
+	length 189
+	piece as 2*sp 46*ps sp ae
+	end
+
+	length 190
+	piece as 2*sp 46*ps 2*sp ae
+	end
+
+	length 191
+	piece as sp 47*ps ae
+	end
+
+	length 192
+	piece as 2*sp 47*ps ae
+	end
+
+	length 193
+	piece as 2*sp 47*ps sp ae
+	end
+
+	length 194
+	piece as 2*sp 47*ps 2*sp ae
+	end
+
+	length 195
+	piece as sp 48*ps ae
+	end
+
+	length 196
+	piece as 2*sp 48*ps ae
+	end
+
+	length 197
+	piece as 2*sp 48*ps sp ae
+	end
+
+	length 198
+	piece as 2*sp 48*ps 2*sp ae
+	end
+
+	length 199
+	piece as sp 49*ps ae
+	end
+
+	length 200
+	piece as 2*sp 49*ps ae
+	end
+
+	length 201
+	piece as 2*sp 49*ps sp ae
+	end
+
+	length 202
+	piece as 2*sp 49*ps 2*sp ae
+	end
+
+	length 203
+	piece as sp 50*ps ae
+	end
+
+	length 204
+	piece as 2*sp 50*ps ae
+	end
+
+	length 205
+	piece as 2*sp 50*ps sp ae
+	end
+
+	length 206
+	piece as 2*sp 50*ps 2*sp ae
+	end
+
+	length 207
+	piece as sp 51*ps ae
+	end
+
+	length 208
+	piece as 2*sp 51*ps ae
+	end
+
+	length 209
+	piece as 2*sp 51*ps sp ae
+	end
+
+	length 210
+	piece as 2*sp 51*ps 2*sp ae
+	end
+
+	length 211
+	piece as sp 52*ps ae
+	end
+
+	length 212
+	piece as 2*sp 52*ps ae
+	end
+
+	length 213
+	piece as 2*sp 52*ps sp ae
+	end
+
+	length 214
+	piece as 2*sp 52*ps 2*sp ae
+	end
+
+	length 215
+	piece as sp 53*ps ae
+	end
+
+	length 216
+	piece as 2*sp 53*ps ae
+	end
+
+	length 217
+	piece as 2*sp 53*ps sp ae
+	end
+
+	length 218
+	piece as 2*sp 53*ps 2*sp ae
+	end
+
+	length 219
+	piece as sp 54*ps ae
+	end
+
+	length 220
+	piece as 2*sp 54*ps ae
+	end
+
+	length 221
+	piece as 2*sp 54*ps sp ae
+	end
+
+	length 222
+	piece as 2*sp 54*ps 2*sp ae
+	end
+
+	length 223
+	piece as sp 55*ps ae
+	end
+
+	length 224
+	piece as 2*sp 55*ps ae
+	end
+
+	length 225
+	piece as 2*sp 55*ps sp ae
+	end
+
+	length 226
+	piece as 2*sp 55*ps 2*sp ae
+	end
+
+	length 227
+	piece as sp 56*ps ae
+	end
+
+	length 228
+	piece as 2*sp 56*ps ae
+	end
+
+	length 229
+	piece as 2*sp 56*ps sp ae
+	end
+
+	length 230
+	piece as 2*sp 56*ps 2*sp ae
+	end
+
+	length 231
+	piece as sp 57*ps ae
+	end
+
+	length 232
+	piece as 2*sp 57*ps ae
+	end
+
+	length 233
+	piece as 2*sp 57*ps sp ae
+	end
+
+	length 234
+	piece as 2*sp 57*ps 2*sp ae
+	end
+
+	length 235
+	piece as sp 58*ps ae
+	end
+
+	length 236
+	piece as 2*sp 58*ps ae
+	end
+
+	length 237
+	piece as 2*sp 58*ps sp ae
+	end
+
+	length 238
+	piece as 2*sp 58*ps 2*sp ae
+	end
+
+	length 239
+	piece as sp 59*ps ae
+	end
+
+	length 240
+	piece as 2*sp 59*ps ae
+	end
+
+	length 241
+	piece as 2*sp 59*ps sp ae
+	end
+
+	length 242
+	piece as 2*sp 59*ps 2*sp ae
+	end
+
+	length 243
+	piece as sp 60*ps ae
+	end
+
+	length 244
+	piece as 2*sp 60*ps ae
+	end
+
+	length 245
+	piece as 2*sp 60*ps sp ae
+	end
+
+	length 246
+	piece as 2*sp 60*ps 2*sp ae
+	end
+
+	length 247
+	piece as sp 61*ps ae
+	end
+
+	length 248
+	piece as 2*sp 61*ps ae
+	end
+
+	length 249
+	piece as 2*sp 61*ps sp ae
+	end
+
+	length 250
+	piece as 2*sp 61*ps 2*sp ae
+	end
+
+	length 251
+	piece as sp 62*ps ae
+	end
+
+	length 252
+	piece as 2*sp 62*ps ae
+	end
+
+	length 253
+	piece as 2*sp 62*ps sp ae
+	end
+
+	length 254
+	piece as 2*sp 62*ps 2*sp ae
+	end
+end
+
+
+# Yellow Steel Girder (SAM-7) by IDS2 (09/23)
+
+bridge 33
+
+# abutment start - 1 tile
+section as
+	piece <0x403C4000, 0>
+end 
+
+# pillar section - 3 tiles
+section pi
+	piece <0x403C5000, 0>
+	piece <0x403C6000, 0>
+	piece <0x403C5000, 0>
+end 
+
+# span only - 1 tile
+section sp
+	piece <0x403C7000, 0>
+end 
+
+# combined repeat segment - 4 tiles
+section ps
+	piece pi sp
+end
+
+#abutment end - 1 tile
+section ae
+	piece <0x403C4000, 2>
+end
+
+	length 5
+	piece as 3*sp ae
+	end
+	
+	length 6
+	piece as 4*sp ae
+	end
+	
+	length 7
+	piece as sp ps ae
+	end
+	
+	length 8
+	piece as sp ps sp ae
+	end
+	
+	length 9
+	piece as 2*sp ps sp ae
+	end
+	
+	length 10
+	piece as 2*sp ps 2*sp ae
+	end
+	
+	length 11
+	piece as sp 2*ps ae
+	end
+	
+	length 12
+	piece as 2*sp 2*ps ae
+	end
+	
+	length 13
+	piece as 2*sp 2*ps sp ae
+	end
+	
+	length 14
+	piece as 2*sp ps sp ps sp ae
+	end
+	
+	length 15
+	piece as sp 3*ps ae
+	end
+	
+	length 16
+	piece as 2*sp 3*ps ae
+	end
+	
+	length 17
+	piece as 2*sp 3*ps sp ae
+	end
+	
+	length 18
+	piece as 2*sp 3*ps 2*sp ae
+	end
+	
+	length 19
+	piece as sp 4*ps ae
+	end
+	
+	length 20
+	piece as 2*sp 4*ps ae
+	end
+	
+	length 21
+	piece as 2*sp 4*ps sp ae
+	end
+	
+	length 22
+	piece as 2*sp 4*ps 2*sp ae
+	end
+	
+	length 23
+	piece as sp 5*ps ae
+	end
+
+	length 24
+	piece as 2*sp 5*ps ae
+	end
+
+	length 25
+	piece as 2*sp 5*ps sp ae
+	end
+
+	length 26
+	piece as 2*sp 5*ps 2*sp ae
+	end
+
+	length 27
+	piece as sp 6*ps ae
+	end
+
+	length 28
+	piece as 2*sp 6*ps ae
+	end
+
+	length 29
+	piece as 2*sp 6*ps sp ae
+	end
+
+	length 30
+	piece as 2*sp 6*ps 2*sp ae
+	end
+
+	length 31
+	piece as sp 7*ps ae
+	end
+
+	length 32
+	piece as 2*sp 7*ps ae
+	end
+
+	length 33
+	piece as 2*sp 7*ps sp ae
+	end
+
+	length 34
+	piece as 2*sp 7*ps 2*sp ae
+	end
+
+	length 35
+	piece as sp 8*ps ae
+	end
+
+	length 36
+	piece as 2*sp 8*ps ae
+	end
+
+	length 37
+	piece as 2*sp 8*ps sp ae
+	end
+
+	length 38
+	piece as 2*sp 8*ps 2*sp ae
+	end
+
+	length 39
+	piece as sp 9*ps ae
+	end
+
+	length 40
+	piece as 2*sp 9*ps ae
+	end
+
+	length 41
+	piece as 2*sp 9*ps sp ae
+	end
+
+	length 42
+	piece as 2*sp 9*ps 2*sp ae
+	end
+
+	length 43
+	piece as sp 10*ps ae
+	end
+
+	length 44
+	piece as 2*sp 10*ps ae
+	end
+
+	length 45
+	piece as 2*sp 10*ps sp ae
+	end
+
+	length 46
+	piece as 2*sp 10*ps 2*sp ae
+	end
+
+	length 47
+	piece as sp 11*ps ae
+	end
+
+	length 48
+	piece as 2*sp 11*ps ae
+	end
+
+	length 49
+	piece as 2*sp 11*ps sp ae
+	end
+
+	length 50
+	piece as 2*sp 11*ps 2*sp ae
+	end
+
+	length 51
+	piece as sp 12*ps ae
+	end
+
+	length 52
+	piece as 2*sp 12*ps ae
+	end
+
+	length 53
+	piece as 2*sp 12*ps sp ae
+	end
+
+	length 54
+	piece as 2*sp 12*ps 2*sp ae
+	end
+
+	length 55
+	piece as sp 13*ps ae
+	end
+
+	length 56
+	piece as 2*sp 13*ps ae
+	end
+
+	length 57
+	piece as 2*sp 13*ps sp ae
+	end
+
+	length 58
+	piece as 2*sp 13*ps 2*sp ae
+	end
+
+	length 59
+	piece as sp 14*ps ae
+	end
+
+	length 60
+	piece as 2*sp 14*ps ae
+	end
+
+	length 61
+	piece as 2*sp 14*ps sp ae
+	end
+
+	length 62
+	piece as 2*sp 14*ps 2*sp ae
+	end
+
+	length 63
+	piece as sp 15*ps ae
+	end
+
+	length 64
+	piece as 2*sp 15*ps ae
+	end
+
+	length 65
+	piece as 2*sp 15*ps sp ae
+	end
+
+	length 66
+	piece as 2*sp 15*ps 2*sp ae
+	end
+
+	length 67
+	piece as sp 16*ps ae
+	end
+
+	length 68
+	piece as 2*sp 16*ps ae
+	end
+
+	length 69
+	piece as 2*sp 16*ps sp ae
+	end
+
+	length 70
+	piece as 2*sp 16*ps 2*sp ae
+	end
+
+	length 71
+	piece as sp 17*ps ae
+	end
+
+	length 72
+	piece as 2*sp 17*ps ae
+	end
+
+	length 73
+	piece as 2*sp 17*ps sp ae
+	end
+
+	length 74
+	piece as 2*sp 17*ps 2*sp ae
+	end
+
+	length 75
+	piece as sp 18*ps ae
+	end
+
+	length 76
+	piece as 2*sp 18*ps ae
+	end
+
+	length 77
+	piece as 2*sp 18*ps sp ae
+	end
+
+	length 78
+	piece as 2*sp 18*ps 2*sp ae
+	end
+
+	length 79
+	piece as sp 19*ps ae
+	end
+
+	length 80
+	piece as 2*sp 19*ps ae
+	end
+
+	length 81
+	piece as 2*sp 19*ps sp ae
+	end
+
+	length 82
+	piece as 2*sp 19*ps 2*sp ae
+	end
+
+	length 83
+	piece as sp 20*ps ae
+	end
+
+	length 84
+	piece as 2*sp 20*ps ae
+	end
+
+	length 85
+	piece as 2*sp 20*ps sp ae
+	end
+
+	length 86
+	piece as 2*sp 20*ps 2*sp ae
+	end
+
+	length 87
+	piece as sp 21*ps ae
+	end
+
+	length 88
+	piece as 2*sp 21*ps ae
+	end
+
+	length 89
+	piece as 2*sp 21*ps sp ae
+	end
+
+	length 90
+	piece as 2*sp 21*ps 2*sp ae
+	end
+
+	length 91
+	piece as sp 22*ps ae
+	end
+
+	length 92
+	piece as 2*sp 22*ps ae
+	end
+
+	length 93
+	piece as 2*sp 22*ps sp ae
+	end
+
+	length 94
+	piece as 2*sp 22*ps 2*sp ae
+	end
+
+	length 95
+	piece as sp 23*ps ae
+	end
+
+	length 96
+	piece as 2*sp 23*ps ae
+	end
+
+	length 97
+	piece as 2*sp 23*ps sp ae
+	end
+
+	length 98
+	piece as 2*sp 23*ps 2*sp ae
+	end
+
+	length 99
+	piece as sp 24*ps ae
+	end
+
+	length 100
+	piece as 2*sp 24*ps ae
+	end
+
+	length 101
+	piece as 2*sp 24*ps sp ae
+	end
+
+	length 102
+	piece as 2*sp 24*ps 2*sp ae
+	end
+
+	length 103
+	piece as sp 25*ps ae
+	end
+
+	length 104
+	piece as 2*sp 25*ps ae
+	end
+
+	length 105
+	piece as 2*sp 25*ps sp ae
+	end
+
+	length 106
+	piece as 2*sp 25*ps 2*sp ae
+	end
+
+	length 107
+	piece as sp 26*ps ae
+	end
+
+	length 108
+	piece as 2*sp 26*ps ae
+	end
+
+	length 109
+	piece as 2*sp 26*ps sp ae
+	end
+
+	length 110
+	piece as 2*sp 26*ps 2*sp ae
+	end
+
+	length 111
+	piece as sp 27*ps ae
+	end
+
+	length 112
+	piece as 2*sp 27*ps ae
+	end
+
+	length 113
+	piece as 2*sp 27*ps sp ae
+	end
+
+	length 114
+	piece as 2*sp 27*ps 2*sp ae
+	end
+
+	length 115
+	piece as sp 28*ps ae
+	end
+
+	length 116
+	piece as 2*sp 28*ps ae
+	end
+
+	length 117
+	piece as 2*sp 28*ps sp ae
+	end
+
+	length 118
+	piece as 2*sp 28*ps 2*sp ae
+	end
+
+	length 119
+	piece as sp 29*ps ae
+	end
+
+	length 120
+	piece as 2*sp 29*ps ae
+	end
+
+	length 121
+	piece as 2*sp 29*ps sp ae
+	end
+
+	length 122
+	piece as 2*sp 29*ps 2*sp ae
+	end
+
+	length 123
+	piece as sp 30*ps ae
+	end
+
+	length 124
+	piece as 2*sp 30*ps ae
+	end
+
+	length 125
+	piece as 2*sp 30*ps sp ae
+	end
+
+	length 126
+	piece as 2*sp 30*ps 2*sp ae
+	end
+
+	length 127
+	piece as sp 31*ps ae
+	end
+
+	length 128
+	piece as 2*sp 31*ps ae
+	end
+
+	length 129
+	piece as 2*sp 31*ps sp ae
+	end
+
+	length 130
+	piece as 2*sp 31*ps 2*sp ae
+	end
+
+	length 131
+	piece as sp 32*ps ae
+	end
+
+	length 132
+	piece as 2*sp 32*ps ae
+	end
+
+	length 133
+	piece as 2*sp 32*ps sp ae
+	end
+
+	length 134
+	piece as 2*sp 32*ps 2*sp ae
+	end
+
+	length 135
+	piece as sp 33*ps ae
+	end
+
+	length 136
+	piece as 2*sp 33*ps ae
+	end
+
+	length 137
+	piece as 2*sp 33*ps sp ae
+	end
+
+	length 138
+	piece as 2*sp 33*ps 2*sp ae
+	end
+
+	length 139
+	piece as sp 34*ps ae
+	end
+
+	length 140
+	piece as 2*sp 34*ps ae
+	end
+
+	length 141
+	piece as 2*sp 34*ps sp ae
+	end
+
+	length 142
+	piece as 2*sp 34*ps 2*sp ae
+	end
+
+	length 143
+	piece as sp 35*ps ae
+	end
+
+	length 144
+	piece as 2*sp 35*ps ae
+	end
+
+	length 145
+	piece as 2*sp 35*ps sp ae
+	end
+
+	length 146
+	piece as 2*sp 35*ps 2*sp ae
+	end
+
+	length 147
+	piece as sp 36*ps ae
+	end
+
+	length 148
+	piece as 2*sp 36*ps ae
+	end
+
+	length 149
+	piece as 2*sp 36*ps sp ae
+	end
+
+	length 150
+	piece as 2*sp 36*ps 2*sp ae
+	end
+
+	length 151
+	piece as sp 37*ps ae
+	end
+
+	length 152
+	piece as 2*sp 37*ps ae
+	end
+
+	length 153
+	piece as 2*sp 37*ps sp ae
+	end
+
+	length 154
+	piece as 2*sp 37*ps 2*sp ae
+	end
+
+	length 155
+	piece as sp 38*ps ae
+	end
+
+	length 156
+	piece as 2*sp 38*ps ae
+	end
+
+	length 157
+	piece as 2*sp 38*ps sp ae
+	end
+
+	length 158
+	piece as 2*sp 38*ps 2*sp ae
+	end
+
+	length 159
+	piece as sp 39*ps ae
+	end
+
+	length 160
+	piece as 2*sp 39*ps ae
+	end
+
+	length 161
+	piece as 2*sp 39*ps sp ae
+	end
+
+	length 162
+	piece as 2*sp 39*ps 2*sp ae
+	end
+
+	length 163
+	piece as sp 40*ps ae
+	end
+
+	length 164
+	piece as 2*sp 40*ps ae
+	end
+
+	length 165
+	piece as 2*sp 40*ps sp ae
+	end
+
+	length 166
+	piece as 2*sp 40*ps 2*sp ae
+	end
+
+	length 167
+	piece as sp 41*ps ae
+	end
+
+	length 168
+	piece as 2*sp 41*ps ae
+	end
+
+	length 169
+	piece as 2*sp 41*ps sp ae
+	end
+
+	length 170
+	piece as 2*sp 41*ps 2*sp ae
+	end
+
+	length 171
+	piece as sp 42*ps ae
+	end
+
+	length 172
+	piece as 2*sp 42*ps ae
+	end
+
+	length 173
+	piece as 2*sp 42*ps sp ae
+	end
+
+	length 174
+	piece as 2*sp 42*ps 2*sp ae
+	end
+
+	length 175
+	piece as sp 43*ps ae
+	end
+
+	length 176
+	piece as 2*sp 43*ps ae
+	end
+
+	length 177
+	piece as 2*sp 43*ps sp ae
+	end
+
+	length 178
+	piece as 2*sp 43*ps 2*sp ae
+	end
+
+	length 179
+	piece as sp 44*ps ae
+	end
+
+	length 180
+
+	piece as 2*sp 44*ps ae
+	end
+
+	length 181
+	piece as 2*sp 44*ps sp ae
+	end
+
+	length 182
+	piece as 2*sp 44*ps 2*sp ae
+	end
+
+	length 183
+	piece as sp 45*ps ae
+	end
+
+	length 184
+	piece as 2*sp 45*ps ae
+	end
+
+	length 185
+	piece as 2*sp 45*ps sp ae
+	end
+
+	length 186
+	piece as 2*sp 45*ps 2*sp ae
+	end
+
+	length 187
+	piece as sp 46*ps ae
+	end
+
+	length 188
+	piece as 2*sp 46*ps ae
+	end
+
+	length 189
+	piece as 2*sp 46*ps sp ae
+	end
+
+	length 190
+	piece as 2*sp 46*ps 2*sp ae
+	end
+
+	length 191
+	piece as sp 47*ps ae
+	end
+
+	length 192
+	piece as 2*sp 47*ps ae
+	end
+
+	length 193
+	piece as 2*sp 47*ps sp ae
+	end
+
+	length 194
+	piece as 2*sp 47*ps 2*sp ae
+	end
+
+	length 195
+	piece as sp 48*ps ae
+	end
+
+	length 196
+	piece as 2*sp 48*ps ae
+	end
+
+	length 197
+	piece as 2*sp 48*ps sp ae
+	end
+
+	length 198
+	piece as 2*sp 48*ps 2*sp ae
+	end
+
+	length 199
+	piece as sp 49*ps ae
+	end
+
+	length 200
+	piece as 2*sp 49*ps ae
+	end
+
+	length 201
+	piece as 2*sp 49*ps sp ae
+	end
+
+	length 202
+	piece as 2*sp 49*ps 2*sp ae
+	end
+
+	length 203
+	piece as sp 50*ps ae
+	end
+
+	length 204
+	piece as 2*sp 50*ps ae
+	end
+
+	length 205
+	piece as 2*sp 50*ps sp ae
+	end
+
+	length 206
+	piece as 2*sp 50*ps 2*sp ae
+	end
+
+	length 207
+	piece as sp 51*ps ae
+	end
+
+	length 208
+	piece as 2*sp 51*ps ae
+	end
+
+	length 209
+	piece as 2*sp 51*ps sp ae
+	end
+
+	length 210
+	piece as 2*sp 51*ps 2*sp ae
+	end
+
+	length 211
+	piece as sp 52*ps ae
+	end
+
+	length 212
+	piece as 2*sp 52*ps ae
+	end
+
+	length 213
+	piece as 2*sp 52*ps sp ae
+	end
+
+	length 214
+	piece as 2*sp 52*ps 2*sp ae
+	end
+
+	length 215
+	piece as sp 53*ps ae
+	end
+
+	length 216
+	piece as 2*sp 53*ps ae
+	end
+
+	length 217
+	piece as 2*sp 53*ps sp ae
+	end
+
+	length 218
+	piece as 2*sp 53*ps 2*sp ae
+	end
+
+	length 219
+	piece as sp 54*ps ae
+	end
+
+	length 220
+	piece as 2*sp 54*ps ae
+	end
+
+	length 221
+	piece as 2*sp 54*ps sp ae
+	end
+
+	length 222
+	piece as 2*sp 54*ps 2*sp ae
+	end
+
+	length 223
+	piece as sp 55*ps ae
+	end
+
+	length 224
+	piece as 2*sp 55*ps ae
+	end
+
+	length 225
+	piece as 2*sp 55*ps sp ae
+	end
+
+	length 226
+	piece as 2*sp 55*ps 2*sp ae
+	end
+
+	length 227
+	piece as sp 56*ps ae
+	end
+
+	length 228
+	piece as 2*sp 56*ps ae
+	end
+
+	length 229
+	piece as 2*sp 56*ps sp ae
+	end
+
+	length 230
+	piece as 2*sp 56*ps 2*sp ae
+	end
+
+	length 231
+	piece as sp 57*ps ae
+	end
+
+	length 232
+	piece as 2*sp 57*ps ae
+	end
+
+	length 233
+	piece as 2*sp 57*ps sp ae
+	end
+
+	length 234
+	piece as 2*sp 57*ps 2*sp ae
+	end
+
+	length 235
+	piece as sp 58*ps ae
+	end
+
+	length 236
+	piece as 2*sp 58*ps ae
+	end
+
+	length 237
+	piece as 2*sp 58*ps sp ae
+	end
+
+	length 238
+	piece as 2*sp 58*ps 2*sp ae
+	end
+
+	length 239
+	piece as sp 59*ps ae
+	end
+
+	length 240
+	piece as 2*sp 59*ps ae
+	end
+
+	length 241
+	piece as 2*sp 59*ps sp ae
+	end
+
+	length 242
+	piece as 2*sp 59*ps 2*sp ae
+	end
+
+	length 243
+	piece as sp 60*ps ae
+	end
+
+	length 244
+	piece as 2*sp 60*ps ae
+	end
+
+	length 245
+	piece as 2*sp 60*ps sp ae
+	end
+
+	length 246
+	piece as 2*sp 60*ps 2*sp ae
+	end
+
+	length 247
+	piece as sp 61*ps ae
+	end
+
+	length 248
+	piece as 2*sp 61*ps ae
+	end
+
+	length 249
+	piece as 2*sp 61*ps sp ae
+	end
+
+	length 250
+	piece as 2*sp 61*ps 2*sp ae
+	end
+
+	length 251
+	piece as sp 62*ps ae
+	end
+
+	length 252
+	piece as 2*sp 62*ps ae
+	end
+
+	length 253
+	piece as 2*sp 62*ps sp ae
+	end
+
+	length 254
+	piece as 2*sp 62*ps 2*sp ae
+	end
+end
+
+
+# Yellow Steel Girder (SAM-8) by IDS2 (09/23)
+
+bridge 34
+
+# abutment start - 1 tile
+section as
+	piece <0x403D4000, 0>
+end 
+
+# pillar section - 3 tiles
+section pi
+	piece <0x403D5000, 0>
+	piece <0x403D6000, 0>
+	piece <0x403D5000, 0>
+end 
+
+# span only - 1 tile
+section sp
+	piece <0x403D7000, 0>
+end 
+
+# combined repeat segment - 4 tiles
+section ps
+	piece pi sp
+end
+
+#abutment end - 1 tile
+section ae
+	piece <0x403D4000, 2>
+end
+
+	length 5
+	piece as 3*sp ae
+	end
+	
+	length 6
+	piece as 4*sp ae
+	end
+	
+	length 7
+	piece as sp ps ae
+	end
+	
+	length 8
+	piece as sp ps sp ae
+	end
+	
+	length 9
+	piece as 2*sp ps sp ae
+	end
+	
+	length 10
+	piece as 2*sp ps 2*sp ae
+	end
+	
+	length 11
+	piece as sp 2*ps ae
+	end
+	
+	length 12
+	piece as 2*sp 2*ps ae
+	end
+	
+	length 13
+	piece as 2*sp 2*ps sp ae
+	end
+	
+	length 14
+	piece as 2*sp ps sp ps sp ae
+	end
+	
+	length 15
+	piece as sp 3*ps ae
+	end
+	
+	length 16
+	piece as 2*sp 3*ps ae
+	end
+	
+	length 17
+	piece as 2*sp 3*ps sp ae
+	end
+	
+	length 18
+	piece as 2*sp 3*ps 2*sp ae
+	end
+	
+	length 19
+	piece as sp 4*ps ae
+	end
+	
+	length 20
+	piece as 2*sp 4*ps ae
+	end
+	
+	length 21
+	piece as 2*sp 4*ps sp ae
+	end
+	
+	length 22
+	piece as 2*sp 4*ps 2*sp ae
+	end
+	
+	length 23
+	piece as sp 5*ps ae
+	end
+
+	length 24
+	piece as 2*sp 5*ps ae
+	end
+
+	length 25
+	piece as 2*sp 5*ps sp ae
+	end
+
+	length 26
+	piece as 2*sp 5*ps 2*sp ae
+	end
+
+	length 27
+	piece as sp 6*ps ae
+	end
+
+	length 28
+	piece as 2*sp 6*ps ae
+	end
+
+	length 29
+	piece as 2*sp 6*ps sp ae
+	end
+
+	length 30
+	piece as 2*sp 6*ps 2*sp ae
+	end
+
+	length 31
+	piece as sp 7*ps ae
+	end
+
+	length 32
+	piece as 2*sp 7*ps ae
+	end
+
+	length 33
+	piece as 2*sp 7*ps sp ae
+	end
+
+	length 34
+	piece as 2*sp 7*ps 2*sp ae
+	end
+
+	length 35
+	piece as sp 8*ps ae
+	end
+
+	length 36
+	piece as 2*sp 8*ps ae
+	end
+
+	length 37
+	piece as 2*sp 8*ps sp ae
+	end
+
+	length 38
+	piece as 2*sp 8*ps 2*sp ae
+	end
+
+	length 39
+	piece as sp 9*ps ae
+	end
+
+	length 40
+	piece as 2*sp 9*ps ae
+	end
+
+	length 41
+	piece as 2*sp 9*ps sp ae
+	end
+
+	length 42
+	piece as 2*sp 9*ps 2*sp ae
+	end
+
+	length 43
+	piece as sp 10*ps ae
+	end
+
+	length 44
+	piece as 2*sp 10*ps ae
+	end
+
+	length 45
+	piece as 2*sp 10*ps sp ae
+	end
+
+	length 46
+	piece as 2*sp 10*ps 2*sp ae
+	end
+
+	length 47
+	piece as sp 11*ps ae
+	end
+
+	length 48
+	piece as 2*sp 11*ps ae
+	end
+
+	length 49
+	piece as 2*sp 11*ps sp ae
+	end
+
+	length 50
+	piece as 2*sp 11*ps 2*sp ae
+	end
+
+	length 51
+	piece as sp 12*ps ae
+	end
+
+	length 52
+	piece as 2*sp 12*ps ae
+	end
+
+	length 53
+	piece as 2*sp 12*ps sp ae
+	end
+
+	length 54
+	piece as 2*sp 12*ps 2*sp ae
+	end
+
+	length 55
+	piece as sp 13*ps ae
+	end
+
+	length 56
+	piece as 2*sp 13*ps ae
+	end
+
+	length 57
+	piece as 2*sp 13*ps sp ae
+	end
+
+	length 58
+	piece as 2*sp 13*ps 2*sp ae
+	end
+
+	length 59
+	piece as sp 14*ps ae
+	end
+
+	length 60
+	piece as 2*sp 14*ps ae
+	end
+
+	length 61
+	piece as 2*sp 14*ps sp ae
+	end
+
+	length 62
+	piece as 2*sp 14*ps 2*sp ae
+	end
+
+	length 63
+	piece as sp 15*ps ae
+	end
+
+	length 64
+	piece as 2*sp 15*ps ae
+	end
+
+	length 65
+	piece as 2*sp 15*ps sp ae
+	end
+
+	length 66
+	piece as 2*sp 15*ps 2*sp ae
+	end
+
+	length 67
+	piece as sp 16*ps ae
+	end
+
+	length 68
+	piece as 2*sp 16*ps ae
+	end
+
+	length 69
+	piece as 2*sp 16*ps sp ae
+	end
+
+	length 70
+	piece as 2*sp 16*ps 2*sp ae
+	end
+
+	length 71
+	piece as sp 17*ps ae
+	end
+
+	length 72
+	piece as 2*sp 17*ps ae
+	end
+
+	length 73
+	piece as 2*sp 17*ps sp ae
+	end
+
+	length 74
+	piece as 2*sp 17*ps 2*sp ae
+	end
+
+	length 75
+	piece as sp 18*ps ae
+	end
+
+	length 76
+	piece as 2*sp 18*ps ae
+	end
+
+	length 77
+	piece as 2*sp 18*ps sp ae
+	end
+
+	length 78
+	piece as 2*sp 18*ps 2*sp ae
+	end
+
+	length 79
+	piece as sp 19*ps ae
+	end
+
+	length 80
+	piece as 2*sp 19*ps ae
+	end
+
+	length 81
+	piece as 2*sp 19*ps sp ae
+	end
+
+	length 82
+	piece as 2*sp 19*ps 2*sp ae
+	end
+
+	length 83
+	piece as sp 20*ps ae
+	end
+
+	length 84
+	piece as 2*sp 20*ps ae
+	end
+
+	length 85
+	piece as 2*sp 20*ps sp ae
+	end
+
+	length 86
+	piece as 2*sp 20*ps 2*sp ae
+	end
+
+	length 87
+	piece as sp 21*ps ae
+	end
+
+	length 88
+	piece as 2*sp 21*ps ae
+	end
+
+	length 89
+	piece as 2*sp 21*ps sp ae
+	end
+
+	length 90
+	piece as 2*sp 21*ps 2*sp ae
+	end
+
+	length 91
+	piece as sp 22*ps ae
+	end
+
+	length 92
+	piece as 2*sp 22*ps ae
+	end
+
+	length 93
+	piece as 2*sp 22*ps sp ae
+	end
+
+	length 94
+	piece as 2*sp 22*ps 2*sp ae
+	end
+
+	length 95
+	piece as sp 23*ps ae
+	end
+
+	length 96
+	piece as 2*sp 23*ps ae
+	end
+
+	length 97
+	piece as 2*sp 23*ps sp ae
+	end
+
+	length 98
+	piece as 2*sp 23*ps 2*sp ae
+	end
+
+	length 99
+	piece as sp 24*ps ae
+	end
+
+	length 100
+	piece as 2*sp 24*ps ae
+	end
+
+	length 101
+	piece as 2*sp 24*ps sp ae
+	end
+
+	length 102
+	piece as 2*sp 24*ps 2*sp ae
+	end
+
+	length 103
+	piece as sp 25*ps ae
+	end
+
+	length 104
+	piece as 2*sp 25*ps ae
+	end
+
+	length 105
+	piece as 2*sp 25*ps sp ae
+	end
+
+	length 106
+	piece as 2*sp 25*ps 2*sp ae
+	end
+
+	length 107
+	piece as sp 26*ps ae
+	end
+
+	length 108
+	piece as 2*sp 26*ps ae
+	end
+
+	length 109
+	piece as 2*sp 26*ps sp ae
+	end
+
+	length 110
+	piece as 2*sp 26*ps 2*sp ae
+	end
+
+	length 111
+	piece as sp 27*ps ae
+	end
+
+	length 112
+	piece as 2*sp 27*ps ae
+	end
+
+	length 113
+	piece as 2*sp 27*ps sp ae
+	end
+
+	length 114
+	piece as 2*sp 27*ps 2*sp ae
+	end
+
+	length 115
+	piece as sp 28*ps ae
+	end
+
+	length 116
+	piece as 2*sp 28*ps ae
+	end
+
+	length 117
+	piece as 2*sp 28*ps sp ae
+	end
+
+	length 118
+	piece as 2*sp 28*ps 2*sp ae
+	end
+
+	length 119
+	piece as sp 29*ps ae
+	end
+
+	length 120
+	piece as 2*sp 29*ps ae
+	end
+
+	length 121
+	piece as 2*sp 29*ps sp ae
+	end
+
+	length 122
+	piece as 2*sp 29*ps 2*sp ae
+	end
+
+	length 123
+	piece as sp 30*ps ae
+	end
+
+	length 124
+	piece as 2*sp 30*ps ae
+	end
+
+	length 125
+	piece as 2*sp 30*ps sp ae
+	end
+
+	length 126
+	piece as 2*sp 30*ps 2*sp ae
+	end
+
+	length 127
+	piece as sp 31*ps ae
+	end
+
+	length 128
+	piece as 2*sp 31*ps ae
+	end
+
+	length 129
+	piece as 2*sp 31*ps sp ae
+	end
+
+	length 130
+	piece as 2*sp 31*ps 2*sp ae
+	end
+
+	length 131
+	piece as sp 32*ps ae
+	end
+
+	length 132
+	piece as 2*sp 32*ps ae
+	end
+
+	length 133
+	piece as 2*sp 32*ps sp ae
+	end
+
+	length 134
+	piece as 2*sp 32*ps 2*sp ae
+	end
+
+	length 135
+	piece as sp 33*ps ae
+	end
+
+	length 136
+	piece as 2*sp 33*ps ae
+	end
+
+	length 137
+	piece as 2*sp 33*ps sp ae
+	end
+
+	length 138
+	piece as 2*sp 33*ps 2*sp ae
+	end
+
+	length 139
+	piece as sp 34*ps ae
+	end
+
+	length 140
+	piece as 2*sp 34*ps ae
+	end
+
+	length 141
+	piece as 2*sp 34*ps sp ae
+	end
+
+	length 142
+	piece as 2*sp 34*ps 2*sp ae
+	end
+
+	length 143
+	piece as sp 35*ps ae
+	end
+
+	length 144
+	piece as 2*sp 35*ps ae
+	end
+
+	length 145
+	piece as 2*sp 35*ps sp ae
+	end
+
+	length 146
+	piece as 2*sp 35*ps 2*sp ae
+	end
+
+	length 147
+	piece as sp 36*ps ae
+	end
+
+	length 148
+	piece as 2*sp 36*ps ae
+	end
+
+	length 149
+	piece as 2*sp 36*ps sp ae
+	end
+
+	length 150
+	piece as 2*sp 36*ps 2*sp ae
+	end
+
+	length 151
+	piece as sp 37*ps ae
+	end
+
+	length 152
+	piece as 2*sp 37*ps ae
+	end
+
+	length 153
+	piece as 2*sp 37*ps sp ae
+	end
+
+	length 154
+	piece as 2*sp 37*ps 2*sp ae
+	end
+
+	length 155
+	piece as sp 38*ps ae
+	end
+
+	length 156
+	piece as 2*sp 38*ps ae
+	end
+
+	length 157
+	piece as 2*sp 38*ps sp ae
+	end
+
+	length 158
+	piece as 2*sp 38*ps 2*sp ae
+	end
+
+	length 159
+	piece as sp 39*ps ae
+	end
+
+	length 160
+	piece as 2*sp 39*ps ae
+	end
+
+	length 161
+	piece as 2*sp 39*ps sp ae
+	end
+
+	length 162
+	piece as 2*sp 39*ps 2*sp ae
+	end
+
+	length 163
+	piece as sp 40*ps ae
+	end
+
+	length 164
+	piece as 2*sp 40*ps ae
+	end
+
+	length 165
+	piece as 2*sp 40*ps sp ae
+	end
+
+	length 166
+	piece as 2*sp 40*ps 2*sp ae
+	end
+
+	length 167
+	piece as sp 41*ps ae
+	end
+
+	length 168
+	piece as 2*sp 41*ps ae
+	end
+
+	length 169
+	piece as 2*sp 41*ps sp ae
+	end
+
+	length 170
+	piece as 2*sp 41*ps 2*sp ae
+	end
+
+	length 171
+	piece as sp 42*ps ae
+	end
+
+	length 172
+	piece as 2*sp 42*ps ae
+	end
+
+	length 173
+	piece as 2*sp 42*ps sp ae
+	end
+
+	length 174
+	piece as 2*sp 42*ps 2*sp ae
+	end
+
+	length 175
+	piece as sp 43*ps ae
+	end
+
+	length 176
+	piece as 2*sp 43*ps ae
+	end
+
+	length 177
+	piece as 2*sp 43*ps sp ae
+	end
+
+	length 178
+	piece as 2*sp 43*ps 2*sp ae
+	end
+
+	length 179
+	piece as sp 44*ps ae
+	end
+
+	length 180
+
+	piece as 2*sp 44*ps ae
+	end
+
+	length 181
+	piece as 2*sp 44*ps sp ae
+	end
+
+	length 182
+	piece as 2*sp 44*ps 2*sp ae
+	end
+
+	length 183
+	piece as sp 45*ps ae
+	end
+
+	length 184
+	piece as 2*sp 45*ps ae
+	end
+
+	length 185
+	piece as 2*sp 45*ps sp ae
+	end
+
+	length 186
+	piece as 2*sp 45*ps 2*sp ae
+	end
+
+	length 187
+	piece as sp 46*ps ae
+	end
+
+	length 188
+	piece as 2*sp 46*ps ae
+	end
+
+	length 189
+	piece as 2*sp 46*ps sp ae
+	end
+
+	length 190
+	piece as 2*sp 46*ps 2*sp ae
+	end
+
+	length 191
+	piece as sp 47*ps ae
+	end
+
+	length 192
+	piece as 2*sp 47*ps ae
+	end
+
+	length 193
+	piece as 2*sp 47*ps sp ae
+	end
+
+	length 194
+	piece as 2*sp 47*ps 2*sp ae
+	end
+
+	length 195
+	piece as sp 48*ps ae
+	end
+
+	length 196
+	piece as 2*sp 48*ps ae
+	end
+
+	length 197
+	piece as 2*sp 48*ps sp ae
+	end
+
+	length 198
+	piece as 2*sp 48*ps 2*sp ae
+	end
+
+	length 199
+	piece as sp 49*ps ae
+	end
+
+	length 200
+	piece as 2*sp 49*ps ae
+	end
+
+	length 201
+	piece as 2*sp 49*ps sp ae
+	end
+
+	length 202
+	piece as 2*sp 49*ps 2*sp ae
+	end
+
+	length 203
+	piece as sp 50*ps ae
+	end
+
+	length 204
+	piece as 2*sp 50*ps ae
+	end
+
+	length 205
+	piece as 2*sp 50*ps sp ae
+	end
+
+	length 206
+	piece as 2*sp 50*ps 2*sp ae
+	end
+
+	length 207
+	piece as sp 51*ps ae
+	end
+
+	length 208
+	piece as 2*sp 51*ps ae
+	end
+
+	length 209
+	piece as 2*sp 51*ps sp ae
+	end
+
+	length 210
+	piece as 2*sp 51*ps 2*sp ae
+	end
+
+	length 211
+	piece as sp 52*ps ae
+	end
+
+	length 212
+	piece as 2*sp 52*ps ae
+	end
+
+	length 213
+	piece as 2*sp 52*ps sp ae
+	end
+
+	length 214
+	piece as 2*sp 52*ps 2*sp ae
+	end
+
+	length 215
+	piece as sp 53*ps ae
+	end
+
+	length 216
+	piece as 2*sp 53*ps ae
+	end
+
+	length 217
+	piece as 2*sp 53*ps sp ae
+	end
+
+	length 218
+	piece as 2*sp 53*ps 2*sp ae
+	end
+
+	length 219
+	piece as sp 54*ps ae
+	end
+
+	length 220
+	piece as 2*sp 54*ps ae
+	end
+
+	length 221
+	piece as 2*sp 54*ps sp ae
+	end
+
+	length 222
+	piece as 2*sp 54*ps 2*sp ae
+	end
+
+	length 223
+	piece as sp 55*ps ae
+	end
+
+	length 224
+	piece as 2*sp 55*ps ae
+	end
+
+	length 225
+	piece as 2*sp 55*ps sp ae
+	end
+
+	length 226
+	piece as 2*sp 55*ps 2*sp ae
+	end
+
+	length 227
+	piece as sp 56*ps ae
+	end
+
+	length 228
+	piece as 2*sp 56*ps ae
+	end
+
+	length 229
+	piece as 2*sp 56*ps sp ae
+	end
+
+	length 230
+	piece as 2*sp 56*ps 2*sp ae
+	end
+
+	length 231
+	piece as sp 57*ps ae
+	end
+
+	length 232
+	piece as 2*sp 57*ps ae
+	end
+
+	length 233
+	piece as 2*sp 57*ps sp ae
+	end
+
+	length 234
+	piece as 2*sp 57*ps 2*sp ae
+	end
+
+	length 235
+	piece as sp 58*ps ae
+	end
+
+	length 236
+	piece as 2*sp 58*ps ae
+	end
+
+	length 237
+	piece as 2*sp 58*ps sp ae
+	end
+
+	length 238
+	piece as 2*sp 58*ps 2*sp ae
+	end
+
+	length 239
+	piece as sp 59*ps ae
+	end
+
+	length 240
+	piece as 2*sp 59*ps ae
+	end
+
+	length 241
+	piece as 2*sp 59*ps sp ae
+	end
+
+	length 242
+	piece as 2*sp 59*ps 2*sp ae
+	end
+
+	length 243
+	piece as sp 60*ps ae
+	end
+
+	length 244
+	piece as 2*sp 60*ps ae
+	end
+
+	length 245
+	piece as 2*sp 60*ps sp ae
+	end
+
+	length 246
+	piece as 2*sp 60*ps 2*sp ae
+	end
+
+	length 247
+	piece as sp 61*ps ae
+	end
+
+	length 248
+	piece as 2*sp 61*ps ae
+	end
+
+	length 249
+	piece as 2*sp 61*ps sp ae
+	end
+
+	length 250
+	piece as 2*sp 61*ps 2*sp ae
+	end
+
+	length 251
+	piece as sp 62*ps ae
+	end
+
+	length 252
+	piece as 2*sp 62*ps ae
+	end
+
+	length 253
+	piece as 2*sp 62*ps sp ae
+	end
+
+	length 254
+	piece as 2*sp 62*ps 2*sp ae
+	end
+end
+
+
+# Yellow Steel Girder (SAM-9) by IDS2 (09/23)
+
+bridge 35
+
+# abutment start - 1 tile
+section as
+	piece <0x403E4000, 0>
+end 
+
+# pillar section - 3 tiles
+section pi
+	piece <0x403E5000, 0>
+	piece <0x403E6000, 0>
+	piece <0x403E5000, 0>
+end 
+
+# span only - 1 tile
+section sp
+	piece <0x403E7000, 0>
+end 
+
+# combined repeat segment - 4 tiles
+section ps
+	piece pi sp
+end
+
+#abutment end - 1 tile
+section ae
+	piece <0x403E4000, 2>
+end
+
+	length 5
+	piece as 3*sp ae
+	end
+	
+	length 6
+	piece as 4*sp ae
+	end
+	
+	length 7
+	piece as sp ps ae
+	end
+	
+	length 8
+	piece as sp ps sp ae
+	end
+	
+	length 9
+	piece as 2*sp ps sp ae
+	end
+	
+	length 10
+	piece as 2*sp ps 2*sp ae
+	end
+	
+	length 11
+	piece as sp 2*ps ae
+	end
+	
+	length 12
+	piece as 2*sp 2*ps ae
+	end
+	
+	length 13
+	piece as 2*sp 2*ps sp ae
+	end
+	
+	length 14
+	piece as 2*sp ps sp ps sp ae
+	end
+	
+	length 15
+	piece as sp 3*ps ae
+	end
+	
+	length 16
+	piece as 2*sp 3*ps ae
+	end
+	
+	length 17
+	piece as 2*sp 3*ps sp ae
+	end
+	
+	length 18
+	piece as 2*sp 3*ps 2*sp ae
+	end
+	
+	length 19
+	piece as sp 4*ps ae
+	end
+	
+	length 20
+	piece as 2*sp 4*ps ae
+	end
+	
+	length 21
+	piece as 2*sp 4*ps sp ae
+	end
+	
+	length 22
+	piece as 2*sp 4*ps 2*sp ae
+	end
+	
+	length 23
+	piece as sp 5*ps ae
+	end
+
+	length 24
+	piece as 2*sp 5*ps ae
+	end
+
+	length 25
+	piece as 2*sp 5*ps sp ae
+	end
+
+	length 26
+	piece as 2*sp 5*ps 2*sp ae
+	end
+
+	length 27
+	piece as sp 6*ps ae
+	end
+
+	length 28
+	piece as 2*sp 6*ps ae
+	end
+
+	length 29
+	piece as 2*sp 6*ps sp ae
+	end
+
+	length 30
+	piece as 2*sp 6*ps 2*sp ae
+	end
+
+	length 31
+	piece as sp 7*ps ae
+	end
+
+	length 32
+	piece as 2*sp 7*ps ae
+	end
+
+	length 33
+	piece as 2*sp 7*ps sp ae
+	end
+
+	length 34
+	piece as 2*sp 7*ps 2*sp ae
+	end
+
+	length 35
+	piece as sp 8*ps ae
+	end
+
+	length 36
+	piece as 2*sp 8*ps ae
+	end
+
+	length 37
+	piece as 2*sp 8*ps sp ae
+	end
+
+	length 38
+	piece as 2*sp 8*ps 2*sp ae
+	end
+
+	length 39
+	piece as sp 9*ps ae
+	end
+
+	length 40
+	piece as 2*sp 9*ps ae
+	end
+
+	length 41
+	piece as 2*sp 9*ps sp ae
+	end
+
+	length 42
+	piece as 2*sp 9*ps 2*sp ae
+	end
+
+	length 43
+	piece as sp 10*ps ae
+	end
+
+	length 44
+	piece as 2*sp 10*ps ae
+	end
+
+	length 45
+	piece as 2*sp 10*ps sp ae
+	end
+
+	length 46
+	piece as 2*sp 10*ps 2*sp ae
+	end
+
+	length 47
+	piece as sp 11*ps ae
+	end
+
+	length 48
+	piece as 2*sp 11*ps ae
+	end
+
+	length 49
+	piece as 2*sp 11*ps sp ae
+	end
+
+	length 50
+	piece as 2*sp 11*ps 2*sp ae
+	end
+
+	length 51
+	piece as sp 12*ps ae
+	end
+
+	length 52
+	piece as 2*sp 12*ps ae
+	end
+
+	length 53
+	piece as 2*sp 12*ps sp ae
+	end
+
+	length 54
+	piece as 2*sp 12*ps 2*sp ae
+	end
+
+	length 55
+	piece as sp 13*ps ae
+	end
+
+	length 56
+	piece as 2*sp 13*ps ae
+	end
+
+	length 57
+	piece as 2*sp 13*ps sp ae
+	end
+
+	length 58
+	piece as 2*sp 13*ps 2*sp ae
+	end
+
+	length 59
+	piece as sp 14*ps ae
+	end
+
+	length 60
+	piece as 2*sp 14*ps ae
+	end
+
+	length 61
+	piece as 2*sp 14*ps sp ae
+	end
+
+	length 62
+	piece as 2*sp 14*ps 2*sp ae
+	end
+
+	length 63
+	piece as sp 15*ps ae
+	end
+
+	length 64
+	piece as 2*sp 15*ps ae
+	end
+
+	length 65
+	piece as 2*sp 15*ps sp ae
+	end
+
+	length 66
+	piece as 2*sp 15*ps 2*sp ae
+	end
+
+	length 67
+	piece as sp 16*ps ae
+	end
+
+	length 68
+	piece as 2*sp 16*ps ae
+	end
+
+	length 69
+	piece as 2*sp 16*ps sp ae
+	end
+
+	length 70
+	piece as 2*sp 16*ps 2*sp ae
+	end
+
+	length 71
+	piece as sp 17*ps ae
+	end
+
+	length 72
+	piece as 2*sp 17*ps ae
+	end
+
+	length 73
+	piece as 2*sp 17*ps sp ae
+	end
+
+	length 74
+	piece as 2*sp 17*ps 2*sp ae
+	end
+
+	length 75
+	piece as sp 18*ps ae
+	end
+
+	length 76
+	piece as 2*sp 18*ps ae
+	end
+
+	length 77
+	piece as 2*sp 18*ps sp ae
+	end
+
+	length 78
+	piece as 2*sp 18*ps 2*sp ae
+	end
+
+	length 79
+	piece as sp 19*ps ae
+	end
+
+	length 80
+	piece as 2*sp 19*ps ae
+	end
+
+	length 81
+	piece as 2*sp 19*ps sp ae
+	end
+
+	length 82
+	piece as 2*sp 19*ps 2*sp ae
+	end
+
+	length 83
+	piece as sp 20*ps ae
+	end
+
+	length 84
+	piece as 2*sp 20*ps ae
+	end
+
+	length 85
+	piece as 2*sp 20*ps sp ae
+	end
+
+	length 86
+	piece as 2*sp 20*ps 2*sp ae
+	end
+
+	length 87
+	piece as sp 21*ps ae
+	end
+
+	length 88
+	piece as 2*sp 21*ps ae
+	end
+
+	length 89
+	piece as 2*sp 21*ps sp ae
+	end
+
+	length 90
+	piece as 2*sp 21*ps 2*sp ae
+	end
+
+	length 91
+	piece as sp 22*ps ae
+	end
+
+	length 92
+	piece as 2*sp 22*ps ae
+	end
+
+	length 93
+	piece as 2*sp 22*ps sp ae
+	end
+
+	length 94
+	piece as 2*sp 22*ps 2*sp ae
+	end
+
+	length 95
+	piece as sp 23*ps ae
+	end
+
+	length 96
+	piece as 2*sp 23*ps ae
+	end
+
+	length 97
+	piece as 2*sp 23*ps sp ae
+	end
+
+	length 98
+	piece as 2*sp 23*ps 2*sp ae
+	end
+
+	length 99
+	piece as sp 24*ps ae
+	end
+
+	length 100
+	piece as 2*sp 24*ps ae
+	end
+
+	length 101
+	piece as 2*sp 24*ps sp ae
+	end
+
+	length 102
+	piece as 2*sp 24*ps 2*sp ae
+	end
+
+	length 103
+	piece as sp 25*ps ae
+	end
+
+	length 104
+	piece as 2*sp 25*ps ae
+	end
+
+	length 105
+	piece as 2*sp 25*ps sp ae
+	end
+
+	length 106
+	piece as 2*sp 25*ps 2*sp ae
+	end
+
+	length 107
+	piece as sp 26*ps ae
+	end
+
+	length 108
+	piece as 2*sp 26*ps ae
+	end
+
+	length 109
+	piece as 2*sp 26*ps sp ae
+	end
+
+	length 110
+	piece as 2*sp 26*ps 2*sp ae
+	end
+
+	length 111
+	piece as sp 27*ps ae
+	end
+
+	length 112
+	piece as 2*sp 27*ps ae
+	end
+
+	length 113
+	piece as 2*sp 27*ps sp ae
+	end
+
+	length 114
+	piece as 2*sp 27*ps 2*sp ae
+	end
+
+	length 115
+	piece as sp 28*ps ae
+	end
+
+	length 116
+	piece as 2*sp 28*ps ae
+	end
+
+	length 117
+	piece as 2*sp 28*ps sp ae
+	end
+
+	length 118
+	piece as 2*sp 28*ps 2*sp ae
+	end
+
+	length 119
+	piece as sp 29*ps ae
+	end
+
+	length 120
+	piece as 2*sp 29*ps ae
+	end
+
+	length 121
+	piece as 2*sp 29*ps sp ae
+	end
+
+	length 122
+	piece as 2*sp 29*ps 2*sp ae
+	end
+
+	length 123
+	piece as sp 30*ps ae
+	end
+
+	length 124
+	piece as 2*sp 30*ps ae
+	end
+
+	length 125
+	piece as 2*sp 30*ps sp ae
+	end
+
+	length 126
+	piece as 2*sp 30*ps 2*sp ae
+	end
+
+	length 127
+	piece as sp 31*ps ae
+	end
+
+	length 128
+	piece as 2*sp 31*ps ae
+	end
+
+	length 129
+	piece as 2*sp 31*ps sp ae
+	end
+
+	length 130
+	piece as 2*sp 31*ps 2*sp ae
+	end
+
+	length 131
+	piece as sp 32*ps ae
+	end
+
+	length 132
+	piece as 2*sp 32*ps ae
+	end
+
+	length 133
+	piece as 2*sp 32*ps sp ae
+	end
+
+	length 134
+	piece as 2*sp 32*ps 2*sp ae
+	end
+
+	length 135
+	piece as sp 33*ps ae
+	end
+
+	length 136
+	piece as 2*sp 33*ps ae
+	end
+
+	length 137
+	piece as 2*sp 33*ps sp ae
+	end
+
+	length 138
+	piece as 2*sp 33*ps 2*sp ae
+	end
+
+	length 139
+	piece as sp 34*ps ae
+	end
+
+	length 140
+	piece as 2*sp 34*ps ae
+	end
+
+	length 141
+	piece as 2*sp 34*ps sp ae
+	end
+
+	length 142
+	piece as 2*sp 34*ps 2*sp ae
+	end
+
+	length 143
+	piece as sp 35*ps ae
+	end
+
+	length 144
+	piece as 2*sp 35*ps ae
+	end
+
+	length 145
+	piece as 2*sp 35*ps sp ae
+	end
+
+	length 146
+	piece as 2*sp 35*ps 2*sp ae
+	end
+
+	length 147
+	piece as sp 36*ps ae
+	end
+
+	length 148
+	piece as 2*sp 36*ps ae
+	end
+
+	length 149
+	piece as 2*sp 36*ps sp ae
+	end
+
+	length 150
+	piece as 2*sp 36*ps 2*sp ae
+	end
+
+	length 151
+	piece as sp 37*ps ae
+	end
+
+	length 152
+	piece as 2*sp 37*ps ae
+	end
+
+	length 153
+	piece as 2*sp 37*ps sp ae
+	end
+
+	length 154
+	piece as 2*sp 37*ps 2*sp ae
+	end
+
+	length 155
+	piece as sp 38*ps ae
+	end
+
+	length 156
+	piece as 2*sp 38*ps ae
+	end
+
+	length 157
+	piece as 2*sp 38*ps sp ae
+	end
+
+	length 158
+	piece as 2*sp 38*ps 2*sp ae
+	end
+
+	length 159
+	piece as sp 39*ps ae
+	end
+
+	length 160
+	piece as 2*sp 39*ps ae
+	end
+
+	length 161
+	piece as 2*sp 39*ps sp ae
+	end
+
+	length 162
+	piece as 2*sp 39*ps 2*sp ae
+	end
+
+	length 163
+	piece as sp 40*ps ae
+	end
+
+	length 164
+	piece as 2*sp 40*ps ae
+	end
+
+	length 165
+	piece as 2*sp 40*ps sp ae
+	end
+
+	length 166
+	piece as 2*sp 40*ps 2*sp ae
+	end
+
+	length 167
+	piece as sp 41*ps ae
+	end
+
+	length 168
+	piece as 2*sp 41*ps ae
+	end
+
+	length 169
+	piece as 2*sp 41*ps sp ae
+	end
+
+	length 170
+	piece as 2*sp 41*ps 2*sp ae
+	end
+
+	length 171
+	piece as sp 42*ps ae
+	end
+
+	length 172
+	piece as 2*sp 42*ps ae
+	end
+
+	length 173
+	piece as 2*sp 42*ps sp ae
+	end
+
+	length 174
+	piece as 2*sp 42*ps 2*sp ae
+	end
+
+	length 175
+	piece as sp 43*ps ae
+	end
+
+	length 176
+	piece as 2*sp 43*ps ae
+	end
+
+	length 177
+	piece as 2*sp 43*ps sp ae
+	end
+
+	length 178
+	piece as 2*sp 43*ps 2*sp ae
+	end
+
+	length 179
+	piece as sp 44*ps ae
+	end
+
+	length 180
+
+	piece as 2*sp 44*ps ae
+	end
+
+	length 181
+	piece as 2*sp 44*ps sp ae
+	end
+
+	length 182
+	piece as 2*sp 44*ps 2*sp ae
+	end
+
+	length 183
+	piece as sp 45*ps ae
+	end
+
+	length 184
+	piece as 2*sp 45*ps ae
+	end
+
+	length 185
+	piece as 2*sp 45*ps sp ae
+	end
+
+	length 186
+	piece as 2*sp 45*ps 2*sp ae
+	end
+
+	length 187
+	piece as sp 46*ps ae
+	end
+
+	length 188
+	piece as 2*sp 46*ps ae
+	end
+
+	length 189
+	piece as 2*sp 46*ps sp ae
+	end
+
+	length 190
+	piece as 2*sp 46*ps 2*sp ae
+	end
+
+	length 191
+	piece as sp 47*ps ae
+	end
+
+	length 192
+	piece as 2*sp 47*ps ae
+	end
+
+	length 193
+	piece as 2*sp 47*ps sp ae
+	end
+
+	length 194
+	piece as 2*sp 47*ps 2*sp ae
+	end
+
+	length 195
+	piece as sp 48*ps ae
+	end
+
+	length 196
+	piece as 2*sp 48*ps ae
+	end
+
+	length 197
+	piece as 2*sp 48*ps sp ae
+	end
+
+	length 198
+	piece as 2*sp 48*ps 2*sp ae
+	end
+
+	length 199
+	piece as sp 49*ps ae
+	end
+
+	length 200
+	piece as 2*sp 49*ps ae
+	end
+
+	length 201
+	piece as 2*sp 49*ps sp ae
+	end
+
+	length 202
+	piece as 2*sp 49*ps 2*sp ae
+	end
+
+	length 203
+	piece as sp 50*ps ae
+	end
+
+	length 204
+	piece as 2*sp 50*ps ae
+	end
+
+	length 205
+	piece as 2*sp 50*ps sp ae
+	end
+
+	length 206
+	piece as 2*sp 50*ps 2*sp ae
+	end
+
+	length 207
+	piece as sp 51*ps ae
+	end
+
+	length 208
+	piece as 2*sp 51*ps ae
+	end
+
+	length 209
+	piece as 2*sp 51*ps sp ae
+	end
+
+	length 210
+	piece as 2*sp 51*ps 2*sp ae
+	end
+
+	length 211
+	piece as sp 52*ps ae
+	end
+
+	length 212
+	piece as 2*sp 52*ps ae
+	end
+
+	length 213
+	piece as 2*sp 52*ps sp ae
+	end
+
+	length 214
+	piece as 2*sp 52*ps 2*sp ae
+	end
+
+	length 215
+	piece as sp 53*ps ae
+	end
+
+	length 216
+	piece as 2*sp 53*ps ae
+	end
+
+	length 217
+	piece as 2*sp 53*ps sp ae
+	end
+
+	length 218
+	piece as 2*sp 53*ps 2*sp ae
+	end
+
+	length 219
+	piece as sp 54*ps ae
+	end
+
+	length 220
+	piece as 2*sp 54*ps ae
+	end
+
+	length 221
+	piece as 2*sp 54*ps sp ae
+	end
+
+	length 222
+	piece as 2*sp 54*ps 2*sp ae
+	end
+
+	length 223
+	piece as sp 55*ps ae
+	end
+
+	length 224
+	piece as 2*sp 55*ps ae
+	end
+
+	length 225
+	piece as 2*sp 55*ps sp ae
+	end
+
+	length 226
+	piece as 2*sp 55*ps 2*sp ae
+	end
+
+	length 227
+	piece as sp 56*ps ae
+	end
+
+	length 228
+	piece as 2*sp 56*ps ae
+	end
+
+	length 229
+	piece as 2*sp 56*ps sp ae
+	end
+
+	length 230
+	piece as 2*sp 56*ps 2*sp ae
+	end
+
+	length 231
+	piece as sp 57*ps ae
+	end
+
+	length 232
+	piece as 2*sp 57*ps ae
+	end
+
+	length 233
+	piece as 2*sp 57*ps sp ae
+	end
+
+	length 234
+	piece as 2*sp 57*ps 2*sp ae
+	end
+
+	length 235
+	piece as sp 58*ps ae
+	end
+
+	length 236
+	piece as 2*sp 58*ps ae
+	end
+
+	length 237
+	piece as 2*sp 58*ps sp ae
+	end
+
+	length 238
+	piece as 2*sp 58*ps 2*sp ae
+	end
+
+	length 239
+	piece as sp 59*ps ae
+	end
+
+	length 240
+	piece as 2*sp 59*ps ae
+	end
+
+	length 241
+	piece as 2*sp 59*ps sp ae
+	end
+
+	length 242
+	piece as 2*sp 59*ps 2*sp ae
+	end
+
+	length 243
+	piece as sp 60*ps ae
+	end
+
+	length 244
+	piece as 2*sp 60*ps ae
+	end
+
+	length 245
+	piece as 2*sp 60*ps sp ae
+	end
+
+	length 246
+	piece as 2*sp 60*ps 2*sp ae
+	end
+
+	length 247
+	piece as sp 61*ps ae
+	end
+
+	length 248
+	piece as 2*sp 61*ps ae
+	end
+
+	length 249
+	piece as 2*sp 61*ps sp ae
+	end
+
+	length 250
+	piece as 2*sp 61*ps 2*sp ae
+	end
+
+	length 251
+	piece as sp 62*ps ae
+	end
+
+	length 252
+	piece as 2*sp 62*ps ae
+	end
+
+	length 253
+	piece as 2*sp 62*ps sp ae
+	end
+
+	length 254
+	piece as 2*sp 62*ps 2*sp ae
+	end
+end
+
+
+# Yellow Steel Girder (SAM-10) by IDS2 (09/23)
+
+bridge 36
+
+# abutment start - 1 tile
+section as
+	piece <0x403F4000, 0>
+end 
+
+# pillar section - 3 tiles
+section pi
+	piece <0x403F5000, 0>
+	piece <0x403F6000, 0>
+	piece <0x403F5000, 0>
+end 
+
+# span only - 1 tile
+section sp
+	piece <0x403F7000, 0>
+end 
+
+# combined repeat segment - 4 tiles
+section ps
+	piece pi sp
+end
+
+#abutment end - 1 tile
+section ae
+	piece <0x403F4000, 2>
+end
+
+	length 5
+	piece as 3*sp ae
+	end
+	
+	length 6
+	piece as 4*sp ae
+	end
+	
+	length 7
+	piece as sp ps ae
+	end
+	
+	length 8
+	piece as sp ps sp ae
+	end
+	
+	length 9
+	piece as 2*sp ps sp ae
+	end
+	
+	length 10
+	piece as 2*sp ps 2*sp ae
+	end
+	
+	length 11
+	piece as sp 2*ps ae
+	end
+	
+	length 12
+	piece as 2*sp 2*ps ae
+	end
+	
+	length 13
+	piece as 2*sp 2*ps sp ae
+	end
+	
+	length 14
+	piece as 2*sp ps sp ps sp ae
+	end
+	
+	length 15
+	piece as sp 3*ps ae
+	end
+	
+	length 16
+	piece as 2*sp 3*ps ae
+	end
+	
+	length 17
+	piece as 2*sp 3*ps sp ae
+	end
+	
+	length 18
+	piece as 2*sp 3*ps 2*sp ae
+	end
+	
+	length 19
+	piece as sp 4*ps ae
+	end
+	
+	length 20
+	piece as 2*sp 4*ps ae
+	end
+	
+	length 21
+	piece as 2*sp 4*ps sp ae
+	end
+	
+	length 22
+	piece as 2*sp 4*ps 2*sp ae
+	end
+	
+	length 23
+	piece as sp 5*ps ae
+	end
+
+	length 24
+	piece as 2*sp 5*ps ae
+	end
+
+	length 25
+	piece as 2*sp 5*ps sp ae
+	end
+
+	length 26
+	piece as 2*sp 5*ps 2*sp ae
+	end
+
+	length 27
+	piece as sp 6*ps ae
+	end
+
+	length 28
+	piece as 2*sp 6*ps ae
+	end
+
+	length 29
+	piece as 2*sp 6*ps sp ae
+	end
+
+	length 30
+	piece as 2*sp 6*ps 2*sp ae
+	end
+
+	length 31
+	piece as sp 7*ps ae
+	end
+
+	length 32
+	piece as 2*sp 7*ps ae
+	end
+
+	length 33
+	piece as 2*sp 7*ps sp ae
+	end
+
+	length 34
+	piece as 2*sp 7*ps 2*sp ae
+	end
+
+	length 35
+	piece as sp 8*ps ae
+	end
+
+	length 36
+	piece as 2*sp 8*ps ae
+	end
+
+	length 37
+	piece as 2*sp 8*ps sp ae
+	end
+
+	length 38
+	piece as 2*sp 8*ps 2*sp ae
+	end
+
+	length 39
+	piece as sp 9*ps ae
+	end
+
+	length 40
+	piece as 2*sp 9*ps ae
+	end
+
+	length 41
+	piece as 2*sp 9*ps sp ae
+	end
+
+	length 42
+	piece as 2*sp 9*ps 2*sp ae
+	end
+
+	length 43
+	piece as sp 10*ps ae
+	end
+
+	length 44
+	piece as 2*sp 10*ps ae
+	end
+
+	length 45
+	piece as 2*sp 10*ps sp ae
+	end
+
+	length 46
+	piece as 2*sp 10*ps 2*sp ae
+	end
+
+	length 47
+	piece as sp 11*ps ae
+	end
+
+	length 48
+	piece as 2*sp 11*ps ae
+	end
+
+	length 49
+	piece as 2*sp 11*ps sp ae
+	end
+
+	length 50
+	piece as 2*sp 11*ps 2*sp ae
+	end
+
+	length 51
+	piece as sp 12*ps ae
+	end
+
+	length 52
+	piece as 2*sp 12*ps ae
+	end
+
+	length 53
+	piece as 2*sp 12*ps sp ae
+	end
+
+	length 54
+	piece as 2*sp 12*ps 2*sp ae
+	end
+
+	length 55
+	piece as sp 13*ps ae
+	end
+
+	length 56
+	piece as 2*sp 13*ps ae
+	end
+
+	length 57
+	piece as 2*sp 13*ps sp ae
+	end
+
+	length 58
+	piece as 2*sp 13*ps 2*sp ae
+	end
+
+	length 59
+	piece as sp 14*ps ae
+	end
+
+	length 60
+	piece as 2*sp 14*ps ae
+	end
+
+	length 61
+	piece as 2*sp 14*ps sp ae
+	end
+
+	length 62
+	piece as 2*sp 14*ps 2*sp ae
+	end
+
+	length 63
+	piece as sp 15*ps ae
+	end
+
+	length 64
+	piece as 2*sp 15*ps ae
+	end
+
+	length 65
+	piece as 2*sp 15*ps sp ae
+	end
+
+	length 66
+	piece as 2*sp 15*ps 2*sp ae
+	end
+
+	length 67
+	piece as sp 16*ps ae
+	end
+
+	length 68
+	piece as 2*sp 16*ps ae
+	end
+
+	length 69
+	piece as 2*sp 16*ps sp ae
+	end
+
+	length 70
+	piece as 2*sp 16*ps 2*sp ae
+	end
+
+	length 71
+	piece as sp 17*ps ae
+	end
+
+	length 72
+	piece as 2*sp 17*ps ae
+	end
+
+	length 73
+	piece as 2*sp 17*ps sp ae
+	end
+
+	length 74
+	piece as 2*sp 17*ps 2*sp ae
+	end
+
+	length 75
+	piece as sp 18*ps ae
+	end
+
+	length 76
+	piece as 2*sp 18*ps ae
+	end
+
+	length 77
+	piece as 2*sp 18*ps sp ae
+	end
+
+	length 78
+	piece as 2*sp 18*ps 2*sp ae
+	end
+
+	length 79
+	piece as sp 19*ps ae
+	end
+
+	length 80
+	piece as 2*sp 19*ps ae
+	end
+
+	length 81
+	piece as 2*sp 19*ps sp ae
+	end
+
+	length 82
+	piece as 2*sp 19*ps 2*sp ae
+	end
+
+	length 83
+	piece as sp 20*ps ae
+	end
+
+	length 84
+	piece as 2*sp 20*ps ae
+	end
+
+	length 85
+	piece as 2*sp 20*ps sp ae
+	end
+
+	length 86
+	piece as 2*sp 20*ps 2*sp ae
+	end
+
+	length 87
+	piece as sp 21*ps ae
+	end
+
+	length 88
+	piece as 2*sp 21*ps ae
+	end
+
+	length 89
+	piece as 2*sp 21*ps sp ae
+	end
+
+	length 90
+	piece as 2*sp 21*ps 2*sp ae
+	end
+
+	length 91
+	piece as sp 22*ps ae
+	end
+
+	length 92
+	piece as 2*sp 22*ps ae
+	end
+
+	length 93
+	piece as 2*sp 22*ps sp ae
+	end
+
+	length 94
+	piece as 2*sp 22*ps 2*sp ae
+	end
+
+	length 95
+	piece as sp 23*ps ae
+	end
+
+	length 96
+	piece as 2*sp 23*ps ae
+	end
+
+	length 97
+	piece as 2*sp 23*ps sp ae
+	end
+
+	length 98
+	piece as 2*sp 23*ps 2*sp ae
+	end
+
+	length 99
+	piece as sp 24*ps ae
+	end
+
+	length 100
+	piece as 2*sp 24*ps ae
+	end
+
+	length 101
+	piece as 2*sp 24*ps sp ae
+	end
+
+	length 102
+	piece as 2*sp 24*ps 2*sp ae
+	end
+
+	length 103
+	piece as sp 25*ps ae
+	end
+
+	length 104
+	piece as 2*sp 25*ps ae
+	end
+
+	length 105
+	piece as 2*sp 25*ps sp ae
+	end
+
+	length 106
+	piece as 2*sp 25*ps 2*sp ae
+	end
+
+	length 107
+	piece as sp 26*ps ae
+	end
+
+	length 108
+	piece as 2*sp 26*ps ae
+	end
+
+	length 109
+	piece as 2*sp 26*ps sp ae
+	end
+
+	length 110
+	piece as 2*sp 26*ps 2*sp ae
+	end
+
+	length 111
+	piece as sp 27*ps ae
+	end
+
+	length 112
+	piece as 2*sp 27*ps ae
+	end
+
+	length 113
+	piece as 2*sp 27*ps sp ae
+	end
+
+	length 114
+	piece as 2*sp 27*ps 2*sp ae
+	end
+
+	length 115
+	piece as sp 28*ps ae
+	end
+
+	length 116
+	piece as 2*sp 28*ps ae
+	end
+
+	length 117
+	piece as 2*sp 28*ps sp ae
+	end
+
+	length 118
+	piece as 2*sp 28*ps 2*sp ae
+	end
+
+	length 119
+	piece as sp 29*ps ae
+	end
+
+	length 120
+	piece as 2*sp 29*ps ae
+	end
+
+	length 121
+	piece as 2*sp 29*ps sp ae
+	end
+
+	length 122
+	piece as 2*sp 29*ps 2*sp ae
+	end
+
+	length 123
+	piece as sp 30*ps ae
+	end
+
+	length 124
+	piece as 2*sp 30*ps ae
+	end
+
+	length 125
+	piece as 2*sp 30*ps sp ae
+	end
+
+	length 126
+	piece as 2*sp 30*ps 2*sp ae
+	end
+
+	length 127
+	piece as sp 31*ps ae
+	end
+
+	length 128
+	piece as 2*sp 31*ps ae
+	end
+
+	length 129
+	piece as 2*sp 31*ps sp ae
+	end
+
+	length 130
+	piece as 2*sp 31*ps 2*sp ae
+	end
+
+	length 131
+	piece as sp 32*ps ae
+	end
+
+	length 132
+	piece as 2*sp 32*ps ae
+	end
+
+	length 133
+	piece as 2*sp 32*ps sp ae
+	end
+
+	length 134
+	piece as 2*sp 32*ps 2*sp ae
+	end
+
+	length 135
+	piece as sp 33*ps ae
+	end
+
+	length 136
+	piece as 2*sp 33*ps ae
+	end
+
+	length 137
+	piece as 2*sp 33*ps sp ae
+	end
+
+	length 138
+	piece as 2*sp 33*ps 2*sp ae
+	end
+
+	length 139
+	piece as sp 34*ps ae
+	end
+
+	length 140
+	piece as 2*sp 34*ps ae
+	end
+
+	length 141
+	piece as 2*sp 34*ps sp ae
+	end
+
+	length 142
+	piece as 2*sp 34*ps 2*sp ae
+	end
+
+	length 143
+	piece as sp 35*ps ae
+	end
+
+	length 144
+	piece as 2*sp 35*ps ae
+	end
+
+	length 145
+	piece as 2*sp 35*ps sp ae
+	end
+
+	length 146
+	piece as 2*sp 35*ps 2*sp ae
+	end
+
+	length 147
+	piece as sp 36*ps ae
+	end
+
+	length 148
+	piece as 2*sp 36*ps ae
+	end
+
+	length 149
+	piece as 2*sp 36*ps sp ae
+	end
+
+	length 150
+	piece as 2*sp 36*ps 2*sp ae
+	end
+
+	length 151
+	piece as sp 37*ps ae
+	end
+
+	length 152
+	piece as 2*sp 37*ps ae
+	end
+
+	length 153
+	piece as 2*sp 37*ps sp ae
+	end
+
+	length 154
+	piece as 2*sp 37*ps 2*sp ae
+	end
+
+	length 155
+	piece as sp 38*ps ae
+	end
+
+	length 156
+	piece as 2*sp 38*ps ae
+	end
+
+	length 157
+	piece as 2*sp 38*ps sp ae
+	end
+
+	length 158
+	piece as 2*sp 38*ps 2*sp ae
+	end
+
+	length 159
+	piece as sp 39*ps ae
+	end
+
+	length 160
+	piece as 2*sp 39*ps ae
+	end
+
+	length 161
+	piece as 2*sp 39*ps sp ae
+	end
+
+	length 162
+	piece as 2*sp 39*ps 2*sp ae
+	end
+
+	length 163
+	piece as sp 40*ps ae
+	end
+
+	length 164
+	piece as 2*sp 40*ps ae
+	end
+
+	length 165
+	piece as 2*sp 40*ps sp ae
+	end
+
+	length 166
+	piece as 2*sp 40*ps 2*sp ae
+	end
+
+	length 167
+	piece as sp 41*ps ae
+	end
+
+	length 168
+	piece as 2*sp 41*ps ae
+	end
+
+	length 169
+	piece as 2*sp 41*ps sp ae
+	end
+
+	length 170
+	piece as 2*sp 41*ps 2*sp ae
+	end
+
+	length 171
+	piece as sp 42*ps ae
+	end
+
+	length 172
+	piece as 2*sp 42*ps ae
+	end
+
+	length 173
+	piece as 2*sp 42*ps sp ae
+	end
+
+	length 174
+	piece as 2*sp 42*ps 2*sp ae
+	end
+
+	length 175
+	piece as sp 43*ps ae
+	end
+
+	length 176
+	piece as 2*sp 43*ps ae
+	end
+
+	length 177
+	piece as 2*sp 43*ps sp ae
+	end
+
+	length 178
+	piece as 2*sp 43*ps 2*sp ae
+	end
+
+	length 179
+	piece as sp 44*ps ae
+	end
+
+	length 180
+
+	piece as 2*sp 44*ps ae
+	end
+
+	length 181
+	piece as 2*sp 44*ps sp ae
+	end
+
+	length 182
+	piece as 2*sp 44*ps 2*sp ae
+	end
+
+	length 183
+	piece as sp 45*ps ae
+	end
+
+	length 184
+	piece as 2*sp 45*ps ae
+	end
+
+	length 185
+	piece as 2*sp 45*ps sp ae
+	end
+
+	length 186
+	piece as 2*sp 45*ps 2*sp ae
+	end
+
+	length 187
+	piece as sp 46*ps ae
+	end
+
+	length 188
+	piece as 2*sp 46*ps ae
+	end
+
+	length 189
+	piece as 2*sp 46*ps sp ae
+	end
+
+	length 190
+	piece as 2*sp 46*ps 2*sp ae
+	end
+
+	length 191
+	piece as sp 47*ps ae
+	end
+
+	length 192
+	piece as 2*sp 47*ps ae
+	end
+
+	length 193
+	piece as 2*sp 47*ps sp ae
+	end
+
+	length 194
+	piece as 2*sp 47*ps 2*sp ae
+	end
+
+	length 195
+	piece as sp 48*ps ae
+	end
+
+	length 196
+	piece as 2*sp 48*ps ae
+	end
+
+	length 197
+	piece as 2*sp 48*ps sp ae
+	end
+
+	length 198
+	piece as 2*sp 48*ps 2*sp ae
+	end
+
+	length 199
+	piece as sp 49*ps ae
+	end
+
+	length 200
+	piece as 2*sp 49*ps ae
+	end
+
+	length 201
+	piece as 2*sp 49*ps sp ae
+	end
+
+	length 202
+	piece as 2*sp 49*ps 2*sp ae
+	end
+
+	length 203
+	piece as sp 50*ps ae
+	end
+
+	length 204
+	piece as 2*sp 50*ps ae
+	end
+
+	length 205
+	piece as 2*sp 50*ps sp ae
+	end
+
+	length 206
+	piece as 2*sp 50*ps 2*sp ae
+	end
+
+	length 207
+	piece as sp 51*ps ae
+	end
+
+	length 208
+	piece as 2*sp 51*ps ae
+	end
+
+	length 209
+	piece as 2*sp 51*ps sp ae
+	end
+
+	length 210
+	piece as 2*sp 51*ps 2*sp ae
+	end
+
+	length 211
+	piece as sp 52*ps ae
+	end
+
+	length 212
+	piece as 2*sp 52*ps ae
+	end
+
+	length 213
+	piece as 2*sp 52*ps sp ae
+	end
+
+	length 214
+	piece as 2*sp 52*ps 2*sp ae
+	end
+
+	length 215
+	piece as sp 53*ps ae
+	end
+
+	length 216
+	piece as 2*sp 53*ps ae
+	end
+
+	length 217
+	piece as 2*sp 53*ps sp ae
+	end
+
+	length 218
+	piece as 2*sp 53*ps 2*sp ae
+	end
+
+	length 219
+	piece as sp 54*ps ae
+	end
+
+	length 220
+	piece as 2*sp 54*ps ae
+	end
+
+	length 221
+	piece as 2*sp 54*ps sp ae
+	end
+
+	length 222
+	piece as 2*sp 54*ps 2*sp ae
+	end
+
+	length 223
+	piece as sp 55*ps ae
+	end
+
+	length 224
+	piece as 2*sp 55*ps ae
+	end
+
+	length 225
+	piece as 2*sp 55*ps sp ae
+	end
+
+	length 226
+	piece as 2*sp 55*ps 2*sp ae
+	end
+
+	length 227
+	piece as sp 56*ps ae
+	end
+
+	length 228
+	piece as 2*sp 56*ps ae
+	end
+
+	length 229
+	piece as 2*sp 56*ps sp ae
+	end
+
+	length 230
+	piece as 2*sp 56*ps 2*sp ae
+	end
+
+	length 231
+	piece as sp 57*ps ae
+	end
+
+	length 232
+	piece as 2*sp 57*ps ae
+	end
+
+	length 233
+	piece as 2*sp 57*ps sp ae
+	end
+
+	length 234
+	piece as 2*sp 57*ps 2*sp ae
+	end
+
+	length 235
+	piece as sp 58*ps ae
+	end
+
+	length 236
+	piece as 2*sp 58*ps ae
+	end
+
+	length 237
+	piece as 2*sp 58*ps sp ae
+	end
+
+	length 238
+	piece as 2*sp 58*ps 2*sp ae
+	end
+
+	length 239
+	piece as sp 59*ps ae
+	end
+
+	length 240
+	piece as 2*sp 59*ps ae
+	end
+
+	length 241
+	piece as 2*sp 59*ps sp ae
+	end
+
+	length 242
+	piece as 2*sp 59*ps 2*sp ae
+	end
+
+	length 243
+	piece as sp 60*ps ae
+	end
+
+	length 244
+	piece as 2*sp 60*ps ae
+	end
+
+	length 245
+	piece as 2*sp 60*ps sp ae
+	end
+
+	length 246
+	piece as 2*sp 60*ps 2*sp ae
+	end
+
+	length 247
+	piece as sp 61*ps ae
+	end
+
+	length 248
+	piece as 2*sp 61*ps ae
+	end
+
+	length 249
+	piece as 2*sp 61*ps sp ae
+	end
+
+	length 250
+	piece as 2*sp 61*ps 2*sp ae
+	end
+
+	length 251
+	piece as sp 62*ps ae
+	end
+
+	length 252
+	piece as 2*sp 62*ps ae
+	end
+
+	length 253
+	piece as 2*sp 62*ps sp ae
+	end
+
+	length 254
+	piece as 2*sp 62*ps 2*sp ae
+	end
+end
+
+
+# Yellow Steel Girder (SAM-11) by IDS2 (09/23)
+
+bridge 37
+
+# abutment start - 1 tile
+section as
+	piece <0x40404000, 0>
+end 
+
+# pillar section - 3 tiles
+section pi
+	piece <0x40405000, 0>
+	piece <0x40406000, 0>
+	piece <0x40405000, 0>
+end 
+
+# span only - 1 tile
+section sp
+	piece <0x40407000, 0>
+end 
+
+# combined repeat segment - 4 tiles
+section ps
+	piece pi sp
+end
+
+#abutment end - 1 tile
+section ae
+	piece <0x40404000, 2>
+end
+
+	length 5
+	piece as 3*sp ae
+	end
+	
+	length 6
+	piece as 4*sp ae
+	end
+	
+	length 7
+	piece as sp ps ae
+	end
+	
+	length 8
+	piece as sp ps sp ae
+	end
+	
+	length 9
+	piece as 2*sp ps sp ae
+	end
+	
+	length 10
+	piece as 2*sp ps 2*sp ae
+	end
+	
+	length 11
+	piece as sp 2*ps ae
+	end
+	
+	length 12
+	piece as 2*sp 2*ps ae
+	end
+	
+	length 13
+	piece as 2*sp 2*ps sp ae
+	end
+	
+	length 14
+	piece as 2*sp ps sp ps sp ae
+	end
+	
+	length 15
+	piece as sp 3*ps ae
+	end
+	
+	length 16
+	piece as 2*sp 3*ps ae
+	end
+	
+	length 17
+	piece as 2*sp 3*ps sp ae
+	end
+	
+	length 18
+	piece as 2*sp 3*ps 2*sp ae
+	end
+	
+	length 19
+	piece as sp 4*ps ae
+	end
+	
+	length 20
+	piece as 2*sp 4*ps ae
+	end
+	
+	length 21
+	piece as 2*sp 4*ps sp ae
+	end
+	
+	length 22
+	piece as 2*sp 4*ps 2*sp ae
+	end
+	
+	length 23
+	piece as sp 5*ps ae
+	end
+
+	length 24
+	piece as 2*sp 5*ps ae
+	end
+
+	length 25
+	piece as 2*sp 5*ps sp ae
+	end
+
+	length 26
+	piece as 2*sp 5*ps 2*sp ae
+	end
+
+	length 27
+	piece as sp 6*ps ae
+	end
+
+	length 28
+	piece as 2*sp 6*ps ae
+	end
+
+	length 29
+	piece as 2*sp 6*ps sp ae
+	end
+
+	length 30
+	piece as 2*sp 6*ps 2*sp ae
+	end
+
+	length 31
+	piece as sp 7*ps ae
+	end
+
+	length 32
+	piece as 2*sp 7*ps ae
+	end
+
+	length 33
+	piece as 2*sp 7*ps sp ae
+	end
+
+	length 34
+	piece as 2*sp 7*ps 2*sp ae
+	end
+
+	length 35
+	piece as sp 8*ps ae
+	end
+
+	length 36
+	piece as 2*sp 8*ps ae
+	end
+
+	length 37
+	piece as 2*sp 8*ps sp ae
+	end
+
+	length 38
+	piece as 2*sp 8*ps 2*sp ae
+	end
+
+	length 39
+	piece as sp 9*ps ae
+	end
+
+	length 40
+	piece as 2*sp 9*ps ae
+	end
+
+	length 41
+	piece as 2*sp 9*ps sp ae
+	end
+
+	length 42
+	piece as 2*sp 9*ps 2*sp ae
+	end
+
+	length 43
+	piece as sp 10*ps ae
+	end
+
+	length 44
+	piece as 2*sp 10*ps ae
+	end
+
+	length 45
+	piece as 2*sp 10*ps sp ae
+	end
+
+	length 46
+	piece as 2*sp 10*ps 2*sp ae
+	end
+
+	length 47
+	piece as sp 11*ps ae
+	end
+
+	length 48
+	piece as 2*sp 11*ps ae
+	end
+
+	length 49
+	piece as 2*sp 11*ps sp ae
+	end
+
+	length 50
+	piece as 2*sp 11*ps 2*sp ae
+	end
+
+	length 51
+	piece as sp 12*ps ae
+	end
+
+	length 52
+	piece as 2*sp 12*ps ae
+	end
+
+	length 53
+	piece as 2*sp 12*ps sp ae
+	end
+
+	length 54
+	piece as 2*sp 12*ps 2*sp ae
+	end
+
+	length 55
+	piece as sp 13*ps ae
+	end
+
+	length 56
+	piece as 2*sp 13*ps ae
+	end
+
+	length 57
+	piece as 2*sp 13*ps sp ae
+	end
+
+	length 58
+	piece as 2*sp 13*ps 2*sp ae
+	end
+
+	length 59
+	piece as sp 14*ps ae
+	end
+
+	length 60
+	piece as 2*sp 14*ps ae
+	end
+
+	length 61
+	piece as 2*sp 14*ps sp ae
+	end
+
+	length 62
+	piece as 2*sp 14*ps 2*sp ae
+	end
+
+	length 63
+	piece as sp 15*ps ae
+	end
+
+	length 64
+	piece as 2*sp 15*ps ae
+	end
+
+	length 65
+	piece as 2*sp 15*ps sp ae
+	end
+
+	length 66
+	piece as 2*sp 15*ps 2*sp ae
+	end
+
+	length 67
+	piece as sp 16*ps ae
+	end
+
+	length 68
+	piece as 2*sp 16*ps ae
+	end
+
+	length 69
+	piece as 2*sp 16*ps sp ae
+	end
+
+	length 70
+	piece as 2*sp 16*ps 2*sp ae
+	end
+
+	length 71
+	piece as sp 17*ps ae
+	end
+
+	length 72
+	piece as 2*sp 17*ps ae
+	end
+
+	length 73
+	piece as 2*sp 17*ps sp ae
+	end
+
+	length 74
+	piece as 2*sp 17*ps 2*sp ae
+	end
+
+	length 75
+	piece as sp 18*ps ae
+	end
+
+	length 76
+	piece as 2*sp 18*ps ae
+	end
+
+	length 77
+	piece as 2*sp 18*ps sp ae
+	end
+
+	length 78
+	piece as 2*sp 18*ps 2*sp ae
+	end
+
+	length 79
+	piece as sp 19*ps ae
+	end
+
+	length 80
+	piece as 2*sp 19*ps ae
+	end
+
+	length 81
+	piece as 2*sp 19*ps sp ae
+	end
+
+	length 82
+	piece as 2*sp 19*ps 2*sp ae
+	end
+
+	length 83
+	piece as sp 20*ps ae
+	end
+
+	length 84
+	piece as 2*sp 20*ps ae
+	end
+
+	length 85
+	piece as 2*sp 20*ps sp ae
+	end
+
+	length 86
+	piece as 2*sp 20*ps 2*sp ae
+	end
+
+	length 87
+	piece as sp 21*ps ae
+	end
+
+	length 88
+	piece as 2*sp 21*ps ae
+	end
+
+	length 89
+	piece as 2*sp 21*ps sp ae
+	end
+
+	length 90
+	piece as 2*sp 21*ps 2*sp ae
+	end
+
+	length 91
+	piece as sp 22*ps ae
+	end
+
+	length 92
+	piece as 2*sp 22*ps ae
+	end
+
+	length 93
+	piece as 2*sp 22*ps sp ae
+	end
+
+	length 94
+	piece as 2*sp 22*ps 2*sp ae
+	end
+
+	length 95
+	piece as sp 23*ps ae
+	end
+
+	length 96
+	piece as 2*sp 23*ps ae
+	end
+
+	length 97
+	piece as 2*sp 23*ps sp ae
+	end
+
+	length 98
+	piece as 2*sp 23*ps 2*sp ae
+	end
+
+	length 99
+	piece as sp 24*ps ae
+	end
+
+	length 100
+	piece as 2*sp 24*ps ae
+	end
+
+	length 101
+	piece as 2*sp 24*ps sp ae
+	end
+
+	length 102
+	piece as 2*sp 24*ps 2*sp ae
+	end
+
+	length 103
+	piece as sp 25*ps ae
+	end
+
+	length 104
+	piece as 2*sp 25*ps ae
+	end
+
+	length 105
+	piece as 2*sp 25*ps sp ae
+	end
+
+	length 106
+	piece as 2*sp 25*ps 2*sp ae
+	end
+
+	length 107
+	piece as sp 26*ps ae
+	end
+
+	length 108
+	piece as 2*sp 26*ps ae
+	end
+
+	length 109
+	piece as 2*sp 26*ps sp ae
+	end
+
+	length 110
+	piece as 2*sp 26*ps 2*sp ae
+	end
+
+	length 111
+	piece as sp 27*ps ae
+	end
+
+	length 112
+	piece as 2*sp 27*ps ae
+	end
+
+	length 113
+	piece as 2*sp 27*ps sp ae
+	end
+
+	length 114
+	piece as 2*sp 27*ps 2*sp ae
+	end
+
+	length 115
+	piece as sp 28*ps ae
+	end
+
+	length 116
+	piece as 2*sp 28*ps ae
+	end
+
+	length 117
+	piece as 2*sp 28*ps sp ae
+	end
+
+	length 118
+	piece as 2*sp 28*ps 2*sp ae
+	end
+
+	length 119
+	piece as sp 29*ps ae
+	end
+
+	length 120
+	piece as 2*sp 29*ps ae
+	end
+
+	length 121
+	piece as 2*sp 29*ps sp ae
+	end
+
+	length 122
+	piece as 2*sp 29*ps 2*sp ae
+	end
+
+	length 123
+	piece as sp 30*ps ae
+	end
+
+	length 124
+	piece as 2*sp 30*ps ae
+	end
+
+	length 125
+	piece as 2*sp 30*ps sp ae
+	end
+
+	length 126
+	piece as 2*sp 30*ps 2*sp ae
+	end
+
+	length 127
+	piece as sp 31*ps ae
+	end
+
+	length 128
+	piece as 2*sp 31*ps ae
+	end
+
+	length 129
+	piece as 2*sp 31*ps sp ae
+	end
+
+	length 130
+	piece as 2*sp 31*ps 2*sp ae
+	end
+
+	length 131
+	piece as sp 32*ps ae
+	end
+
+	length 132
+	piece as 2*sp 32*ps ae
+	end
+
+	length 133
+	piece as 2*sp 32*ps sp ae
+	end
+
+	length 134
+	piece as 2*sp 32*ps 2*sp ae
+	end
+
+	length 135
+	piece as sp 33*ps ae
+	end
+
+	length 136
+	piece as 2*sp 33*ps ae
+	end
+
+	length 137
+	piece as 2*sp 33*ps sp ae
+	end
+
+	length 138
+	piece as 2*sp 33*ps 2*sp ae
+	end
+
+	length 139
+	piece as sp 34*ps ae
+	end
+
+	length 140
+	piece as 2*sp 34*ps ae
+	end
+
+	length 141
+	piece as 2*sp 34*ps sp ae
+	end
+
+	length 142
+	piece as 2*sp 34*ps 2*sp ae
+	end
+
+	length 143
+	piece as sp 35*ps ae
+	end
+
+	length 144
+	piece as 2*sp 35*ps ae
+	end
+
+	length 145
+	piece as 2*sp 35*ps sp ae
+	end
+
+	length 146
+	piece as 2*sp 35*ps 2*sp ae
+	end
+
+	length 147
+	piece as sp 36*ps ae
+	end
+
+	length 148
+	piece as 2*sp 36*ps ae
+	end
+
+	length 149
+	piece as 2*sp 36*ps sp ae
+	end
+
+	length 150
+	piece as 2*sp 36*ps 2*sp ae
+	end
+
+	length 151
+	piece as sp 37*ps ae
+	end
+
+	length 152
+	piece as 2*sp 37*ps ae
+	end
+
+	length 153
+	piece as 2*sp 37*ps sp ae
+	end
+
+	length 154
+	piece as 2*sp 37*ps 2*sp ae
+	end
+
+	length 155
+	piece as sp 38*ps ae
+	end
+
+	length 156
+	piece as 2*sp 38*ps ae
+	end
+
+	length 157
+	piece as 2*sp 38*ps sp ae
+	end
+
+	length 158
+	piece as 2*sp 38*ps 2*sp ae
+	end
+
+	length 159
+	piece as sp 39*ps ae
+	end
+
+	length 160
+	piece as 2*sp 39*ps ae
+	end
+
+	length 161
+	piece as 2*sp 39*ps sp ae
+	end
+
+	length 162
+	piece as 2*sp 39*ps 2*sp ae
+	end
+
+	length 163
+	piece as sp 40*ps ae
+	end
+
+	length 164
+	piece as 2*sp 40*ps ae
+	end
+
+	length 165
+	piece as 2*sp 40*ps sp ae
+	end
+
+	length 166
+	piece as 2*sp 40*ps 2*sp ae
+	end
+
+	length 167
+	piece as sp 41*ps ae
+	end
+
+	length 168
+	piece as 2*sp 41*ps ae
+	end
+
+	length 169
+	piece as 2*sp 41*ps sp ae
+	end
+
+	length 170
+	piece as 2*sp 41*ps 2*sp ae
+	end
+
+	length 171
+	piece as sp 42*ps ae
+	end
+
+	length 172
+	piece as 2*sp 42*ps ae
+	end
+
+	length 173
+	piece as 2*sp 42*ps sp ae
+	end
+
+	length 174
+	piece as 2*sp 42*ps 2*sp ae
+	end
+
+	length 175
+	piece as sp 43*ps ae
+	end
+
+	length 176
+	piece as 2*sp 43*ps ae
+	end
+
+	length 177
+	piece as 2*sp 43*ps sp ae
+	end
+
+	length 178
+	piece as 2*sp 43*ps 2*sp ae
+	end
+
+	length 179
+	piece as sp 44*ps ae
+	end
+
+	length 180
+
+	piece as 2*sp 44*ps ae
+	end
+
+	length 181
+	piece as 2*sp 44*ps sp ae
+	end
+
+	length 182
+	piece as 2*sp 44*ps 2*sp ae
+	end
+
+	length 183
+	piece as sp 45*ps ae
+	end
+
+	length 184
+	piece as 2*sp 45*ps ae
+	end
+
+	length 185
+	piece as 2*sp 45*ps sp ae
+	end
+
+	length 186
+	piece as 2*sp 45*ps 2*sp ae
+	end
+
+	length 187
+	piece as sp 46*ps ae
+	end
+
+	length 188
+	piece as 2*sp 46*ps ae
+	end
+
+	length 189
+	piece as 2*sp 46*ps sp ae
+	end
+
+	length 190
+	piece as 2*sp 46*ps 2*sp ae
+	end
+
+	length 191
+	piece as sp 47*ps ae
+	end
+
+	length 192
+	piece as 2*sp 47*ps ae
+	end
+
+	length 193
+	piece as 2*sp 47*ps sp ae
+	end
+
+	length 194
+	piece as 2*sp 47*ps 2*sp ae
+	end
+
+	length 195
+	piece as sp 48*ps ae
+	end
+
+	length 196
+	piece as 2*sp 48*ps ae
+	end
+
+	length 197
+	piece as 2*sp 48*ps sp ae
+	end
+
+	length 198
+	piece as 2*sp 48*ps 2*sp ae
+	end
+
+	length 199
+	piece as sp 49*ps ae
+	end
+
+	length 200
+	piece as 2*sp 49*ps ae
+	end
+
+	length 201
+	piece as 2*sp 49*ps sp ae
+	end
+
+	length 202
+	piece as 2*sp 49*ps 2*sp ae
+	end
+
+	length 203
+	piece as sp 50*ps ae
+	end
+
+	length 204
+	piece as 2*sp 50*ps ae
+	end
+
+	length 205
+	piece as 2*sp 50*ps sp ae
+	end
+
+	length 206
+	piece as 2*sp 50*ps 2*sp ae
+	end
+
+	length 207
+	piece as sp 51*ps ae
+	end
+
+	length 208
+	piece as 2*sp 51*ps ae
+	end
+
+	length 209
+	piece as 2*sp 51*ps sp ae
+	end
+
+	length 210
+	piece as 2*sp 51*ps 2*sp ae
+	end
+
+	length 211
+	piece as sp 52*ps ae
+	end
+
+	length 212
+	piece as 2*sp 52*ps ae
+	end
+
+	length 213
+	piece as 2*sp 52*ps sp ae
+	end
+
+	length 214
+	piece as 2*sp 52*ps 2*sp ae
+	end
+
+	length 215
+	piece as sp 53*ps ae
+	end
+
+	length 216
+	piece as 2*sp 53*ps ae
+	end
+
+	length 217
+	piece as 2*sp 53*ps sp ae
+	end
+
+	length 218
+	piece as 2*sp 53*ps 2*sp ae
+	end
+
+	length 219
+	piece as sp 54*ps ae
+	end
+
+	length 220
+	piece as 2*sp 54*ps ae
+	end
+
+	length 221
+	piece as 2*sp 54*ps sp ae
+	end
+
+	length 222
+	piece as 2*sp 54*ps 2*sp ae
+	end
+
+	length 223
+	piece as sp 55*ps ae
+	end
+
+	length 224
+	piece as 2*sp 55*ps ae
+	end
+
+	length 225
+	piece as 2*sp 55*ps sp ae
+	end
+
+	length 226
+	piece as 2*sp 55*ps 2*sp ae
+	end
+
+	length 227
+	piece as sp 56*ps ae
+	end
+
+	length 228
+	piece as 2*sp 56*ps ae
+	end
+
+	length 229
+	piece as 2*sp 56*ps sp ae
+	end
+
+	length 230
+	piece as 2*sp 56*ps 2*sp ae
+	end
+
+	length 231
+	piece as sp 57*ps ae
+	end
+
+	length 232
+	piece as 2*sp 57*ps ae
+	end
+
+	length 233
+	piece as 2*sp 57*ps sp ae
+	end
+
+	length 234
+	piece as 2*sp 57*ps 2*sp ae
+	end
+
+	length 235
+	piece as sp 58*ps ae
+	end
+
+	length 236
+	piece as 2*sp 58*ps ae
+	end
+
+	length 237
+	piece as 2*sp 58*ps sp ae
+	end
+
+	length 238
+	piece as 2*sp 58*ps 2*sp ae
+	end
+
+	length 239
+	piece as sp 59*ps ae
+	end
+
+	length 240
+	piece as 2*sp 59*ps ae
+	end
+
+	length 241
+	piece as 2*sp 59*ps sp ae
+	end
+
+	length 242
+	piece as 2*sp 59*ps 2*sp ae
+	end
+
+	length 243
+	piece as sp 60*ps ae
+	end
+
+	length 244
+	piece as 2*sp 60*ps ae
+	end
+
+	length 245
+	piece as 2*sp 60*ps sp ae
+	end
+
+	length 246
+	piece as 2*sp 60*ps 2*sp ae
+	end
+
+	length 247
+	piece as sp 61*ps ae
+	end
+
+	length 248
+	piece as 2*sp 61*ps ae
+	end
+
+	length 249
+	piece as 2*sp 61*ps sp ae
+	end
+
+	length 250
+	piece as 2*sp 61*ps 2*sp ae
+	end
+
+	length 251
+	piece as sp 62*ps ae
+	end
+
+	length 252
+	piece as 2*sp 62*ps ae
+	end
+
+	length 253
+	piece as 2*sp 62*ps sp ae
+	end
+
+	length 254
+	piece as 2*sp 62*ps 2*sp ae
+	end
+end
+
+
 # Red Under Deck Truss Arch (street) by IDS2 (10/23)
 
 bridge 38
@@ -15854,4 +24126,7548 @@ end
 	length 254
 	piece sp pi sp ep 18*mp rev(ep) rev(sp) rev(pi) rev(sp)
 	end
+end
+
+
+# Blue Suspension (street) by IDS2 (03/2024)
+
+bridge 54
+
+# abutment - 1 tile
+section ab
+	piece <0x405C7000, 0>
+end
+
+# girder - 1 tile
+section gi
+	piece <0x405D7000, 0>
+end
+
+# pillar - 1 tile
+section pi
+	piece <0x405E7000, 0>
+end
+
+# girder pillar - 4 tiles
+section gp
+	piece <0x405E7000, 0>
+	piece <0x405D7000, 0>
+	piece <0x405D7000, 0>
+	piece <0x405D7000, 0>
+end
+
+# middle tower - 25 tiles
+section mt
+	piece <0x405F5000, 0>
+	piece <0x405F5000, 0>
+	piece <0x405F5000, 0>
+	piece <0x405F5000, 0>
+	piece <0x405F5000, 0>
+	piece <0x405F5000, 0>
+	piece <0x405F5000, 0>
+	piece <0x405F5000, 0>
+	piece <0x405F5000, 0>
+	piece <0x405F5000, 0>
+	piece <0x405F7000, 0>
+	piece <0x405F7000, 0>
+	piece <0x405F6000, 0>
+	piece <0x405F7000, 0>
+	piece <0x405F7000, 0>
+	piece <0x405F5000, 0>
+	piece <0x405F5000, 0>
+	piece <0x405F5000, 0>
+	piece <0x405F5000, 0>
+	piece <0x405F5000, 0>
+	piece <0x405F5000, 0>
+	piece <0x405F5000, 0>
+	piece <0x405F5000, 0>
+	piece <0x405F5000, 0>
+	piece <0x405F5000, 0>
+end
+
+# end tower - 19 tiles
+section et
+	piece <0x405F3000, 0>
+	piece <0x405D7000, 0>
+	piece <0x405E7000, 0>
+	piece <0x405D7000, 0>
+	piece <0x405F7000, 0>
+	piece <0x405F7000, 0>
+	piece <0x405F4000, 0>
+	piece <0x405F7000, 0>
+	piece <0x405F7000, 0>
+	piece <0x405F5000, 0>
+	piece <0x405F5000, 0>
+	piece <0x405F5000, 0>
+	piece <0x405F5000, 0>
+	piece <0x405F5000, 0>
+	piece <0x405F5000, 0>
+	piece <0x405F5000, 0>
+	piece <0x405F5000, 0>
+	piece <0x405F5000, 0>
+	piece <0x405F5000, 0>
+end 
+
+	length 40
+	piece ab et rev(et) rev(ab)
+	end
+
+	length 41
+	piece ab gi et rev(et) rev(ab)
+	end
+	
+	length 42
+	piece ab gi et rev(et) rev(gi) rev(ab)
+	end
+	
+	length 43
+	piece ab pi gi et rev(et) rev(gi) rev(ab)
+	end
+	
+	length 44
+	piece ab pi gi et rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 45
+	piece ab gi pi gi et rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 46
+	piece ab gi pi gi et rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 47
+	piece ab 2*gi pi gi et rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 48
+	piece ab 2*gi pi gi et rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 49
+	piece ab 3*gi pi gi et rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 50
+	piece ab 3*gi pi gi et rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 51
+	piece ab gp pi gi et rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 52
+	piece ab gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 53
+	piece ab gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 54
+	piece ab gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 55
+	piece ab 2*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 56
+	piece ab 2*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 57
+	piece ab 3*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 58
+	piece ab 3*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 59
+	piece ab 2*gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 60
+	piece ab 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 61
+	piece ab gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 62
+	piece ab gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 63
+	piece ab 2*gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 64
+	piece ab 2*gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+
+	length 65
+	piece ab et mt rev(et) rev(ab)
+	end
+	
+	length 66
+	piece ab gi et mt rev(et) rev(ab)
+	end
+	
+	length 67
+	piece ab gi et mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 68
+	piece ab pi gi et mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 69
+	piece ab pi gi et mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 70
+	piece ab gi pi gi et mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 71
+	piece ab gi pi gi et mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 72
+	piece ab 2*gi pi gi et mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 73
+	piece ab 2*gi pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 74
+	piece ab 3*gi pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 75
+	piece ab 3*gi pi gi et mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 76
+	piece ab gp pi gi et mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 77
+	piece ab gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 78
+	piece ab gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 79
+	piece ab gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 80
+	piece ab 2*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 81
+	piece ab 2*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 82
+	piece ab 3*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 83
+	piece ab 3*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 84
+	piece ab 2*gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 85
+	piece ab 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 86
+	piece ab gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 87
+	piece ab gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 88
+	piece ab 2*gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 89
+	piece ab 2*gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 90
+	piece ab et 2*mt rev(et) rev(ab)
+	end
+	
+	length 91
+	piece ab gi et 2*mt rev(et) rev(ab)
+	end
+	
+	length 92
+	piece ab gi et 2*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 93
+	piece ab pi gi et 2*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 94
+	piece ab pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 95
+	piece ab gi pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 96
+	piece ab gi pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 97
+	piece ab 2*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 98
+	piece ab 2*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 99
+	piece ab 3*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 100
+	piece ab 3*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 101
+	piece ab gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 102
+	piece ab gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 103
+	piece ab gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 104
+	piece ab gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 105
+	piece ab 2*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 106
+	piece ab 2*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 107
+	piece ab 3*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 108
+	piece ab 3*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 109
+	piece ab 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 110
+	piece ab 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 111
+	piece ab gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 112
+	piece ab gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 113
+	piece ab 2*gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 114
+	piece ab 2*gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 115
+	piece ab et 3*mt rev(et) rev(ab)
+	end
+	
+	length 116
+	piece ab gi et 3*mt rev(et) rev(ab)
+	end
+	
+	length 117
+	piece ab gi et 3*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 118
+	piece ab pi gi et 3*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 119
+	piece ab pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 120
+	piece ab gi pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 121
+	piece ab gi pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 122
+	piece ab 2*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 123
+	piece ab 2*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 124
+	piece ab 3*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 125
+	piece ab 3*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 126
+	piece ab gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 127
+	piece ab gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 128
+	piece ab gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 129
+	piece ab gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 130
+	piece ab 2*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 131
+	piece ab 2*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 132
+	piece ab 3*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 133
+	piece ab 3*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 134
+	piece ab 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 135
+	piece ab 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 136
+	piece ab gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 137
+	piece ab gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 138
+	piece ab 2*gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 139
+	piece ab 2*gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 140
+	piece ab et 4*mt rev(et) rev(ab)
+	end
+	
+	length 141
+	piece ab gi et 4*mt rev(et) rev(ab)
+	end
+	
+	length 142
+	piece ab gi et 4*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 143
+	piece ab pi gi et 4*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 144
+	piece ab pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 145
+	piece ab gi pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 146
+	piece ab gi pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 147
+	piece ab 2*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 148
+	piece ab 2*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 149
+	piece ab 3*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 150
+	piece ab 3*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 151
+	piece ab gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 152
+	piece ab gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 153
+	piece ab gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 154
+	piece ab gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 155
+	piece ab 2*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 156
+	piece ab 2*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 157
+	piece ab 3*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 158
+	piece ab 3*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 159
+	piece ab 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 160
+
+	piece ab 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 161
+	piece ab gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 162
+	piece ab gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 163
+	piece ab 2*gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 164
+	piece ab 2*gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 165
+	piece ab et 5*mt rev(et) rev(ab)
+	end
+	
+	length 166
+	piece ab gi et 5*mt rev(et) rev(ab)
+	end
+	
+	length 167
+	piece ab gi et 5*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 168
+	piece ab pi gi et 5*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 169
+	piece ab pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 170
+	piece ab gi pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 171
+	piece ab gi pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 172
+	piece ab 2*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 173
+	piece ab 2*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 174
+	piece ab 3*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 175
+	piece ab 3*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 176
+	piece ab gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 177
+	piece ab gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 178
+	piece ab gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 179
+	piece ab gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 180
+	piece ab 2*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 181
+	piece ab 2*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 182
+	piece ab 3*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 183
+	piece ab 3*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 184
+	piece ab 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 185
+	piece ab 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 186
+	piece ab gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 187
+	piece ab gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 188
+	piece ab 2*gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 189
+	piece ab 2*gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 190
+	piece ab et 6*mt rev(et) rev(ab)
+	end
+	
+	length 191
+	piece ab gi et 6*mt rev(et) rev(ab)
+	end
+	
+	length 192
+	piece ab gi et 6*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 193
+	piece ab pi gi et 6*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 194
+	piece ab pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 195
+	piece ab gi pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 196
+	piece ab gi pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 197
+	piece ab 2*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 198
+	piece ab 2*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 199
+	piece ab 3*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 200
+	piece ab 3*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 201
+	piece ab gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 202
+	piece ab gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 203
+	piece ab gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 204
+	piece ab gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 205
+	piece ab 2*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 206
+	piece ab 2*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 207
+	piece ab 3*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 208
+	piece ab 3*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 209
+	piece ab 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 210
+	piece ab 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 211
+	piece ab gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 212
+	piece ab gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 213
+	piece ab 2*gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 214
+	piece ab 2*gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 215
+	piece ab et 7*mt rev(et) rev(ab)
+	end
+	
+	length 216
+	piece ab gi et 7*mt rev(et) rev(ab)
+	end
+	
+	length 217
+	piece ab gi et 7*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 218
+	piece ab pi gi et 7*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 219
+	piece ab pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 220
+	piece ab gi pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 221
+	piece ab gi pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 222
+	piece ab 2*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 223
+	piece ab 2*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 224
+	piece ab 3*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 225
+	piece ab 3*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 226
+	piece ab gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 227
+	piece ab gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 228
+	piece ab gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 229
+	piece ab gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 230
+	piece ab 2*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 231
+	piece ab 2*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 232
+	piece ab 3*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 233
+	piece ab 3*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 234
+	piece ab 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 235
+	piece ab 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 236
+	piece ab gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 237
+	piece ab gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 238
+	piece ab 2*gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 239
+	piece ab 2*gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 240
+	piece ab et 8*mt rev(et) rev(ab)
+	end
+
+	length 241
+	piece ab gi et 8*mt rev(et) rev(ab)
+	end
+	
+	length 242
+	piece ab gi et 8*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 243
+	piece ab pi gi et 8*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 244
+	piece ab pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 245
+	piece ab gi pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 246
+	piece ab gi pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 247
+	piece ab 2*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 248
+	piece ab 2*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 249
+	piece ab 3*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 250
+	piece ab 3*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 251
+	piece ab gp pi gi et 8*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 252
+	piece ab gp pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 253
+	piece ab gi gp pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 254
+	piece ab gi gp pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+end
+
+
+# Blue Suspension (SAM-2) by IDS2 (03/2024)
+
+bridge 55
+
+# abutment - 1 tile
+section ab
+	piece <0x40690000, 0>
+end
+
+# girder - 1 tile
+section gi
+	piece <0x40691000, 0>
+end
+
+# pillar - 1 tile
+section pi
+	piece <0x40692000, 0>
+end
+
+# girder pillar - 4 tiles
+section gp
+	piece <0x40692000, 0>
+	piece <0x40691000, 0>
+	piece <0x40691000, 0>
+	piece <0x40691000, 0>
+end
+
+# middle tower - 25 tiles
+section mt
+	piece <0x40695000, 0>
+	piece <0x40695000, 0>
+	piece <0x40695000, 0>
+	piece <0x40695000, 0>
+	piece <0x40695000, 0>
+	piece <0x40695000, 0>
+	piece <0x40695000, 0>
+	piece <0x40695000, 0>
+	piece <0x40695000, 0>
+	piece <0x40695000, 0>
+	piece <0x40697000, 0>
+	piece <0x40697000, 0>
+	piece <0x40696000, 0>
+	piece <0x40697000, 0>
+	piece <0x40697000, 0>
+	piece <0x40695000, 0>
+	piece <0x40695000, 0>
+	piece <0x40695000, 0>
+	piece <0x40695000, 0>
+	piece <0x40695000, 0>
+	piece <0x40695000, 0>
+	piece <0x40695000, 0>
+	piece <0x40695000, 0>
+	piece <0x40695000, 0>
+	piece <0x40695000, 0>
+end
+
+# end tower - 19 tiles
+section et
+	piece <0x40693000, 0>
+	piece <0x40691000, 0>
+	piece <0x40692000, 0>
+	piece <0x40691000, 0>
+	piece <0x40697000, 0>
+	piece <0x40697000, 0>
+	piece <0x40694000, 0>
+	piece <0x40697000, 0>
+	piece <0x40697000, 0>
+	piece <0x40695000, 0>
+	piece <0x40695000, 0>
+	piece <0x40695000, 0>
+	piece <0x40695000, 0>
+	piece <0x40695000, 0>
+	piece <0x40695000, 0>
+	piece <0x40695000, 0>
+	piece <0x40695000, 0>
+	piece <0x40695000, 0>
+	piece <0x40695000, 0>
+end 
+
+	length 40
+	piece ab et rev(et) rev(ab)
+	end
+
+	length 41
+	piece ab gi et rev(et) rev(ab)
+	end
+	
+	length 42
+	piece ab gi et rev(et) rev(gi) rev(ab)
+	end
+	
+	length 43
+	piece ab pi gi et rev(et) rev(gi) rev(ab)
+	end
+	
+	length 44
+	piece ab pi gi et rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 45
+	piece ab gi pi gi et rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 46
+	piece ab gi pi gi et rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 47
+	piece ab 2*gi pi gi et rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 48
+	piece ab 2*gi pi gi et rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 49
+	piece ab 3*gi pi gi et rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 50
+	piece ab 3*gi pi gi et rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 51
+	piece ab gp pi gi et rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 52
+	piece ab gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 53
+	piece ab gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 54
+	piece ab gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 55
+	piece ab 2*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 56
+	piece ab 2*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 57
+	piece ab 3*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 58
+	piece ab 3*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 59
+	piece ab 2*gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 60
+	piece ab 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 61
+	piece ab gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 62
+	piece ab gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 63
+	piece ab 2*gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 64
+	piece ab 2*gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+
+	length 65
+	piece ab et mt rev(et) rev(ab)
+	end
+	
+	length 66
+	piece ab gi et mt rev(et) rev(ab)
+	end
+	
+	length 67
+	piece ab gi et mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 68
+	piece ab pi gi et mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 69
+	piece ab pi gi et mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 70
+	piece ab gi pi gi et mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 71
+	piece ab gi pi gi et mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 72
+	piece ab 2*gi pi gi et mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 73
+	piece ab 2*gi pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 74
+	piece ab 3*gi pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 75
+	piece ab 3*gi pi gi et mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 76
+	piece ab gp pi gi et mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 77
+	piece ab gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 78
+	piece ab gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 79
+	piece ab gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 80
+	piece ab 2*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 81
+	piece ab 2*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 82
+	piece ab 3*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 83
+	piece ab 3*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 84
+	piece ab 2*gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 85
+	piece ab 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 86
+	piece ab gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 87
+	piece ab gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 88
+	piece ab 2*gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 89
+	piece ab 2*gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 90
+	piece ab et 2*mt rev(et) rev(ab)
+	end
+	
+	length 91
+	piece ab gi et 2*mt rev(et) rev(ab)
+	end
+	
+	length 92
+	piece ab gi et 2*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 93
+	piece ab pi gi et 2*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 94
+	piece ab pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 95
+	piece ab gi pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 96
+	piece ab gi pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 97
+	piece ab 2*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 98
+	piece ab 2*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 99
+	piece ab 3*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 100
+	piece ab 3*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 101
+	piece ab gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 102
+	piece ab gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 103
+	piece ab gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 104
+	piece ab gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 105
+	piece ab 2*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 106
+	piece ab 2*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 107
+	piece ab 3*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 108
+	piece ab 3*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 109
+	piece ab 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 110
+	piece ab 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 111
+	piece ab gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 112
+	piece ab gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 113
+	piece ab 2*gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 114
+	piece ab 2*gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 115
+	piece ab et 3*mt rev(et) rev(ab)
+	end
+	
+	length 116
+	piece ab gi et 3*mt rev(et) rev(ab)
+	end
+	
+	length 117
+	piece ab gi et 3*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 118
+	piece ab pi gi et 3*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 119
+	piece ab pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 120
+	piece ab gi pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 121
+	piece ab gi pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 122
+	piece ab 2*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 123
+	piece ab 2*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 124
+	piece ab 3*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 125
+	piece ab 3*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 126
+	piece ab gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 127
+	piece ab gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 128
+	piece ab gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 129
+	piece ab gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 130
+	piece ab 2*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 131
+	piece ab 2*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 132
+	piece ab 3*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 133
+	piece ab 3*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 134
+	piece ab 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 135
+	piece ab 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 136
+	piece ab gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 137
+	piece ab gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 138
+	piece ab 2*gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 139
+	piece ab 2*gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 140
+	piece ab et 4*mt rev(et) rev(ab)
+	end
+	
+	length 141
+	piece ab gi et 4*mt rev(et) rev(ab)
+	end
+	
+	length 142
+	piece ab gi et 4*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 143
+	piece ab pi gi et 4*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 144
+	piece ab pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 145
+	piece ab gi pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 146
+	piece ab gi pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 147
+	piece ab 2*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 148
+	piece ab 2*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 149
+	piece ab 3*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 150
+	piece ab 3*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 151
+	piece ab gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 152
+	piece ab gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 153
+	piece ab gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 154
+	piece ab gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 155
+	piece ab 2*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 156
+	piece ab 2*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 157
+	piece ab 3*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 158
+	piece ab 3*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 159
+	piece ab 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 160
+
+	piece ab 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 161
+	piece ab gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 162
+	piece ab gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 163
+	piece ab 2*gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 164
+	piece ab 2*gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 165
+	piece ab et 5*mt rev(et) rev(ab)
+	end
+	
+	length 166
+	piece ab gi et 5*mt rev(et) rev(ab)
+	end
+	
+	length 167
+	piece ab gi et 5*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 168
+	piece ab pi gi et 5*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 169
+	piece ab pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 170
+	piece ab gi pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 171
+	piece ab gi pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 172
+	piece ab 2*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 173
+	piece ab 2*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 174
+	piece ab 3*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 175
+	piece ab 3*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 176
+	piece ab gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 177
+	piece ab gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 178
+	piece ab gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 179
+	piece ab gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 180
+	piece ab 2*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 181
+	piece ab 2*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 182
+	piece ab 3*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 183
+	piece ab 3*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 184
+	piece ab 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 185
+	piece ab 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 186
+	piece ab gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 187
+	piece ab gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 188
+	piece ab 2*gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 189
+	piece ab 2*gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 190
+	piece ab et 6*mt rev(et) rev(ab)
+	end
+	
+	length 191
+	piece ab gi et 6*mt rev(et) rev(ab)
+	end
+	
+	length 192
+	piece ab gi et 6*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 193
+	piece ab pi gi et 6*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 194
+	piece ab pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 195
+	piece ab gi pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 196
+	piece ab gi pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 197
+	piece ab 2*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 198
+	piece ab 2*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 199
+	piece ab 3*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 200
+	piece ab 3*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 201
+	piece ab gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 202
+	piece ab gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 203
+	piece ab gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 204
+	piece ab gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 205
+	piece ab 2*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 206
+	piece ab 2*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 207
+	piece ab 3*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 208
+	piece ab 3*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 209
+	piece ab 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 210
+	piece ab 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 211
+	piece ab gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 212
+	piece ab gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 213
+	piece ab 2*gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 214
+	piece ab 2*gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 215
+	piece ab et 7*mt rev(et) rev(ab)
+	end
+	
+	length 216
+	piece ab gi et 7*mt rev(et) rev(ab)
+	end
+	
+	length 217
+	piece ab gi et 7*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 218
+	piece ab pi gi et 7*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 219
+	piece ab pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 220
+	piece ab gi pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 221
+	piece ab gi pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 222
+	piece ab 2*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 223
+	piece ab 2*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 224
+	piece ab 3*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 225
+	piece ab 3*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 226
+	piece ab gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 227
+	piece ab gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 228
+	piece ab gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 229
+	piece ab gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 230
+	piece ab 2*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 231
+	piece ab 2*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 232
+	piece ab 3*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 233
+	piece ab 3*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 234
+	piece ab 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 235
+	piece ab 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 236
+	piece ab gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 237
+	piece ab gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 238
+	piece ab 2*gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 239
+	piece ab 2*gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 240
+	piece ab et 8*mt rev(et) rev(ab)
+	end
+
+	length 241
+	piece ab gi et 8*mt rev(et) rev(ab)
+	end
+	
+	length 242
+	piece ab gi et 8*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 243
+	piece ab pi gi et 8*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 244
+	piece ab pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 245
+	piece ab gi pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 246
+	piece ab gi pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 247
+	piece ab 2*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 248
+	piece ab 2*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 249
+	piece ab 3*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 250
+	piece ab 3*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 251
+	piece ab gp pi gi et 8*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 252
+	piece ab gp pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 253
+	piece ab gi gp pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 254
+	piece ab gi gp pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+end
+
+
+# Blue Suspension (SAM-6) by IDS2 (03/2024)
+
+bridge 56
+
+# abutment - 1 tile
+section ab
+	piece <0x406A0000, 0>
+end
+
+# girder - 1 tile
+section gi
+	piece <0x406A1000, 0>
+end
+
+# pillar - 1 tile
+section pi
+	piece <0x406A2000, 0>
+end
+
+# girder pillar - 4 tiles
+section gp
+	piece <0x406A2000, 0>
+	piece <0x406A1000, 0>
+	piece <0x406A1000, 0>
+	piece <0x406A1000, 0>
+end
+
+# middle tower - 25 tiles
+section mt
+	piece <0x406A5000, 0>
+	piece <0x406A5000, 0>
+	piece <0x406A5000, 0>
+	piece <0x406A5000, 0>
+	piece <0x406A5000, 0>
+	piece <0x406A5000, 0>
+	piece <0x406A5000, 0>
+	piece <0x406A5000, 0>
+	piece <0x406A5000, 0>
+	piece <0x406A5000, 0>
+	piece <0x406A7000, 0>
+	piece <0x406A7000, 0>
+	piece <0x406A6000, 0>
+	piece <0x406A7000, 0>
+	piece <0x406A7000, 0>
+	piece <0x406A5000, 0>
+	piece <0x406A5000, 0>
+	piece <0x406A5000, 0>
+	piece <0x406A5000, 0>
+	piece <0x406A5000, 0>
+	piece <0x406A5000, 0>
+	piece <0x406A5000, 0>
+	piece <0x406A5000, 0>
+	piece <0x406A5000, 0>
+	piece <0x406A5000, 0>
+end
+
+# end tower - 19 tiles
+section et
+	piece <0x406A3000, 0>
+	piece <0x406A1000, 0>
+	piece <0x406A2000, 0>
+	piece <0x406A1000, 0>
+	piece <0x406A7000, 0>
+	piece <0x406A7000, 0>
+	piece <0x406A4000, 0>
+	piece <0x406A7000, 0>
+	piece <0x406A7000, 0>
+	piece <0x406A5000, 0>
+	piece <0x406A5000, 0>
+	piece <0x406A5000, 0>
+	piece <0x406A5000, 0>
+	piece <0x406A5000, 0>
+	piece <0x406A5000, 0>
+	piece <0x406A5000, 0>
+	piece <0x406A5000, 0>
+	piece <0x406A5000, 0>
+	piece <0x406A5000, 0>
+end 
+
+	length 40
+	piece ab et rev(et) rev(ab)
+	end
+
+	length 41
+	piece ab gi et rev(et) rev(ab)
+	end
+	
+	length 42
+	piece ab gi et rev(et) rev(gi) rev(ab)
+	end
+	
+	length 43
+	piece ab pi gi et rev(et) rev(gi) rev(ab)
+	end
+	
+	length 44
+	piece ab pi gi et rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 45
+	piece ab gi pi gi et rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 46
+	piece ab gi pi gi et rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 47
+	piece ab 2*gi pi gi et rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 48
+	piece ab 2*gi pi gi et rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 49
+	piece ab 3*gi pi gi et rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 50
+	piece ab 3*gi pi gi et rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 51
+	piece ab gp pi gi et rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 52
+	piece ab gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 53
+	piece ab gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 54
+	piece ab gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 55
+	piece ab 2*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 56
+	piece ab 2*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 57
+	piece ab 3*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 58
+	piece ab 3*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 59
+	piece ab 2*gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 60
+	piece ab 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 61
+	piece ab gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 62
+	piece ab gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 63
+	piece ab 2*gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 64
+	piece ab 2*gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+
+	length 65
+	piece ab et mt rev(et) rev(ab)
+	end
+	
+	length 66
+	piece ab gi et mt rev(et) rev(ab)
+	end
+	
+	length 67
+	piece ab gi et mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 68
+	piece ab pi gi et mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 69
+	piece ab pi gi et mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 70
+	piece ab gi pi gi et mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 71
+	piece ab gi pi gi et mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 72
+	piece ab 2*gi pi gi et mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 73
+	piece ab 2*gi pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 74
+	piece ab 3*gi pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 75
+	piece ab 3*gi pi gi et mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 76
+	piece ab gp pi gi et mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 77
+	piece ab gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 78
+	piece ab gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 79
+	piece ab gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 80
+	piece ab 2*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 81
+	piece ab 2*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 82
+	piece ab 3*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 83
+	piece ab 3*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 84
+	piece ab 2*gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 85
+	piece ab 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 86
+	piece ab gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 87
+	piece ab gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 88
+	piece ab 2*gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 89
+	piece ab 2*gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 90
+	piece ab et 2*mt rev(et) rev(ab)
+	end
+	
+	length 91
+	piece ab gi et 2*mt rev(et) rev(ab)
+	end
+	
+	length 92
+	piece ab gi et 2*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 93
+	piece ab pi gi et 2*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 94
+	piece ab pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 95
+	piece ab gi pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 96
+	piece ab gi pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 97
+	piece ab 2*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 98
+	piece ab 2*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 99
+	piece ab 3*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 100
+	piece ab 3*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 101
+	piece ab gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 102
+	piece ab gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 103
+	piece ab gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 104
+	piece ab gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 105
+	piece ab 2*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 106
+	piece ab 2*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 107
+	piece ab 3*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 108
+	piece ab 3*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 109
+	piece ab 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 110
+	piece ab 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 111
+	piece ab gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 112
+	piece ab gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 113
+	piece ab 2*gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 114
+	piece ab 2*gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 115
+	piece ab et 3*mt rev(et) rev(ab)
+	end
+	
+	length 116
+	piece ab gi et 3*mt rev(et) rev(ab)
+	end
+	
+	length 117
+	piece ab gi et 3*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 118
+	piece ab pi gi et 3*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 119
+	piece ab pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 120
+	piece ab gi pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 121
+	piece ab gi pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 122
+	piece ab 2*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 123
+	piece ab 2*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 124
+	piece ab 3*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 125
+	piece ab 3*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 126
+	piece ab gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 127
+	piece ab gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 128
+	piece ab gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 129
+	piece ab gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 130
+	piece ab 2*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 131
+	piece ab 2*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 132
+	piece ab 3*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 133
+	piece ab 3*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 134
+	piece ab 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 135
+	piece ab 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 136
+	piece ab gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 137
+	piece ab gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 138
+	piece ab 2*gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 139
+	piece ab 2*gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 140
+	piece ab et 4*mt rev(et) rev(ab)
+	end
+	
+	length 141
+	piece ab gi et 4*mt rev(et) rev(ab)
+	end
+	
+	length 142
+	piece ab gi et 4*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 143
+	piece ab pi gi et 4*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 144
+	piece ab pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 145
+	piece ab gi pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 146
+	piece ab gi pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 147
+	piece ab 2*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 148
+	piece ab 2*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 149
+	piece ab 3*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 150
+	piece ab 3*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 151
+	piece ab gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 152
+	piece ab gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 153
+	piece ab gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 154
+	piece ab gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 155
+	piece ab 2*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 156
+	piece ab 2*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 157
+	piece ab 3*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 158
+	piece ab 3*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 159
+	piece ab 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 160
+
+	piece ab 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 161
+	piece ab gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 162
+	piece ab gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 163
+	piece ab 2*gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 164
+	piece ab 2*gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 165
+	piece ab et 5*mt rev(et) rev(ab)
+	end
+	
+	length 166
+	piece ab gi et 5*mt rev(et) rev(ab)
+	end
+	
+	length 167
+	piece ab gi et 5*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 168
+	piece ab pi gi et 5*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 169
+	piece ab pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 170
+	piece ab gi pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 171
+	piece ab gi pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 172
+	piece ab 2*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 173
+	piece ab 2*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 174
+	piece ab 3*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 175
+	piece ab 3*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 176
+	piece ab gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 177
+	piece ab gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 178
+	piece ab gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 179
+	piece ab gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 180
+	piece ab 2*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 181
+	piece ab 2*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 182
+	piece ab 3*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 183
+	piece ab 3*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 184
+	piece ab 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 185
+	piece ab 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 186
+	piece ab gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 187
+	piece ab gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 188
+	piece ab 2*gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 189
+	piece ab 2*gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 190
+	piece ab et 6*mt rev(et) rev(ab)
+	end
+	
+	length 191
+	piece ab gi et 6*mt rev(et) rev(ab)
+	end
+	
+	length 192
+	piece ab gi et 6*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 193
+	piece ab pi gi et 6*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 194
+	piece ab pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 195
+	piece ab gi pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 196
+	piece ab gi pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 197
+	piece ab 2*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 198
+	piece ab 2*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 199
+	piece ab 3*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 200
+	piece ab 3*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 201
+	piece ab gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 202
+	piece ab gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 203
+	piece ab gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 204
+	piece ab gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 205
+	piece ab 2*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 206
+	piece ab 2*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 207
+	piece ab 3*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 208
+	piece ab 3*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 209
+	piece ab 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 210
+	piece ab 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 211
+	piece ab gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 212
+	piece ab gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 213
+	piece ab 2*gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 214
+	piece ab 2*gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 215
+	piece ab et 7*mt rev(et) rev(ab)
+	end
+	
+	length 216
+	piece ab gi et 7*mt rev(et) rev(ab)
+	end
+	
+	length 217
+	piece ab gi et 7*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 218
+	piece ab pi gi et 7*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 219
+	piece ab pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 220
+	piece ab gi pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 221
+	piece ab gi pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 222
+	piece ab 2*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 223
+	piece ab 2*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 224
+	piece ab 3*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 225
+	piece ab 3*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 226
+	piece ab gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 227
+	piece ab gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 228
+	piece ab gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 229
+	piece ab gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 230
+	piece ab 2*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 231
+	piece ab 2*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 232
+	piece ab 3*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 233
+	piece ab 3*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 234
+	piece ab 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 235
+	piece ab 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 236
+	piece ab gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 237
+	piece ab gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 238
+	piece ab 2*gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 239
+	piece ab 2*gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 240
+	piece ab et 8*mt rev(et) rev(ab)
+	end
+
+	length 241
+	piece ab gi et 8*mt rev(et) rev(ab)
+	end
+	
+	length 242
+	piece ab gi et 8*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 243
+	piece ab pi gi et 8*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 244
+	piece ab pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 245
+	piece ab gi pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 246
+	piece ab gi pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 247
+	piece ab 2*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 248
+	piece ab 2*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 249
+	piece ab 3*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 250
+	piece ab 3*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 251
+	piece ab gp pi gi et 8*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 252
+	piece ab gp pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 253
+	piece ab gi gp pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 254
+	piece ab gi gp pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+end
+
+
+# Blue Suspension (SAM-7) by IDS2 (03/2024)
+
+bridge 57
+
+# abutment - 1 tile
+section ab
+	piece <0x406B0000, 0>
+end
+
+# girder - 1 tile
+section gi
+	piece <0x406B1000, 0>
+end
+
+# pillar - 1 tile
+section pi
+	piece <0x406B2000, 0>
+end
+
+# girder pillar - 4 tiles
+section gp
+	piece <0x406B2000, 0>
+	piece <0x406B1000, 0>
+	piece <0x406B1000, 0>
+	piece <0x406B1000, 0>
+end
+
+# middle tower - 25 tiles
+section mt
+	piece <0x406B5000, 0>
+	piece <0x406B5000, 0>
+	piece <0x406B5000, 0>
+	piece <0x406B5000, 0>
+	piece <0x406B5000, 0>
+	piece <0x406B5000, 0>
+	piece <0x406B5000, 0>
+	piece <0x406B5000, 0>
+	piece <0x406B5000, 0>
+	piece <0x406B5000, 0>
+	piece <0x406B7000, 0>
+	piece <0x406B7000, 0>
+	piece <0x406B6000, 0>
+	piece <0x406B7000, 0>
+	piece <0x406B7000, 0>
+	piece <0x406B5000, 0>
+	piece <0x406B5000, 0>
+	piece <0x406B5000, 0>
+	piece <0x406B5000, 0>
+	piece <0x406B5000, 0>
+	piece <0x406B5000, 0>
+	piece <0x406B5000, 0>
+	piece <0x406B5000, 0>
+	piece <0x406B5000, 0>
+	piece <0x406B5000, 0>
+end
+
+# end tower - 19 tiles
+section et
+	piece <0x406B3000, 0>
+	piece <0x406B1000, 0>
+	piece <0x406B2000, 0>
+	piece <0x406B1000, 0>
+	piece <0x406B7000, 0>
+	piece <0x406B7000, 0>
+	piece <0x406B4000, 0>
+	piece <0x406B7000, 0>
+	piece <0x406B7000, 0>
+	piece <0x406B5000, 0>
+	piece <0x406B5000, 0>
+	piece <0x406B5000, 0>
+	piece <0x406B5000, 0>
+	piece <0x406B5000, 0>
+	piece <0x406B5000, 0>
+	piece <0x406B5000, 0>
+	piece <0x406B5000, 0>
+	piece <0x406B5000, 0>
+	piece <0x406B5000, 0>
+end 
+
+	length 40
+	piece ab et rev(et) rev(ab)
+	end
+
+	length 41
+	piece ab gi et rev(et) rev(ab)
+	end
+	
+	length 42
+	piece ab gi et rev(et) rev(gi) rev(ab)
+	end
+	
+	length 43
+	piece ab pi gi et rev(et) rev(gi) rev(ab)
+	end
+	
+	length 44
+	piece ab pi gi et rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 45
+	piece ab gi pi gi et rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 46
+	piece ab gi pi gi et rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 47
+	piece ab 2*gi pi gi et rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 48
+	piece ab 2*gi pi gi et rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 49
+	piece ab 3*gi pi gi et rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 50
+	piece ab 3*gi pi gi et rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 51
+	piece ab gp pi gi et rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 52
+	piece ab gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 53
+	piece ab gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 54
+	piece ab gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 55
+	piece ab 2*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 56
+	piece ab 2*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 57
+	piece ab 3*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 58
+	piece ab 3*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 59
+	piece ab 2*gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 60
+	piece ab 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 61
+	piece ab gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 62
+	piece ab gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 63
+	piece ab 2*gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 64
+	piece ab 2*gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+
+	length 65
+	piece ab et mt rev(et) rev(ab)
+	end
+	
+	length 66
+	piece ab gi et mt rev(et) rev(ab)
+	end
+	
+	length 67
+	piece ab gi et mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 68
+	piece ab pi gi et mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 69
+	piece ab pi gi et mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 70
+	piece ab gi pi gi et mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 71
+	piece ab gi pi gi et mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 72
+	piece ab 2*gi pi gi et mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 73
+	piece ab 2*gi pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 74
+	piece ab 3*gi pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 75
+	piece ab 3*gi pi gi et mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 76
+	piece ab gp pi gi et mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 77
+	piece ab gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 78
+	piece ab gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 79
+	piece ab gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 80
+	piece ab 2*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 81
+	piece ab 2*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 82
+	piece ab 3*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 83
+	piece ab 3*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 84
+	piece ab 2*gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 85
+	piece ab 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 86
+	piece ab gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 87
+	piece ab gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 88
+	piece ab 2*gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 89
+	piece ab 2*gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 90
+	piece ab et 2*mt rev(et) rev(ab)
+	end
+	
+	length 91
+	piece ab gi et 2*mt rev(et) rev(ab)
+	end
+	
+	length 92
+	piece ab gi et 2*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 93
+	piece ab pi gi et 2*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 94
+	piece ab pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 95
+	piece ab gi pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 96
+	piece ab gi pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 97
+	piece ab 2*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 98
+	piece ab 2*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 99
+	piece ab 3*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 100
+	piece ab 3*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 101
+	piece ab gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 102
+	piece ab gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 103
+	piece ab gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 104
+	piece ab gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 105
+	piece ab 2*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 106
+	piece ab 2*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 107
+	piece ab 3*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 108
+	piece ab 3*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 109
+	piece ab 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 110
+	piece ab 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 111
+	piece ab gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 112
+	piece ab gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 113
+	piece ab 2*gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 114
+	piece ab 2*gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 115
+	piece ab et 3*mt rev(et) rev(ab)
+	end
+	
+	length 116
+	piece ab gi et 3*mt rev(et) rev(ab)
+	end
+	
+	length 117
+	piece ab gi et 3*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 118
+	piece ab pi gi et 3*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 119
+	piece ab pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 120
+	piece ab gi pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 121
+	piece ab gi pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 122
+	piece ab 2*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 123
+	piece ab 2*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 124
+	piece ab 3*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 125
+	piece ab 3*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 126
+	piece ab gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 127
+	piece ab gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 128
+	piece ab gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 129
+	piece ab gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 130
+	piece ab 2*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 131
+	piece ab 2*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 132
+	piece ab 3*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 133
+	piece ab 3*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 134
+	piece ab 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 135
+	piece ab 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 136
+	piece ab gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 137
+	piece ab gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 138
+	piece ab 2*gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 139
+	piece ab 2*gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 140
+	piece ab et 4*mt rev(et) rev(ab)
+	end
+	
+	length 141
+	piece ab gi et 4*mt rev(et) rev(ab)
+	end
+	
+	length 142
+	piece ab gi et 4*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 143
+	piece ab pi gi et 4*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 144
+	piece ab pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 145
+	piece ab gi pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 146
+	piece ab gi pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 147
+	piece ab 2*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 148
+	piece ab 2*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 149
+	piece ab 3*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 150
+	piece ab 3*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 151
+	piece ab gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 152
+	piece ab gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 153
+	piece ab gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 154
+	piece ab gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 155
+	piece ab 2*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 156
+	piece ab 2*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 157
+	piece ab 3*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 158
+	piece ab 3*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 159
+	piece ab 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 160
+
+	piece ab 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 161
+	piece ab gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 162
+	piece ab gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 163
+	piece ab 2*gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 164
+	piece ab 2*gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 165
+	piece ab et 5*mt rev(et) rev(ab)
+	end
+	
+	length 166
+	piece ab gi et 5*mt rev(et) rev(ab)
+	end
+	
+	length 167
+	piece ab gi et 5*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 168
+	piece ab pi gi et 5*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 169
+	piece ab pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 170
+	piece ab gi pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 171
+	piece ab gi pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 172
+	piece ab 2*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 173
+	piece ab 2*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 174
+	piece ab 3*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 175
+	piece ab 3*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 176
+	piece ab gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 177
+	piece ab gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 178
+	piece ab gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 179
+	piece ab gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 180
+	piece ab 2*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 181
+	piece ab 2*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 182
+	piece ab 3*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 183
+	piece ab 3*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 184
+	piece ab 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 185
+	piece ab 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 186
+	piece ab gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 187
+	piece ab gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 188
+	piece ab 2*gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 189
+	piece ab 2*gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 190
+	piece ab et 6*mt rev(et) rev(ab)
+	end
+	
+	length 191
+	piece ab gi et 6*mt rev(et) rev(ab)
+	end
+	
+	length 192
+	piece ab gi et 6*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 193
+	piece ab pi gi et 6*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 194
+	piece ab pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 195
+	piece ab gi pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 196
+	piece ab gi pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 197
+	piece ab 2*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 198
+	piece ab 2*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 199
+	piece ab 3*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 200
+	piece ab 3*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 201
+	piece ab gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 202
+	piece ab gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 203
+	piece ab gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 204
+	piece ab gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 205
+	piece ab 2*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 206
+	piece ab 2*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 207
+	piece ab 3*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 208
+	piece ab 3*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 209
+	piece ab 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 210
+	piece ab 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 211
+	piece ab gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 212
+	piece ab gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 213
+	piece ab 2*gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 214
+	piece ab 2*gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 215
+	piece ab et 7*mt rev(et) rev(ab)
+	end
+	
+	length 216
+	piece ab gi et 7*mt rev(et) rev(ab)
+	end
+	
+	length 217
+	piece ab gi et 7*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 218
+	piece ab pi gi et 7*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 219
+	piece ab pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 220
+	piece ab gi pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 221
+	piece ab gi pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 222
+	piece ab 2*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 223
+	piece ab 2*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 224
+	piece ab 3*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 225
+	piece ab 3*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 226
+	piece ab gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 227
+	piece ab gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 228
+	piece ab gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 229
+	piece ab gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 230
+	piece ab 2*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 231
+	piece ab 2*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 232
+	piece ab 3*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 233
+	piece ab 3*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 234
+	piece ab 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 235
+	piece ab 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 236
+	piece ab gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 237
+	piece ab gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 238
+	piece ab 2*gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 239
+	piece ab 2*gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 240
+	piece ab et 8*mt rev(et) rev(ab)
+	end
+
+	length 241
+	piece ab gi et 8*mt rev(et) rev(ab)
+	end
+	
+	length 242
+	piece ab gi et 8*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 243
+	piece ab pi gi et 8*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 244
+	piece ab pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 245
+	piece ab gi pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 246
+	piece ab gi pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 247
+	piece ab 2*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 248
+	piece ab 2*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 249
+	piece ab 3*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 250
+	piece ab 3*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 251
+	piece ab gp pi gi et 8*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 252
+	piece ab gp pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 253
+	piece ab gi gp pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 254
+	piece ab gi gp pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+end
+
+
+# Blue Suspension (SAM-8) by IDS2 (03/2024)
+
+bridge 58
+
+# abutment - 1 tile
+section ab
+	piece <0x406C0000, 0>
+end
+
+# girder - 1 tile
+section gi
+	piece <0x406C1000, 0>
+end
+
+# pillar - 1 tile
+section pi
+	piece <0x406C2000, 0>
+end
+
+# girder pillar - 4 tiles
+section gp
+	piece <0x406C2000, 0>
+	piece <0x406C1000, 0>
+	piece <0x406C1000, 0>
+	piece <0x406C1000, 0>
+end
+
+# middle tower - 25 tiles
+section mt
+	piece <0x406C5000, 0>
+	piece <0x406C5000, 0>
+	piece <0x406C5000, 0>
+	piece <0x406C5000, 0>
+	piece <0x406C5000, 0>
+	piece <0x406C5000, 0>
+	piece <0x406C5000, 0>
+	piece <0x406C5000, 0>
+	piece <0x406C5000, 0>
+	piece <0x406C5000, 0>
+	piece <0x406C7000, 0>
+	piece <0x406C7000, 0>
+	piece <0x406C6000, 0>
+	piece <0x406C7000, 0>
+	piece <0x406C7000, 0>
+	piece <0x406C5000, 0>
+	piece <0x406C5000, 0>
+	piece <0x406C5000, 0>
+	piece <0x406C5000, 0>
+	piece <0x406C5000, 0>
+	piece <0x406C5000, 0>
+	piece <0x406C5000, 0>
+	piece <0x406C5000, 0>
+	piece <0x406C5000, 0>
+	piece <0x406C5000, 0>
+end
+
+# end tower - 19 tiles
+section et
+	piece <0x406C3000, 0>
+	piece <0x406C1000, 0>
+	piece <0x406C2000, 0>
+	piece <0x406C1000, 0>
+	piece <0x406C7000, 0>
+	piece <0x406C7000, 0>
+	piece <0x406C4000, 0>
+	piece <0x406C7000, 0>
+	piece <0x406C7000, 0>
+	piece <0x406C5000, 0>
+	piece <0x406C5000, 0>
+	piece <0x406C5000, 0>
+	piece <0x406C5000, 0>
+	piece <0x406C5000, 0>
+	piece <0x406C5000, 0>
+	piece <0x406C5000, 0>
+	piece <0x406C5000, 0>
+	piece <0x406C5000, 0>
+	piece <0x406C5000, 0>
+end 
+
+	length 40
+	piece ab et rev(et) rev(ab)
+	end
+
+	length 41
+	piece ab gi et rev(et) rev(ab)
+	end
+	
+	length 42
+	piece ab gi et rev(et) rev(gi) rev(ab)
+	end
+	
+	length 43
+	piece ab pi gi et rev(et) rev(gi) rev(ab)
+	end
+	
+	length 44
+	piece ab pi gi et rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 45
+	piece ab gi pi gi et rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 46
+	piece ab gi pi gi et rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 47
+	piece ab 2*gi pi gi et rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 48
+	piece ab 2*gi pi gi et rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 49
+	piece ab 3*gi pi gi et rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 50
+	piece ab 3*gi pi gi et rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 51
+	piece ab gp pi gi et rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 52
+	piece ab gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 53
+	piece ab gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 54
+	piece ab gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 55
+	piece ab 2*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 56
+	piece ab 2*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 57
+	piece ab 3*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 58
+	piece ab 3*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 59
+	piece ab 2*gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 60
+	piece ab 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 61
+	piece ab gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 62
+	piece ab gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 63
+	piece ab 2*gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 64
+	piece ab 2*gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+
+	length 65
+	piece ab et mt rev(et) rev(ab)
+	end
+	
+	length 66
+	piece ab gi et mt rev(et) rev(ab)
+	end
+	
+	length 67
+	piece ab gi et mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 68
+	piece ab pi gi et mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 69
+	piece ab pi gi et mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 70
+	piece ab gi pi gi et mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 71
+	piece ab gi pi gi et mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 72
+	piece ab 2*gi pi gi et mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 73
+	piece ab 2*gi pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 74
+	piece ab 3*gi pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 75
+	piece ab 3*gi pi gi et mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 76
+	piece ab gp pi gi et mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 77
+	piece ab gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 78
+	piece ab gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 79
+	piece ab gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 80
+	piece ab 2*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 81
+	piece ab 2*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 82
+	piece ab 3*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 83
+	piece ab 3*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 84
+	piece ab 2*gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 85
+	piece ab 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 86
+	piece ab gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 87
+	piece ab gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 88
+	piece ab 2*gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 89
+	piece ab 2*gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 90
+	piece ab et 2*mt rev(et) rev(ab)
+	end
+	
+	length 91
+	piece ab gi et 2*mt rev(et) rev(ab)
+	end
+	
+	length 92
+	piece ab gi et 2*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 93
+	piece ab pi gi et 2*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 94
+	piece ab pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 95
+	piece ab gi pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 96
+	piece ab gi pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 97
+	piece ab 2*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 98
+	piece ab 2*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 99
+	piece ab 3*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 100
+	piece ab 3*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 101
+	piece ab gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 102
+	piece ab gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 103
+	piece ab gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 104
+	piece ab gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 105
+	piece ab 2*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 106
+	piece ab 2*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 107
+	piece ab 3*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 108
+	piece ab 3*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 109
+	piece ab 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 110
+	piece ab 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 111
+	piece ab gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 112
+	piece ab gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 113
+	piece ab 2*gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 114
+	piece ab 2*gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 115
+	piece ab et 3*mt rev(et) rev(ab)
+	end
+	
+	length 116
+	piece ab gi et 3*mt rev(et) rev(ab)
+	end
+	
+	length 117
+	piece ab gi et 3*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 118
+	piece ab pi gi et 3*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 119
+	piece ab pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 120
+	piece ab gi pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 121
+	piece ab gi pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 122
+	piece ab 2*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 123
+	piece ab 2*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 124
+	piece ab 3*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 125
+	piece ab 3*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 126
+	piece ab gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 127
+	piece ab gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 128
+	piece ab gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 129
+	piece ab gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 130
+	piece ab 2*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 131
+	piece ab 2*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 132
+	piece ab 3*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 133
+	piece ab 3*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 134
+	piece ab 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 135
+	piece ab 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 136
+	piece ab gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 137
+	piece ab gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 138
+	piece ab 2*gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 139
+	piece ab 2*gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 140
+	piece ab et 4*mt rev(et) rev(ab)
+	end
+	
+	length 141
+	piece ab gi et 4*mt rev(et) rev(ab)
+	end
+	
+	length 142
+	piece ab gi et 4*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 143
+	piece ab pi gi et 4*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 144
+	piece ab pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 145
+	piece ab gi pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 146
+	piece ab gi pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 147
+	piece ab 2*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 148
+	piece ab 2*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 149
+	piece ab 3*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 150
+	piece ab 3*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 151
+	piece ab gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 152
+	piece ab gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 153
+	piece ab gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 154
+	piece ab gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 155
+	piece ab 2*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 156
+	piece ab 2*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 157
+	piece ab 3*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 158
+	piece ab 3*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 159
+	piece ab 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 160
+
+	piece ab 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 161
+	piece ab gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 162
+	piece ab gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 163
+	piece ab 2*gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 164
+	piece ab 2*gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 165
+	piece ab et 5*mt rev(et) rev(ab)
+	end
+	
+	length 166
+	piece ab gi et 5*mt rev(et) rev(ab)
+	end
+	
+	length 167
+	piece ab gi et 5*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 168
+	piece ab pi gi et 5*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 169
+	piece ab pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 170
+	piece ab gi pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 171
+	piece ab gi pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 172
+	piece ab 2*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 173
+	piece ab 2*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 174
+	piece ab 3*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 175
+	piece ab 3*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 176
+	piece ab gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 177
+	piece ab gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 178
+	piece ab gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 179
+	piece ab gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 180
+	piece ab 2*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 181
+	piece ab 2*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 182
+	piece ab 3*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 183
+	piece ab 3*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 184
+	piece ab 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 185
+	piece ab 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 186
+	piece ab gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 187
+	piece ab gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 188
+	piece ab 2*gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 189
+	piece ab 2*gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 190
+	piece ab et 6*mt rev(et) rev(ab)
+	end
+	
+	length 191
+	piece ab gi et 6*mt rev(et) rev(ab)
+	end
+	
+	length 192
+	piece ab gi et 6*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 193
+	piece ab pi gi et 6*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 194
+	piece ab pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 195
+	piece ab gi pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 196
+	piece ab gi pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 197
+	piece ab 2*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 198
+	piece ab 2*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 199
+	piece ab 3*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 200
+	piece ab 3*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 201
+	piece ab gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 202
+	piece ab gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 203
+	piece ab gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 204
+	piece ab gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 205
+	piece ab 2*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 206
+	piece ab 2*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 207
+	piece ab 3*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 208
+	piece ab 3*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 209
+	piece ab 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 210
+	piece ab 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 211
+	piece ab gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 212
+	piece ab gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 213
+	piece ab 2*gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 214
+	piece ab 2*gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 215
+	piece ab et 7*mt rev(et) rev(ab)
+	end
+	
+	length 216
+	piece ab gi et 7*mt rev(et) rev(ab)
+	end
+	
+	length 217
+	piece ab gi et 7*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 218
+	piece ab pi gi et 7*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 219
+	piece ab pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 220
+	piece ab gi pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 221
+	piece ab gi pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 222
+	piece ab 2*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 223
+	piece ab 2*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 224
+	piece ab 3*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 225
+	piece ab 3*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 226
+	piece ab gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 227
+	piece ab gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 228
+	piece ab gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 229
+	piece ab gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 230
+	piece ab 2*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 231
+	piece ab 2*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 232
+	piece ab 3*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 233
+	piece ab 3*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 234
+	piece ab 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 235
+	piece ab 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 236
+	piece ab gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 237
+	piece ab gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 238
+	piece ab 2*gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 239
+	piece ab 2*gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 240
+	piece ab et 8*mt rev(et) rev(ab)
+	end
+
+	length 241
+	piece ab gi et 8*mt rev(et) rev(ab)
+	end
+	
+	length 242
+	piece ab gi et 8*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 243
+	piece ab pi gi et 8*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 244
+	piece ab pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 245
+	piece ab gi pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 246
+	piece ab gi pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 247
+	piece ab 2*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 248
+	piece ab 2*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 249
+	piece ab 3*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 250
+	piece ab 3*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 251
+	piece ab gp pi gi et 8*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 252
+	piece ab gp pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 253
+	piece ab gi gp pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 254
+	piece ab gi gp pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+end
+
+
+# Blue Suspension (SAM-9) by IDS2 (03/2024)
+
+bridge 59
+
+# abutment - 1 tile
+section ab
+	piece <0x406D0000, 0>
+end
+
+# girder - 1 tile
+section gi
+	piece <0x406D1000, 0>
+end
+
+# pillar - 1 tile
+section pi
+	piece <0x406D2000, 0>
+end
+
+# girder pillar - 4 tiles
+section gp
+	piece <0x406D2000, 0>
+	piece <0x406D1000, 0>
+	piece <0x406D1000, 0>
+	piece <0x406D1000, 0>
+end
+
+# middle tower - 25 tiles
+section mt
+	piece <0x406D5000, 0>
+	piece <0x406D5000, 0>
+	piece <0x406D5000, 0>
+	piece <0x406D5000, 0>
+	piece <0x406D5000, 0>
+	piece <0x406D5000, 0>
+	piece <0x406D5000, 0>
+	piece <0x406D5000, 0>
+	piece <0x406D5000, 0>
+	piece <0x406D5000, 0>
+	piece <0x406D7000, 0>
+	piece <0x406D7000, 0>
+	piece <0x406D6000, 0>
+	piece <0x406D7000, 0>
+	piece <0x406D7000, 0>
+	piece <0x406D5000, 0>
+	piece <0x406D5000, 0>
+	piece <0x406D5000, 0>
+	piece <0x406D5000, 0>
+	piece <0x406D5000, 0>
+	piece <0x406D5000, 0>
+	piece <0x406D5000, 0>
+	piece <0x406D5000, 0>
+	piece <0x406D5000, 0>
+	piece <0x406D5000, 0>
+end
+
+# end tower - 19 tiles
+section et
+	piece <0x406D3000, 0>
+	piece <0x406D1000, 0>
+	piece <0x406D2000, 0>
+	piece <0x406D1000, 0>
+	piece <0x406D7000, 0>
+	piece <0x406D7000, 0>
+	piece <0x406D4000, 0>
+	piece <0x406D7000, 0>
+	piece <0x406D7000, 0>
+	piece <0x406D5000, 0>
+	piece <0x406D5000, 0>
+	piece <0x406D5000, 0>
+	piece <0x406D5000, 0>
+	piece <0x406D5000, 0>
+	piece <0x406D5000, 0>
+	piece <0x406D5000, 0>
+	piece <0x406D5000, 0>
+	piece <0x406D5000, 0>
+	piece <0x406D5000, 0>
+end 
+
+	length 40
+	piece ab et rev(et) rev(ab)
+	end
+
+	length 41
+	piece ab gi et rev(et) rev(ab)
+	end
+	
+	length 42
+	piece ab gi et rev(et) rev(gi) rev(ab)
+	end
+	
+	length 43
+	piece ab pi gi et rev(et) rev(gi) rev(ab)
+	end
+	
+	length 44
+	piece ab pi gi et rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 45
+	piece ab gi pi gi et rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 46
+	piece ab gi pi gi et rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 47
+	piece ab 2*gi pi gi et rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 48
+	piece ab 2*gi pi gi et rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 49
+	piece ab 3*gi pi gi et rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 50
+	piece ab 3*gi pi gi et rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 51
+	piece ab gp pi gi et rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 52
+	piece ab gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 53
+	piece ab gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 54
+	piece ab gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 55
+	piece ab 2*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 56
+	piece ab 2*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 57
+	piece ab 3*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 58
+	piece ab 3*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 59
+	piece ab 2*gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 60
+	piece ab 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 61
+	piece ab gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 62
+	piece ab gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 63
+	piece ab 2*gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 64
+	piece ab 2*gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+
+	length 65
+	piece ab et mt rev(et) rev(ab)
+	end
+	
+	length 66
+	piece ab gi et mt rev(et) rev(ab)
+	end
+	
+	length 67
+	piece ab gi et mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 68
+	piece ab pi gi et mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 69
+	piece ab pi gi et mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 70
+	piece ab gi pi gi et mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 71
+	piece ab gi pi gi et mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 72
+	piece ab 2*gi pi gi et mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 73
+	piece ab 2*gi pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 74
+	piece ab 3*gi pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 75
+	piece ab 3*gi pi gi et mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 76
+	piece ab gp pi gi et mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 77
+	piece ab gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 78
+	piece ab gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 79
+	piece ab gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 80
+	piece ab 2*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 81
+	piece ab 2*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 82
+	piece ab 3*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 83
+	piece ab 3*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 84
+	piece ab 2*gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 85
+	piece ab 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 86
+	piece ab gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 87
+	piece ab gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 88
+	piece ab 2*gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 89
+	piece ab 2*gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 90
+	piece ab et 2*mt rev(et) rev(ab)
+	end
+	
+	length 91
+	piece ab gi et 2*mt rev(et) rev(ab)
+	end
+	
+	length 92
+	piece ab gi et 2*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 93
+	piece ab pi gi et 2*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 94
+	piece ab pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 95
+	piece ab gi pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 96
+	piece ab gi pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 97
+	piece ab 2*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 98
+	piece ab 2*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 99
+	piece ab 3*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 100
+	piece ab 3*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 101
+	piece ab gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 102
+	piece ab gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 103
+	piece ab gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 104
+	piece ab gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 105
+	piece ab 2*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 106
+	piece ab 2*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 107
+	piece ab 3*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 108
+	piece ab 3*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 109
+	piece ab 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 110
+	piece ab 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 111
+	piece ab gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 112
+	piece ab gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 113
+	piece ab 2*gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 114
+	piece ab 2*gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 115
+	piece ab et 3*mt rev(et) rev(ab)
+	end
+	
+	length 116
+	piece ab gi et 3*mt rev(et) rev(ab)
+	end
+	
+	length 117
+	piece ab gi et 3*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 118
+	piece ab pi gi et 3*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 119
+	piece ab pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 120
+	piece ab gi pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 121
+	piece ab gi pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 122
+	piece ab 2*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 123
+	piece ab 2*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 124
+	piece ab 3*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 125
+	piece ab 3*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 126
+	piece ab gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 127
+	piece ab gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 128
+	piece ab gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 129
+	piece ab gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 130
+	piece ab 2*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 131
+	piece ab 2*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 132
+	piece ab 3*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 133
+	piece ab 3*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 134
+	piece ab 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 135
+	piece ab 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 136
+	piece ab gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 137
+	piece ab gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 138
+	piece ab 2*gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 139
+	piece ab 2*gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 140
+	piece ab et 4*mt rev(et) rev(ab)
+	end
+	
+	length 141
+	piece ab gi et 4*mt rev(et) rev(ab)
+	end
+	
+	length 142
+	piece ab gi et 4*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 143
+	piece ab pi gi et 4*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 144
+	piece ab pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 145
+	piece ab gi pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 146
+	piece ab gi pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 147
+	piece ab 2*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 148
+	piece ab 2*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 149
+	piece ab 3*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 150
+	piece ab 3*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 151
+	piece ab gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 152
+	piece ab gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 153
+	piece ab gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 154
+	piece ab gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 155
+	piece ab 2*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 156
+	piece ab 2*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 157
+	piece ab 3*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 158
+	piece ab 3*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 159
+	piece ab 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 160
+
+	piece ab 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 161
+	piece ab gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 162
+	piece ab gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 163
+	piece ab 2*gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 164
+	piece ab 2*gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 165
+	piece ab et 5*mt rev(et) rev(ab)
+	end
+	
+	length 166
+	piece ab gi et 5*mt rev(et) rev(ab)
+	end
+	
+	length 167
+	piece ab gi et 5*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 168
+	piece ab pi gi et 5*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 169
+	piece ab pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 170
+	piece ab gi pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 171
+	piece ab gi pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 172
+	piece ab 2*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 173
+	piece ab 2*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 174
+	piece ab 3*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 175
+	piece ab 3*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 176
+	piece ab gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 177
+	piece ab gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 178
+	piece ab gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 179
+	piece ab gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 180
+	piece ab 2*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 181
+	piece ab 2*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 182
+	piece ab 3*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 183
+	piece ab 3*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 184
+	piece ab 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 185
+	piece ab 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 186
+	piece ab gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 187
+	piece ab gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 188
+	piece ab 2*gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 189
+	piece ab 2*gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 190
+	piece ab et 6*mt rev(et) rev(ab)
+	end
+	
+	length 191
+	piece ab gi et 6*mt rev(et) rev(ab)
+	end
+	
+	length 192
+	piece ab gi et 6*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 193
+	piece ab pi gi et 6*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 194
+	piece ab pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 195
+	piece ab gi pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 196
+	piece ab gi pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 197
+	piece ab 2*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 198
+	piece ab 2*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 199
+	piece ab 3*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 200
+	piece ab 3*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 201
+	piece ab gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 202
+	piece ab gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 203
+	piece ab gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 204
+	piece ab gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 205
+	piece ab 2*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 206
+	piece ab 2*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 207
+	piece ab 3*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 208
+	piece ab 3*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 209
+	piece ab 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 210
+	piece ab 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 211
+	piece ab gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 212
+	piece ab gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 213
+	piece ab 2*gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 214
+	piece ab 2*gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 215
+	piece ab et 7*mt rev(et) rev(ab)
+	end
+	
+	length 216
+	piece ab gi et 7*mt rev(et) rev(ab)
+	end
+	
+	length 217
+	piece ab gi et 7*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 218
+	piece ab pi gi et 7*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 219
+	piece ab pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 220
+	piece ab gi pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 221
+	piece ab gi pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 222
+	piece ab 2*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 223
+	piece ab 2*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 224
+	piece ab 3*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 225
+	piece ab 3*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 226
+	piece ab gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 227
+	piece ab gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 228
+	piece ab gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 229
+	piece ab gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 230
+	piece ab 2*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 231
+	piece ab 2*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 232
+	piece ab 3*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 233
+	piece ab 3*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 234
+	piece ab 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 235
+	piece ab 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 236
+	piece ab gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 237
+	piece ab gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 238
+	piece ab 2*gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 239
+	piece ab 2*gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 240
+	piece ab et 8*mt rev(et) rev(ab)
+	end
+
+	length 241
+	piece ab gi et 8*mt rev(et) rev(ab)
+	end
+	
+	length 242
+	piece ab gi et 8*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 243
+	piece ab pi gi et 8*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 244
+	piece ab pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 245
+	piece ab gi pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 246
+	piece ab gi pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 247
+	piece ab 2*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 248
+	piece ab 2*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 249
+	piece ab 3*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 250
+	piece ab 3*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 251
+	piece ab gp pi gi et 8*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 252
+	piece ab gp pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 253
+	piece ab gi gp pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 254
+	piece ab gi gp pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+end
+
+
+# Blue Suspension (SAM-10) by IDS2 (03/2024)
+
+bridge 60
+
+# abutment - 1 tile
+section ab
+	piece <0x406E0000, 0>
+end
+
+# girder - 1 tile
+section gi
+	piece <0x406E1000, 0>
+end
+
+# pillar - 1 tile
+section pi
+	piece <0x406E2000, 0>
+end
+
+# girder pillar - 4 tiles
+section gp
+	piece <0x406E2000, 0>
+	piece <0x406E1000, 0>
+	piece <0x406E1000, 0>
+	piece <0x406E1000, 0>
+end
+
+# middle tower - 25 tiles
+section mt
+	piece <0x406E5000, 0>
+	piece <0x406E5000, 0>
+	piece <0x406E5000, 0>
+	piece <0x406E5000, 0>
+	piece <0x406E5000, 0>
+	piece <0x406E5000, 0>
+	piece <0x406E5000, 0>
+	piece <0x406E5000, 0>
+	piece <0x406E5000, 0>
+	piece <0x406E5000, 0>
+	piece <0x406E7000, 0>
+	piece <0x406E7000, 0>
+	piece <0x406E6000, 0>
+	piece <0x406E7000, 0>
+	piece <0x406E7000, 0>
+	piece <0x406E5000, 0>
+	piece <0x406E5000, 0>
+	piece <0x406E5000, 0>
+	piece <0x406E5000, 0>
+	piece <0x406E5000, 0>
+	piece <0x406E5000, 0>
+	piece <0x406E5000, 0>
+	piece <0x406E5000, 0>
+	piece <0x406E5000, 0>
+	piece <0x406E5000, 0>
+end
+
+# end tower - 19 tiles
+section et
+	piece <0x406E3000, 0>
+	piece <0x406E1000, 0>
+	piece <0x406E2000, 0>
+	piece <0x406E1000, 0>
+	piece <0x406E7000, 0>
+	piece <0x406E7000, 0>
+	piece <0x406E4000, 0>
+	piece <0x406E7000, 0>
+	piece <0x406E7000, 0>
+	piece <0x406E5000, 0>
+	piece <0x406E5000, 0>
+	piece <0x406E5000, 0>
+	piece <0x406E5000, 0>
+	piece <0x406E5000, 0>
+	piece <0x406E5000, 0>
+	piece <0x406E5000, 0>
+	piece <0x406E5000, 0>
+	piece <0x406E5000, 0>
+	piece <0x406E5000, 0>
+end 
+
+	length 40
+	piece ab et rev(et) rev(ab)
+	end
+
+	length 41
+	piece ab gi et rev(et) rev(ab)
+	end
+	
+	length 42
+	piece ab gi et rev(et) rev(gi) rev(ab)
+	end
+	
+	length 43
+	piece ab pi gi et rev(et) rev(gi) rev(ab)
+	end
+	
+	length 44
+	piece ab pi gi et rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 45
+	piece ab gi pi gi et rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 46
+	piece ab gi pi gi et rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 47
+	piece ab 2*gi pi gi et rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 48
+	piece ab 2*gi pi gi et rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 49
+	piece ab 3*gi pi gi et rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 50
+	piece ab 3*gi pi gi et rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 51
+	piece ab gp pi gi et rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 52
+	piece ab gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 53
+	piece ab gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 54
+	piece ab gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 55
+	piece ab 2*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 56
+	piece ab 2*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 57
+	piece ab 3*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 58
+	piece ab 3*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 59
+	piece ab 2*gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 60
+	piece ab 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 61
+	piece ab gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 62
+	piece ab gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 63
+	piece ab 2*gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 64
+	piece ab 2*gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+
+	length 65
+	piece ab et mt rev(et) rev(ab)
+	end
+	
+	length 66
+	piece ab gi et mt rev(et) rev(ab)
+	end
+	
+	length 67
+	piece ab gi et mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 68
+	piece ab pi gi et mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 69
+	piece ab pi gi et mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 70
+	piece ab gi pi gi et mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 71
+	piece ab gi pi gi et mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 72
+	piece ab 2*gi pi gi et mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 73
+	piece ab 2*gi pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 74
+	piece ab 3*gi pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 75
+	piece ab 3*gi pi gi et mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 76
+	piece ab gp pi gi et mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 77
+	piece ab gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 78
+	piece ab gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 79
+	piece ab gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 80
+	piece ab 2*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 81
+	piece ab 2*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 82
+	piece ab 3*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 83
+	piece ab 3*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 84
+	piece ab 2*gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 85
+	piece ab 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 86
+	piece ab gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 87
+	piece ab gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 88
+	piece ab 2*gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 89
+	piece ab 2*gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 90
+	piece ab et 2*mt rev(et) rev(ab)
+	end
+	
+	length 91
+	piece ab gi et 2*mt rev(et) rev(ab)
+	end
+	
+	length 92
+	piece ab gi et 2*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 93
+	piece ab pi gi et 2*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 94
+	piece ab pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 95
+	piece ab gi pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 96
+	piece ab gi pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 97
+	piece ab 2*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 98
+	piece ab 2*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 99
+	piece ab 3*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 100
+	piece ab 3*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 101
+	piece ab gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 102
+	piece ab gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 103
+	piece ab gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 104
+	piece ab gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 105
+	piece ab 2*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 106
+	piece ab 2*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 107
+	piece ab 3*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 108
+	piece ab 3*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 109
+	piece ab 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 110
+	piece ab 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 111
+	piece ab gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 112
+	piece ab gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 113
+	piece ab 2*gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 114
+	piece ab 2*gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 115
+	piece ab et 3*mt rev(et) rev(ab)
+	end
+	
+	length 116
+	piece ab gi et 3*mt rev(et) rev(ab)
+	end
+	
+	length 117
+	piece ab gi et 3*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 118
+	piece ab pi gi et 3*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 119
+	piece ab pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 120
+	piece ab gi pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 121
+	piece ab gi pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 122
+	piece ab 2*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 123
+	piece ab 2*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 124
+	piece ab 3*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 125
+	piece ab 3*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 126
+	piece ab gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 127
+	piece ab gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 128
+	piece ab gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 129
+	piece ab gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 130
+	piece ab 2*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 131
+	piece ab 2*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 132
+	piece ab 3*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 133
+	piece ab 3*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 134
+	piece ab 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 135
+	piece ab 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 136
+	piece ab gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 137
+	piece ab gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 138
+	piece ab 2*gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 139
+	piece ab 2*gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 140
+	piece ab et 4*mt rev(et) rev(ab)
+	end
+	
+	length 141
+	piece ab gi et 4*mt rev(et) rev(ab)
+	end
+	
+	length 142
+	piece ab gi et 4*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 143
+	piece ab pi gi et 4*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 144
+	piece ab pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 145
+	piece ab gi pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 146
+	piece ab gi pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 147
+	piece ab 2*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 148
+	piece ab 2*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 149
+	piece ab 3*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 150
+	piece ab 3*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 151
+	piece ab gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 152
+	piece ab gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 153
+	piece ab gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 154
+	piece ab gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 155
+	piece ab 2*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 156
+	piece ab 2*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 157
+	piece ab 3*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 158
+	piece ab 3*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 159
+	piece ab 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 160
+
+	piece ab 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 161
+	piece ab gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 162
+	piece ab gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 163
+	piece ab 2*gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 164
+	piece ab 2*gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 165
+	piece ab et 5*mt rev(et) rev(ab)
+	end
+	
+	length 166
+	piece ab gi et 5*mt rev(et) rev(ab)
+	end
+	
+	length 167
+	piece ab gi et 5*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 168
+	piece ab pi gi et 5*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 169
+	piece ab pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 170
+	piece ab gi pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 171
+	piece ab gi pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 172
+	piece ab 2*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 173
+	piece ab 2*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 174
+	piece ab 3*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 175
+	piece ab 3*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 176
+	piece ab gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 177
+	piece ab gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 178
+	piece ab gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 179
+	piece ab gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 180
+	piece ab 2*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 181
+	piece ab 2*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 182
+	piece ab 3*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 183
+	piece ab 3*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 184
+	piece ab 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 185
+	piece ab 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 186
+	piece ab gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 187
+	piece ab gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 188
+	piece ab 2*gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 189
+	piece ab 2*gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 190
+	piece ab et 6*mt rev(et) rev(ab)
+	end
+	
+	length 191
+	piece ab gi et 6*mt rev(et) rev(ab)
+	end
+	
+	length 192
+	piece ab gi et 6*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 193
+	piece ab pi gi et 6*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 194
+	piece ab pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 195
+	piece ab gi pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 196
+	piece ab gi pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 197
+	piece ab 2*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 198
+	piece ab 2*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 199
+	piece ab 3*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 200
+	piece ab 3*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 201
+	piece ab gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 202
+	piece ab gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 203
+	piece ab gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 204
+	piece ab gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 205
+	piece ab 2*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 206
+	piece ab 2*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 207
+	piece ab 3*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 208
+	piece ab 3*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 209
+	piece ab 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 210
+	piece ab 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 211
+	piece ab gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 212
+	piece ab gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 213
+	piece ab 2*gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 214
+	piece ab 2*gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 215
+	piece ab et 7*mt rev(et) rev(ab)
+	end
+	
+	length 216
+	piece ab gi et 7*mt rev(et) rev(ab)
+	end
+	
+	length 217
+	piece ab gi et 7*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 218
+	piece ab pi gi et 7*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 219
+	piece ab pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 220
+	piece ab gi pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 221
+	piece ab gi pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 222
+	piece ab 2*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 223
+	piece ab 2*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 224
+	piece ab 3*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 225
+	piece ab 3*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 226
+	piece ab gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 227
+	piece ab gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 228
+	piece ab gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 229
+	piece ab gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 230
+	piece ab 2*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 231
+	piece ab 2*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 232
+	piece ab 3*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 233
+	piece ab 3*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 234
+	piece ab 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 235
+	piece ab 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 236
+	piece ab gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 237
+	piece ab gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 238
+	piece ab 2*gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 239
+	piece ab 2*gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 240
+	piece ab et 8*mt rev(et) rev(ab)
+	end
+
+	length 241
+	piece ab gi et 8*mt rev(et) rev(ab)
+	end
+	
+	length 242
+	piece ab gi et 8*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 243
+	piece ab pi gi et 8*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 244
+	piece ab pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 245
+	piece ab gi pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 246
+	piece ab gi pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 247
+	piece ab 2*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 248
+	piece ab 2*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 249
+	piece ab 3*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 250
+	piece ab 3*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 251
+	piece ab gp pi gi et 8*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 252
+	piece ab gp pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 253
+	piece ab gi gp pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 254
+	piece ab gi gp pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+end
+
+
+# Blue Suspension (SAM-11) by IDS2 (03/2024)
+
+bridge 61
+
+# abutment - 1 tile
+section ab
+	piece <0x406F0000, 0>
+end
+
+# girder - 1 tile
+section gi
+	piece <0x406F1000, 0>
+end
+
+# pillar - 1 tile
+section pi
+	piece <0x406F2000, 0>
+end
+
+# girder pillar - 4 tiles
+section gp
+	piece <0x406F2000, 0>
+	piece <0x406F1000, 0>
+	piece <0x406F1000, 0>
+	piece <0x406F1000, 0>
+end
+
+# middle tower - 25 tiles
+section mt
+	piece <0x406F5000, 0>
+	piece <0x406F5000, 0>
+	piece <0x406F5000, 0>
+	piece <0x406F5000, 0>
+	piece <0x406F5000, 0>
+	piece <0x406F5000, 0>
+	piece <0x406F5000, 0>
+	piece <0x406F5000, 0>
+	piece <0x406F5000, 0>
+	piece <0x406F5000, 0>
+	piece <0x406F7000, 0>
+	piece <0x406F7000, 0>
+	piece <0x406F6000, 0>
+	piece <0x406F7000, 0>
+	piece <0x406F7000, 0>
+	piece <0x406F5000, 0>
+	piece <0x406F5000, 0>
+	piece <0x406F5000, 0>
+	piece <0x406F5000, 0>
+	piece <0x406F5000, 0>
+	piece <0x406F5000, 0>
+	piece <0x406F5000, 0>
+	piece <0x406F5000, 0>
+	piece <0x406F5000, 0>
+	piece <0x406F5000, 0>
+end
+
+# end tower - 19 tiles
+section et
+	piece <0x406F3000, 0>
+	piece <0x406F1000, 0>
+	piece <0x406F2000, 0>
+	piece <0x406F1000, 0>
+	piece <0x406F7000, 0>
+	piece <0x406F7000, 0>
+	piece <0x406F4000, 0>
+	piece <0x406F7000, 0>
+	piece <0x406F7000, 0>
+	piece <0x406F5000, 0>
+	piece <0x406F5000, 0>
+	piece <0x406F5000, 0>
+	piece <0x406F5000, 0>
+	piece <0x406F5000, 0>
+	piece <0x406F5000, 0>
+	piece <0x406F5000, 0>
+	piece <0x406F5000, 0>
+	piece <0x406F5000, 0>
+	piece <0x406F5000, 0>
+end 
+
+	length 40
+	piece ab et rev(et) rev(ab)
+	end
+
+	length 41
+	piece ab gi et rev(et) rev(ab)
+	end
+	
+	length 42
+	piece ab gi et rev(et) rev(gi) rev(ab)
+	end
+	
+	length 43
+	piece ab pi gi et rev(et) rev(gi) rev(ab)
+	end
+	
+	length 44
+	piece ab pi gi et rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 45
+	piece ab gi pi gi et rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 46
+	piece ab gi pi gi et rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 47
+	piece ab 2*gi pi gi et rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 48
+	piece ab 2*gi pi gi et rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 49
+	piece ab 3*gi pi gi et rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 50
+	piece ab 3*gi pi gi et rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 51
+	piece ab gp pi gi et rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 52
+	piece ab gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 53
+	piece ab gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 54
+	piece ab gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 55
+	piece ab 2*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 56
+	piece ab 2*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 57
+	piece ab 3*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 58
+	piece ab 3*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 59
+	piece ab 2*gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 60
+	piece ab 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 61
+	piece ab gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 62
+	piece ab gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 63
+	piece ab 2*gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 64
+	piece ab 2*gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+
+	length 65
+	piece ab et mt rev(et) rev(ab)
+	end
+	
+	length 66
+	piece ab gi et mt rev(et) rev(ab)
+	end
+	
+	length 67
+	piece ab gi et mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 68
+	piece ab pi gi et mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 69
+	piece ab pi gi et mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 70
+	piece ab gi pi gi et mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 71
+	piece ab gi pi gi et mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 72
+	piece ab 2*gi pi gi et mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 73
+	piece ab 2*gi pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 74
+	piece ab 3*gi pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 75
+	piece ab 3*gi pi gi et mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 76
+	piece ab gp pi gi et mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 77
+	piece ab gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 78
+	piece ab gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 79
+	piece ab gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 80
+	piece ab 2*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 81
+	piece ab 2*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 82
+	piece ab 3*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 83
+	piece ab 3*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 84
+	piece ab 2*gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 85
+	piece ab 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 86
+	piece ab gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 87
+	piece ab gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 88
+	piece ab 2*gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 89
+	piece ab 2*gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 90
+	piece ab et 2*mt rev(et) rev(ab)
+	end
+	
+	length 91
+	piece ab gi et 2*mt rev(et) rev(ab)
+	end
+	
+	length 92
+	piece ab gi et 2*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 93
+	piece ab pi gi et 2*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 94
+	piece ab pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 95
+	piece ab gi pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 96
+	piece ab gi pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 97
+	piece ab 2*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 98
+	piece ab 2*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 99
+	piece ab 3*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 100
+	piece ab 3*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 101
+	piece ab gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 102
+	piece ab gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 103
+	piece ab gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 104
+	piece ab gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 105
+	piece ab 2*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 106
+	piece ab 2*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 107
+	piece ab 3*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 108
+	piece ab 3*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 109
+	piece ab 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 110
+	piece ab 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 111
+	piece ab gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 112
+	piece ab gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 113
+	piece ab 2*gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 114
+	piece ab 2*gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 115
+	piece ab et 3*mt rev(et) rev(ab)
+	end
+	
+	length 116
+	piece ab gi et 3*mt rev(et) rev(ab)
+	end
+	
+	length 117
+	piece ab gi et 3*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 118
+	piece ab pi gi et 3*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 119
+	piece ab pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 120
+	piece ab gi pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 121
+	piece ab gi pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 122
+	piece ab 2*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 123
+	piece ab 2*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 124
+	piece ab 3*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 125
+	piece ab 3*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 126
+	piece ab gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 127
+	piece ab gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 128
+	piece ab gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 129
+	piece ab gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 130
+	piece ab 2*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 131
+	piece ab 2*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 132
+	piece ab 3*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 133
+	piece ab 3*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 134
+	piece ab 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 135
+	piece ab 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 136
+	piece ab gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 137
+	piece ab gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 138
+	piece ab 2*gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 139
+	piece ab 2*gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 140
+	piece ab et 4*mt rev(et) rev(ab)
+	end
+	
+	length 141
+	piece ab gi et 4*mt rev(et) rev(ab)
+	end
+	
+	length 142
+	piece ab gi et 4*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 143
+	piece ab pi gi et 4*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 144
+	piece ab pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 145
+	piece ab gi pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 146
+	piece ab gi pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 147
+	piece ab 2*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 148
+	piece ab 2*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 149
+	piece ab 3*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 150
+	piece ab 3*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 151
+	piece ab gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 152
+	piece ab gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 153
+	piece ab gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 154
+	piece ab gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 155
+	piece ab 2*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 156
+	piece ab 2*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 157
+	piece ab 3*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 158
+	piece ab 3*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 159
+	piece ab 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 160
+
+	piece ab 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 161
+	piece ab gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 162
+	piece ab gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 163
+	piece ab 2*gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 164
+	piece ab 2*gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 165
+	piece ab et 5*mt rev(et) rev(ab)
+	end
+	
+	length 166
+	piece ab gi et 5*mt rev(et) rev(ab)
+	end
+	
+	length 167
+	piece ab gi et 5*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 168
+	piece ab pi gi et 5*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 169
+	piece ab pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 170
+	piece ab gi pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 171
+	piece ab gi pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 172
+	piece ab 2*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 173
+	piece ab 2*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 174
+	piece ab 3*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 175
+	piece ab 3*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 176
+	piece ab gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 177
+	piece ab gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 178
+	piece ab gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 179
+	piece ab gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 180
+	piece ab 2*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 181
+	piece ab 2*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 182
+	piece ab 3*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 183
+	piece ab 3*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 184
+	piece ab 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 185
+	piece ab 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 186
+	piece ab gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 187
+	piece ab gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 188
+	piece ab 2*gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 189
+	piece ab 2*gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 190
+	piece ab et 6*mt rev(et) rev(ab)
+	end
+	
+	length 191
+	piece ab gi et 6*mt rev(et) rev(ab)
+	end
+	
+	length 192
+	piece ab gi et 6*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 193
+	piece ab pi gi et 6*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 194
+	piece ab pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 195
+	piece ab gi pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 196
+	piece ab gi pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 197
+	piece ab 2*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 198
+	piece ab 2*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 199
+	piece ab 3*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 200
+	piece ab 3*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 201
+	piece ab gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 202
+	piece ab gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 203
+	piece ab gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 204
+	piece ab gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 205
+	piece ab 2*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 206
+	piece ab 2*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 207
+	piece ab 3*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 208
+	piece ab 3*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 209
+	piece ab 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 210
+	piece ab 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 211
+	piece ab gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 212
+	piece ab gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 213
+	piece ab 2*gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 214
+	piece ab 2*gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 215
+	piece ab et 7*mt rev(et) rev(ab)
+	end
+	
+	length 216
+	piece ab gi et 7*mt rev(et) rev(ab)
+	end
+	
+	length 217
+	piece ab gi et 7*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 218
+	piece ab pi gi et 7*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 219
+	piece ab pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 220
+	piece ab gi pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 221
+	piece ab gi pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 222
+	piece ab 2*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 223
+	piece ab 2*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 224
+	piece ab 3*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 225
+	piece ab 3*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 226
+	piece ab gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 227
+	piece ab gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 228
+	piece ab gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 229
+	piece ab gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 230
+	piece ab 2*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 231
+	piece ab 2*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 232
+	piece ab 3*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 233
+	piece ab 3*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 234
+	piece ab 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 235
+	piece ab 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 236
+	piece ab gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 237
+	piece ab gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 238
+	piece ab 2*gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 239
+	piece ab 2*gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 240
+	piece ab et 8*mt rev(et) rev(ab)
+	end
+
+	length 241
+	piece ab gi et 8*mt rev(et) rev(ab)
+	end
+	
+	length 242
+	piece ab gi et 8*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 243
+	piece ab pi gi et 8*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 244
+	piece ab pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 245
+	piece ab gi pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 246
+	piece ab gi pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 247
+	piece ab 2*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 248
+	piece ab 2*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 249
+	piece ab 3*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 250
+	piece ab 3*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 251
+	piece ab gp pi gi et 8*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 252
+	piece ab gp pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 253
+	piece ab gi gp pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 254
+	piece ab gi gp pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
 end

--- a/Controller/Bridge Controller/0000100a.rul
+++ b/Controller/Bridge Controller/0000100a.rul
@@ -4406,6 +4406,2074 @@ end
 end
 
 
+# Yellow Steel Girder (OWR-2) by IDS2 (09/23)
+
+bridge 16
+
+# abutment start - 1 tile
+section as
+	piece <0x40400000, 0>
+end 
+
+# pillar section - 3 tiles
+section pi
+	piece <0x40401000, 0>
+	piece <0x40402000, 0>
+	piece <0x40401000, 0>
+end 
+
+# span only - 1 tile
+section sp
+	piece <0x40403000, 0>
+end 
+
+# combined repeat segment - 4 tiles
+section ps
+	piece pi sp
+end
+
+#abutment end - 1 tile
+section ae
+	piece <0x40400000, 2>
+end
+
+	length 5
+	piece as 3*sp ae
+	end
+	
+	length 6
+	piece as 4*sp ae
+	end
+	
+	length 7
+	piece as sp ps ae
+	end
+	
+	length 8
+	piece as sp ps sp ae
+	end
+	
+	length 9
+	piece as 2*sp ps sp ae
+	end
+	
+	length 10
+	piece as 2*sp ps 2*sp ae
+	end
+	
+	length 11
+	piece as sp 2*ps ae
+	end
+	
+	length 12
+	piece as 2*sp 2*ps ae
+	end
+	
+	length 13
+	piece as 2*sp 2*ps sp ae
+	end
+	
+	length 14
+	piece as 2*sp ps sp ps sp ae
+	end
+	
+	length 15
+	piece as sp 3*ps ae
+	end
+	
+	length 16
+	piece as 2*sp 3*ps ae
+	end
+	
+	length 17
+	piece as 2*sp 3*ps sp ae
+	end
+	
+	length 18
+	piece as 2*sp 3*ps 2*sp ae
+	end
+	
+	length 19
+	piece as sp 4*ps ae
+	end
+	
+	length 20
+	piece as 2*sp 4*ps ae
+	end
+	
+	length 21
+	piece as 2*sp 4*ps sp ae
+	end
+	
+	length 22
+	piece as 2*sp 4*ps 2*sp ae
+	end
+	
+	length 23
+	piece as sp 5*ps ae
+	end
+
+	length 24
+	piece as 2*sp 5*ps ae
+	end
+
+	length 25
+	piece as 2*sp 5*ps sp ae
+	end
+
+	length 26
+	piece as 2*sp 5*ps 2*sp ae
+	end
+
+	length 27
+	piece as sp 6*ps ae
+	end
+
+	length 28
+	piece as 2*sp 6*ps ae
+	end
+
+	length 29
+	piece as 2*sp 6*ps sp ae
+	end
+
+	length 30
+	piece as 2*sp 6*ps 2*sp ae
+	end
+
+	length 31
+	piece as sp 7*ps ae
+	end
+
+	length 32
+	piece as 2*sp 7*ps ae
+	end
+
+	length 33
+	piece as 2*sp 7*ps sp ae
+	end
+
+	length 34
+	piece as 2*sp 7*ps 2*sp ae
+	end
+
+	length 35
+	piece as sp 8*ps ae
+	end
+
+	length 36
+	piece as 2*sp 8*ps ae
+	end
+
+	length 37
+	piece as 2*sp 8*ps sp ae
+	end
+
+	length 38
+	piece as 2*sp 8*ps 2*sp ae
+	end
+
+	length 39
+	piece as sp 9*ps ae
+	end
+
+	length 40
+	piece as 2*sp 9*ps ae
+	end
+
+	length 41
+	piece as 2*sp 9*ps sp ae
+	end
+
+	length 42
+	piece as 2*sp 9*ps 2*sp ae
+	end
+
+	length 43
+	piece as sp 10*ps ae
+	end
+
+	length 44
+	piece as 2*sp 10*ps ae
+	end
+
+	length 45
+	piece as 2*sp 10*ps sp ae
+	end
+
+	length 46
+	piece as 2*sp 10*ps 2*sp ae
+	end
+
+	length 47
+	piece as sp 11*ps ae
+	end
+
+	length 48
+	piece as 2*sp 11*ps ae
+	end
+
+	length 49
+	piece as 2*sp 11*ps sp ae
+	end
+
+	length 50
+	piece as 2*sp 11*ps 2*sp ae
+	end
+
+	length 51
+	piece as sp 12*ps ae
+	end
+
+	length 52
+	piece as 2*sp 12*ps ae
+	end
+
+	length 53
+	piece as 2*sp 12*ps sp ae
+	end
+
+	length 54
+	piece as 2*sp 12*ps 2*sp ae
+	end
+
+	length 55
+	piece as sp 13*ps ae
+	end
+
+	length 56
+	piece as 2*sp 13*ps ae
+	end
+
+	length 57
+	piece as 2*sp 13*ps sp ae
+	end
+
+	length 58
+	piece as 2*sp 13*ps 2*sp ae
+	end
+
+	length 59
+	piece as sp 14*ps ae
+	end
+
+	length 60
+	piece as 2*sp 14*ps ae
+	end
+
+	length 61
+	piece as 2*sp 14*ps sp ae
+	end
+
+	length 62
+	piece as 2*sp 14*ps 2*sp ae
+	end
+
+	length 63
+	piece as sp 15*ps ae
+	end
+
+	length 64
+	piece as 2*sp 15*ps ae
+	end
+
+	length 65
+	piece as 2*sp 15*ps sp ae
+	end
+
+	length 66
+	piece as 2*sp 15*ps 2*sp ae
+	end
+
+	length 67
+	piece as sp 16*ps ae
+	end
+
+	length 68
+	piece as 2*sp 16*ps ae
+	end
+
+	length 69
+	piece as 2*sp 16*ps sp ae
+	end
+
+	length 70
+	piece as 2*sp 16*ps 2*sp ae
+	end
+
+	length 71
+	piece as sp 17*ps ae
+	end
+
+	length 72
+	piece as 2*sp 17*ps ae
+	end
+
+	length 73
+	piece as 2*sp 17*ps sp ae
+	end
+
+	length 74
+	piece as 2*sp 17*ps 2*sp ae
+	end
+
+	length 75
+	piece as sp 18*ps ae
+	end
+
+	length 76
+	piece as 2*sp 18*ps ae
+	end
+
+	length 77
+	piece as 2*sp 18*ps sp ae
+	end
+
+	length 78
+	piece as 2*sp 18*ps 2*sp ae
+	end
+
+	length 79
+	piece as sp 19*ps ae
+	end
+
+	length 80
+	piece as 2*sp 19*ps ae
+	end
+
+	length 81
+	piece as 2*sp 19*ps sp ae
+	end
+
+	length 82
+	piece as 2*sp 19*ps 2*sp ae
+	end
+
+	length 83
+	piece as sp 20*ps ae
+	end
+
+	length 84
+	piece as 2*sp 20*ps ae
+	end
+
+	length 85
+	piece as 2*sp 20*ps sp ae
+	end
+
+	length 86
+	piece as 2*sp 20*ps 2*sp ae
+	end
+
+	length 87
+	piece as sp 21*ps ae
+	end
+
+	length 88
+	piece as 2*sp 21*ps ae
+	end
+
+	length 89
+	piece as 2*sp 21*ps sp ae
+	end
+
+	length 90
+	piece as 2*sp 21*ps 2*sp ae
+	end
+
+	length 91
+	piece as sp 22*ps ae
+	end
+
+	length 92
+	piece as 2*sp 22*ps ae
+	end
+
+	length 93
+	piece as 2*sp 22*ps sp ae
+	end
+
+	length 94
+	piece as 2*sp 22*ps 2*sp ae
+	end
+
+	length 95
+	piece as sp 23*ps ae
+	end
+
+	length 96
+	piece as 2*sp 23*ps ae
+	end
+
+	length 97
+	piece as 2*sp 23*ps sp ae
+	end
+
+	length 98
+	piece as 2*sp 23*ps 2*sp ae
+	end
+
+	length 99
+	piece as sp 24*ps ae
+	end
+
+	length 100
+	piece as 2*sp 24*ps ae
+	end
+
+	length 101
+	piece as 2*sp 24*ps sp ae
+	end
+
+	length 102
+	piece as 2*sp 24*ps 2*sp ae
+	end
+
+	length 103
+	piece as sp 25*ps ae
+	end
+
+	length 104
+	piece as 2*sp 25*ps ae
+	end
+
+	length 105
+	piece as 2*sp 25*ps sp ae
+	end
+
+	length 106
+	piece as 2*sp 25*ps 2*sp ae
+	end
+
+	length 107
+	piece as sp 26*ps ae
+	end
+
+	length 108
+	piece as 2*sp 26*ps ae
+	end
+
+	length 109
+	piece as 2*sp 26*ps sp ae
+	end
+
+	length 110
+	piece as 2*sp 26*ps 2*sp ae
+	end
+
+	length 111
+	piece as sp 27*ps ae
+	end
+
+	length 112
+	piece as 2*sp 27*ps ae
+	end
+
+	length 113
+	piece as 2*sp 27*ps sp ae
+	end
+
+	length 114
+	piece as 2*sp 27*ps 2*sp ae
+	end
+
+	length 115
+	piece as sp 28*ps ae
+	end
+
+	length 116
+	piece as 2*sp 28*ps ae
+	end
+
+	length 117
+	piece as 2*sp 28*ps sp ae
+	end
+
+	length 118
+	piece as 2*sp 28*ps 2*sp ae
+	end
+
+	length 119
+	piece as sp 29*ps ae
+	end
+
+	length 120
+	piece as 2*sp 29*ps ae
+	end
+
+	length 121
+	piece as 2*sp 29*ps sp ae
+	end
+
+	length 122
+	piece as 2*sp 29*ps 2*sp ae
+	end
+
+	length 123
+	piece as sp 30*ps ae
+	end
+
+	length 124
+	piece as 2*sp 30*ps ae
+	end
+
+	length 125
+	piece as 2*sp 30*ps sp ae
+	end
+
+	length 126
+	piece as 2*sp 30*ps 2*sp ae
+	end
+
+	length 127
+	piece as sp 31*ps ae
+	end
+
+	length 128
+	piece as 2*sp 31*ps ae
+	end
+
+	length 129
+	piece as 2*sp 31*ps sp ae
+	end
+
+	length 130
+	piece as 2*sp 31*ps 2*sp ae
+	end
+
+	length 131
+	piece as sp 32*ps ae
+	end
+
+	length 132
+	piece as 2*sp 32*ps ae
+	end
+
+	length 133
+	piece as 2*sp 32*ps sp ae
+	end
+
+	length 134
+	piece as 2*sp 32*ps 2*sp ae
+	end
+
+	length 135
+	piece as sp 33*ps ae
+	end
+
+	length 136
+	piece as 2*sp 33*ps ae
+	end
+
+	length 137
+	piece as 2*sp 33*ps sp ae
+	end
+
+	length 138
+	piece as 2*sp 33*ps 2*sp ae
+	end
+
+	length 139
+	piece as sp 34*ps ae
+	end
+
+	length 140
+	piece as 2*sp 34*ps ae
+	end
+
+	length 141
+	piece as 2*sp 34*ps sp ae
+	end
+
+	length 142
+	piece as 2*sp 34*ps 2*sp ae
+	end
+
+	length 143
+	piece as sp 35*ps ae
+	end
+
+	length 144
+	piece as 2*sp 35*ps ae
+	end
+
+	length 145
+	piece as 2*sp 35*ps sp ae
+	end
+
+	length 146
+	piece as 2*sp 35*ps 2*sp ae
+	end
+
+	length 147
+	piece as sp 36*ps ae
+	end
+
+	length 148
+	piece as 2*sp 36*ps ae
+	end
+
+	length 149
+	piece as 2*sp 36*ps sp ae
+	end
+
+	length 150
+	piece as 2*sp 36*ps 2*sp ae
+	end
+
+	length 151
+	piece as sp 37*ps ae
+	end
+
+	length 152
+	piece as 2*sp 37*ps ae
+	end
+
+	length 153
+	piece as 2*sp 37*ps sp ae
+	end
+
+	length 154
+	piece as 2*sp 37*ps 2*sp ae
+	end
+
+	length 155
+	piece as sp 38*ps ae
+	end
+
+	length 156
+	piece as 2*sp 38*ps ae
+	end
+
+	length 157
+	piece as 2*sp 38*ps sp ae
+	end
+
+	length 158
+	piece as 2*sp 38*ps 2*sp ae
+	end
+
+	length 159
+	piece as sp 39*ps ae
+	end
+
+	length 160
+	piece as 2*sp 39*ps ae
+	end
+
+	length 161
+	piece as 2*sp 39*ps sp ae
+	end
+
+	length 162
+	piece as 2*sp 39*ps 2*sp ae
+	end
+
+	length 163
+	piece as sp 40*ps ae
+	end
+
+	length 164
+	piece as 2*sp 40*ps ae
+	end
+
+	length 165
+	piece as 2*sp 40*ps sp ae
+	end
+
+	length 166
+	piece as 2*sp 40*ps 2*sp ae
+	end
+
+	length 167
+	piece as sp 41*ps ae
+	end
+
+	length 168
+	piece as 2*sp 41*ps ae
+	end
+
+	length 169
+	piece as 2*sp 41*ps sp ae
+	end
+
+	length 170
+	piece as 2*sp 41*ps 2*sp ae
+	end
+
+	length 171
+	piece as sp 42*ps ae
+	end
+
+	length 172
+	piece as 2*sp 42*ps ae
+	end
+
+	length 173
+	piece as 2*sp 42*ps sp ae
+	end
+
+	length 174
+	piece as 2*sp 42*ps 2*sp ae
+	end
+
+	length 175
+	piece as sp 43*ps ae
+	end
+
+	length 176
+	piece as 2*sp 43*ps ae
+	end
+
+	length 177
+	piece as 2*sp 43*ps sp ae
+	end
+
+	length 178
+	piece as 2*sp 43*ps 2*sp ae
+	end
+
+	length 179
+	piece as sp 44*ps ae
+	end
+
+	length 180
+
+	piece as 2*sp 44*ps ae
+	end
+
+	length 181
+	piece as 2*sp 44*ps sp ae
+	end
+
+	length 182
+	piece as 2*sp 44*ps 2*sp ae
+	end
+
+	length 183
+	piece as sp 45*ps ae
+	end
+
+	length 184
+	piece as 2*sp 45*ps ae
+	end
+
+	length 185
+	piece as 2*sp 45*ps sp ae
+	end
+
+	length 186
+	piece as 2*sp 45*ps 2*sp ae
+	end
+
+	length 187
+	piece as sp 46*ps ae
+	end
+
+	length 188
+	piece as 2*sp 46*ps ae
+	end
+
+	length 189
+	piece as 2*sp 46*ps sp ae
+	end
+
+	length 190
+	piece as 2*sp 46*ps 2*sp ae
+	end
+
+	length 191
+	piece as sp 47*ps ae
+	end
+
+	length 192
+	piece as 2*sp 47*ps ae
+	end
+
+	length 193
+	piece as 2*sp 47*ps sp ae
+	end
+
+	length 194
+	piece as 2*sp 47*ps 2*sp ae
+	end
+
+	length 195
+	piece as sp 48*ps ae
+	end
+
+	length 196
+	piece as 2*sp 48*ps ae
+	end
+
+	length 197
+	piece as 2*sp 48*ps sp ae
+	end
+
+	length 198
+	piece as 2*sp 48*ps 2*sp ae
+	end
+
+	length 199
+	piece as sp 49*ps ae
+	end
+
+	length 200
+	piece as 2*sp 49*ps ae
+	end
+
+	length 201
+	piece as 2*sp 49*ps sp ae
+	end
+
+	length 202
+	piece as 2*sp 49*ps 2*sp ae
+	end
+
+	length 203
+	piece as sp 50*ps ae
+	end
+
+	length 204
+	piece as 2*sp 50*ps ae
+	end
+
+	length 205
+	piece as 2*sp 50*ps sp ae
+	end
+
+	length 206
+	piece as 2*sp 50*ps 2*sp ae
+	end
+
+	length 207
+	piece as sp 51*ps ae
+	end
+
+	length 208
+	piece as 2*sp 51*ps ae
+	end
+
+	length 209
+	piece as 2*sp 51*ps sp ae
+	end
+
+	length 210
+	piece as 2*sp 51*ps 2*sp ae
+	end
+
+	length 211
+	piece as sp 52*ps ae
+	end
+
+	length 212
+	piece as 2*sp 52*ps ae
+	end
+
+	length 213
+	piece as 2*sp 52*ps sp ae
+	end
+
+	length 214
+	piece as 2*sp 52*ps 2*sp ae
+	end
+
+	length 215
+	piece as sp 53*ps ae
+	end
+
+	length 216
+	piece as 2*sp 53*ps ae
+	end
+
+	length 217
+	piece as 2*sp 53*ps sp ae
+	end
+
+	length 218
+	piece as 2*sp 53*ps 2*sp ae
+	end
+
+	length 219
+	piece as sp 54*ps ae
+	end
+
+	length 220
+	piece as 2*sp 54*ps ae
+	end
+
+	length 221
+	piece as 2*sp 54*ps sp ae
+	end
+
+	length 222
+	piece as 2*sp 54*ps 2*sp ae
+	end
+
+	length 223
+	piece as sp 55*ps ae
+	end
+
+	length 224
+	piece as 2*sp 55*ps ae
+	end
+
+	length 225
+	piece as 2*sp 55*ps sp ae
+	end
+
+	length 226
+	piece as 2*sp 55*ps 2*sp ae
+	end
+
+	length 227
+	piece as sp 56*ps ae
+	end
+
+	length 228
+	piece as 2*sp 56*ps ae
+	end
+
+	length 229
+	piece as 2*sp 56*ps sp ae
+	end
+
+	length 230
+	piece as 2*sp 56*ps 2*sp ae
+	end
+
+	length 231
+	piece as sp 57*ps ae
+	end
+
+	length 232
+	piece as 2*sp 57*ps ae
+	end
+
+	length 233
+	piece as 2*sp 57*ps sp ae
+	end
+
+	length 234
+	piece as 2*sp 57*ps 2*sp ae
+	end
+
+	length 235
+	piece as sp 58*ps ae
+	end
+
+	length 236
+	piece as 2*sp 58*ps ae
+	end
+
+	length 237
+	piece as 2*sp 58*ps sp ae
+	end
+
+	length 238
+	piece as 2*sp 58*ps 2*sp ae
+	end
+
+	length 239
+	piece as sp 59*ps ae
+	end
+
+	length 240
+	piece as 2*sp 59*ps ae
+	end
+
+	length 241
+	piece as 2*sp 59*ps sp ae
+	end
+
+	length 242
+	piece as 2*sp 59*ps 2*sp ae
+	end
+
+	length 243
+	piece as sp 60*ps ae
+	end
+
+	length 244
+	piece as 2*sp 60*ps ae
+	end
+
+	length 245
+	piece as 2*sp 60*ps sp ae
+	end
+
+	length 246
+	piece as 2*sp 60*ps 2*sp ae
+	end
+
+	length 247
+	piece as sp 61*ps ae
+	end
+
+	length 248
+	piece as 2*sp 61*ps ae
+	end
+
+	length 249
+	piece as 2*sp 61*ps sp ae
+	end
+
+	length 250
+	piece as 2*sp 61*ps 2*sp ae
+	end
+
+	length 251
+	piece as sp 62*ps ae
+	end
+
+	length 252
+	piece as 2*sp 62*ps ae
+	end
+
+	length 253
+	piece as 2*sp 62*ps sp ae
+	end
+
+	length 254
+	piece as 2*sp 62*ps 2*sp ae
+	end
+end
+
+
+# Yellow Steel Girder (OWR-3) by IDS2 (09/23)
+
+bridge 17
+
+# abutment start - 1 tile
+section as
+	piece <0x40346000, 0>
+end 
+
+# pillar section - 3 tiles
+section pi
+	piece <0x40347000, 0>
+	piece <0x40356000, 0>
+	piece <0x40347000, 0>
+end 
+
+# span only - 1 tile
+section sp
+	piece <0x40357000, 0>
+end 
+
+# combined repeat segment - 4 tiles
+section ps
+	piece pi sp
+end
+
+#abutment end - 1 tile
+section ae
+	piece <0x40346000, 2>
+end
+
+	length 5
+	piece as 3*sp ae
+	end
+	
+	length 6
+	piece as 4*sp ae
+	end
+	
+	length 7
+	piece as sp ps ae
+	end
+	
+	length 8
+	piece as sp ps sp ae
+	end
+	
+	length 9
+	piece as 2*sp ps sp ae
+	end
+	
+	length 10
+	piece as 2*sp ps 2*sp ae
+	end
+	
+	length 11
+	piece as sp 2*ps ae
+	end
+	
+	length 12
+	piece as 2*sp 2*ps ae
+	end
+	
+	length 13
+	piece as 2*sp 2*ps sp ae
+	end
+	
+	length 14
+	piece as 2*sp ps sp ps sp ae
+	end
+	
+	length 15
+	piece as sp 3*ps ae
+	end
+	
+	length 16
+	piece as 2*sp 3*ps ae
+	end
+	
+	length 17
+	piece as 2*sp 3*ps sp ae
+	end
+	
+	length 18
+	piece as 2*sp 3*ps 2*sp ae
+	end
+	
+	length 19
+	piece as sp 4*ps ae
+	end
+	
+	length 20
+	piece as 2*sp 4*ps ae
+	end
+	
+	length 21
+	piece as 2*sp 4*ps sp ae
+	end
+	
+	length 22
+	piece as 2*sp 4*ps 2*sp ae
+	end
+	
+	length 23
+	piece as sp 5*ps ae
+	end
+
+	length 24
+	piece as 2*sp 5*ps ae
+	end
+
+	length 25
+	piece as 2*sp 5*ps sp ae
+	end
+
+	length 26
+	piece as 2*sp 5*ps 2*sp ae
+	end
+
+	length 27
+	piece as sp 6*ps ae
+	end
+
+	length 28
+	piece as 2*sp 6*ps ae
+	end
+
+	length 29
+	piece as 2*sp 6*ps sp ae
+	end
+
+	length 30
+	piece as 2*sp 6*ps 2*sp ae
+	end
+
+	length 31
+	piece as sp 7*ps ae
+	end
+
+	length 32
+	piece as 2*sp 7*ps ae
+	end
+
+	length 33
+	piece as 2*sp 7*ps sp ae
+	end
+
+	length 34
+	piece as 2*sp 7*ps 2*sp ae
+	end
+
+	length 35
+	piece as sp 8*ps ae
+	end
+
+	length 36
+	piece as 2*sp 8*ps ae
+	end
+
+	length 37
+	piece as 2*sp 8*ps sp ae
+	end
+
+	length 38
+	piece as 2*sp 8*ps 2*sp ae
+	end
+
+	length 39
+	piece as sp 9*ps ae
+	end
+
+	length 40
+	piece as 2*sp 9*ps ae
+	end
+
+	length 41
+	piece as 2*sp 9*ps sp ae
+	end
+
+	length 42
+	piece as 2*sp 9*ps 2*sp ae
+	end
+
+	length 43
+	piece as sp 10*ps ae
+	end
+
+	length 44
+	piece as 2*sp 10*ps ae
+	end
+
+	length 45
+	piece as 2*sp 10*ps sp ae
+	end
+
+	length 46
+	piece as 2*sp 10*ps 2*sp ae
+	end
+
+	length 47
+	piece as sp 11*ps ae
+	end
+
+	length 48
+	piece as 2*sp 11*ps ae
+	end
+
+	length 49
+	piece as 2*sp 11*ps sp ae
+	end
+
+	length 50
+	piece as 2*sp 11*ps 2*sp ae
+	end
+
+	length 51
+	piece as sp 12*ps ae
+	end
+
+	length 52
+	piece as 2*sp 12*ps ae
+	end
+
+	length 53
+	piece as 2*sp 12*ps sp ae
+	end
+
+	length 54
+	piece as 2*sp 12*ps 2*sp ae
+	end
+
+	length 55
+	piece as sp 13*ps ae
+	end
+
+	length 56
+	piece as 2*sp 13*ps ae
+	end
+
+	length 57
+	piece as 2*sp 13*ps sp ae
+	end
+
+	length 58
+	piece as 2*sp 13*ps 2*sp ae
+	end
+
+	length 59
+	piece as sp 14*ps ae
+	end
+
+	length 60
+	piece as 2*sp 14*ps ae
+	end
+
+	length 61
+	piece as 2*sp 14*ps sp ae
+	end
+
+	length 62
+	piece as 2*sp 14*ps 2*sp ae
+	end
+
+	length 63
+	piece as sp 15*ps ae
+	end
+
+	length 64
+	piece as 2*sp 15*ps ae
+	end
+
+	length 65
+	piece as 2*sp 15*ps sp ae
+	end
+
+	length 66
+	piece as 2*sp 15*ps 2*sp ae
+	end
+
+	length 67
+	piece as sp 16*ps ae
+	end
+
+	length 68
+	piece as 2*sp 16*ps ae
+	end
+
+	length 69
+	piece as 2*sp 16*ps sp ae
+	end
+
+	length 70
+	piece as 2*sp 16*ps 2*sp ae
+	end
+
+	length 71
+	piece as sp 17*ps ae
+	end
+
+	length 72
+	piece as 2*sp 17*ps ae
+	end
+
+	length 73
+	piece as 2*sp 17*ps sp ae
+	end
+
+	length 74
+	piece as 2*sp 17*ps 2*sp ae
+	end
+
+	length 75
+	piece as sp 18*ps ae
+	end
+
+	length 76
+	piece as 2*sp 18*ps ae
+	end
+
+	length 77
+	piece as 2*sp 18*ps sp ae
+	end
+
+	length 78
+	piece as 2*sp 18*ps 2*sp ae
+	end
+
+	length 79
+	piece as sp 19*ps ae
+	end
+
+	length 80
+	piece as 2*sp 19*ps ae
+	end
+
+	length 81
+	piece as 2*sp 19*ps sp ae
+	end
+
+	length 82
+	piece as 2*sp 19*ps 2*sp ae
+	end
+
+	length 83
+	piece as sp 20*ps ae
+	end
+
+	length 84
+	piece as 2*sp 20*ps ae
+	end
+
+	length 85
+	piece as 2*sp 20*ps sp ae
+	end
+
+	length 86
+	piece as 2*sp 20*ps 2*sp ae
+	end
+
+	length 87
+	piece as sp 21*ps ae
+	end
+
+	length 88
+	piece as 2*sp 21*ps ae
+	end
+
+	length 89
+	piece as 2*sp 21*ps sp ae
+	end
+
+	length 90
+	piece as 2*sp 21*ps 2*sp ae
+	end
+
+	length 91
+	piece as sp 22*ps ae
+	end
+
+	length 92
+	piece as 2*sp 22*ps ae
+	end
+
+	length 93
+	piece as 2*sp 22*ps sp ae
+	end
+
+	length 94
+	piece as 2*sp 22*ps 2*sp ae
+	end
+
+	length 95
+	piece as sp 23*ps ae
+	end
+
+	length 96
+	piece as 2*sp 23*ps ae
+	end
+
+	length 97
+	piece as 2*sp 23*ps sp ae
+	end
+
+	length 98
+	piece as 2*sp 23*ps 2*sp ae
+	end
+
+	length 99
+	piece as sp 24*ps ae
+	end
+
+	length 100
+	piece as 2*sp 24*ps ae
+	end
+
+	length 101
+	piece as 2*sp 24*ps sp ae
+	end
+
+	length 102
+	piece as 2*sp 24*ps 2*sp ae
+	end
+
+	length 103
+	piece as sp 25*ps ae
+	end
+
+	length 104
+	piece as 2*sp 25*ps ae
+	end
+
+	length 105
+	piece as 2*sp 25*ps sp ae
+	end
+
+	length 106
+	piece as 2*sp 25*ps 2*sp ae
+	end
+
+	length 107
+	piece as sp 26*ps ae
+	end
+
+	length 108
+	piece as 2*sp 26*ps ae
+	end
+
+	length 109
+	piece as 2*sp 26*ps sp ae
+	end
+
+	length 110
+	piece as 2*sp 26*ps 2*sp ae
+	end
+
+	length 111
+	piece as sp 27*ps ae
+	end
+
+	length 112
+	piece as 2*sp 27*ps ae
+	end
+
+	length 113
+	piece as 2*sp 27*ps sp ae
+	end
+
+	length 114
+	piece as 2*sp 27*ps 2*sp ae
+	end
+
+	length 115
+	piece as sp 28*ps ae
+	end
+
+	length 116
+	piece as 2*sp 28*ps ae
+	end
+
+	length 117
+	piece as 2*sp 28*ps sp ae
+	end
+
+	length 118
+	piece as 2*sp 28*ps 2*sp ae
+	end
+
+	length 119
+	piece as sp 29*ps ae
+	end
+
+	length 120
+	piece as 2*sp 29*ps ae
+	end
+
+	length 121
+	piece as 2*sp 29*ps sp ae
+	end
+
+	length 122
+	piece as 2*sp 29*ps 2*sp ae
+	end
+
+	length 123
+	piece as sp 30*ps ae
+	end
+
+	length 124
+	piece as 2*sp 30*ps ae
+	end
+
+	length 125
+	piece as 2*sp 30*ps sp ae
+	end
+
+	length 126
+	piece as 2*sp 30*ps 2*sp ae
+	end
+
+	length 127
+	piece as sp 31*ps ae
+	end
+
+	length 128
+	piece as 2*sp 31*ps ae
+	end
+
+	length 129
+	piece as 2*sp 31*ps sp ae
+	end
+
+	length 130
+	piece as 2*sp 31*ps 2*sp ae
+	end
+
+	length 131
+	piece as sp 32*ps ae
+	end
+
+	length 132
+	piece as 2*sp 32*ps ae
+	end
+
+	length 133
+	piece as 2*sp 32*ps sp ae
+	end
+
+	length 134
+	piece as 2*sp 32*ps 2*sp ae
+	end
+
+	length 135
+	piece as sp 33*ps ae
+	end
+
+	length 136
+	piece as 2*sp 33*ps ae
+	end
+
+	length 137
+	piece as 2*sp 33*ps sp ae
+	end
+
+	length 138
+	piece as 2*sp 33*ps 2*sp ae
+	end
+
+	length 139
+	piece as sp 34*ps ae
+	end
+
+	length 140
+	piece as 2*sp 34*ps ae
+	end
+
+	length 141
+	piece as 2*sp 34*ps sp ae
+	end
+
+	length 142
+	piece as 2*sp 34*ps 2*sp ae
+	end
+
+	length 143
+	piece as sp 35*ps ae
+	end
+
+	length 144
+	piece as 2*sp 35*ps ae
+	end
+
+	length 145
+	piece as 2*sp 35*ps sp ae
+	end
+
+	length 146
+	piece as 2*sp 35*ps 2*sp ae
+	end
+
+	length 147
+	piece as sp 36*ps ae
+	end
+
+	length 148
+	piece as 2*sp 36*ps ae
+	end
+
+	length 149
+	piece as 2*sp 36*ps sp ae
+	end
+
+	length 150
+	piece as 2*sp 36*ps 2*sp ae
+	end
+
+	length 151
+	piece as sp 37*ps ae
+	end
+
+	length 152
+	piece as 2*sp 37*ps ae
+	end
+
+	length 153
+	piece as 2*sp 37*ps sp ae
+	end
+
+	length 154
+	piece as 2*sp 37*ps 2*sp ae
+	end
+
+	length 155
+	piece as sp 38*ps ae
+	end
+
+	length 156
+	piece as 2*sp 38*ps ae
+	end
+
+	length 157
+	piece as 2*sp 38*ps sp ae
+	end
+
+	length 158
+	piece as 2*sp 38*ps 2*sp ae
+	end
+
+	length 159
+	piece as sp 39*ps ae
+	end
+
+	length 160
+	piece as 2*sp 39*ps ae
+	end
+
+	length 161
+	piece as 2*sp 39*ps sp ae
+	end
+
+	length 162
+	piece as 2*sp 39*ps 2*sp ae
+	end
+
+	length 163
+	piece as sp 40*ps ae
+	end
+
+	length 164
+	piece as 2*sp 40*ps ae
+	end
+
+	length 165
+	piece as 2*sp 40*ps sp ae
+	end
+
+	length 166
+	piece as 2*sp 40*ps 2*sp ae
+	end
+
+	length 167
+	piece as sp 41*ps ae
+	end
+
+	length 168
+	piece as 2*sp 41*ps ae
+	end
+
+	length 169
+	piece as 2*sp 41*ps sp ae
+	end
+
+	length 170
+	piece as 2*sp 41*ps 2*sp ae
+	end
+
+	length 171
+	piece as sp 42*ps ae
+	end
+
+	length 172
+	piece as 2*sp 42*ps ae
+	end
+
+	length 173
+	piece as 2*sp 42*ps sp ae
+	end
+
+	length 174
+	piece as 2*sp 42*ps 2*sp ae
+	end
+
+	length 175
+	piece as sp 43*ps ae
+	end
+
+	length 176
+	piece as 2*sp 43*ps ae
+	end
+
+	length 177
+	piece as 2*sp 43*ps sp ae
+	end
+
+	length 178
+	piece as 2*sp 43*ps 2*sp ae
+	end
+
+	length 179
+	piece as sp 44*ps ae
+	end
+
+	length 180
+
+	piece as 2*sp 44*ps ae
+	end
+
+	length 181
+	piece as 2*sp 44*ps sp ae
+	end
+
+	length 182
+	piece as 2*sp 44*ps 2*sp ae
+	end
+
+	length 183
+	piece as sp 45*ps ae
+	end
+
+	length 184
+	piece as 2*sp 45*ps ae
+	end
+
+	length 185
+	piece as 2*sp 45*ps sp ae
+	end
+
+	length 186
+	piece as 2*sp 45*ps 2*sp ae
+	end
+
+	length 187
+	piece as sp 46*ps ae
+	end
+
+	length 188
+	piece as 2*sp 46*ps ae
+	end
+
+	length 189
+	piece as 2*sp 46*ps sp ae
+	end
+
+	length 190
+	piece as 2*sp 46*ps 2*sp ae
+	end
+
+	length 191
+	piece as sp 47*ps ae
+	end
+
+	length 192
+	piece as 2*sp 47*ps ae
+	end
+
+	length 193
+	piece as 2*sp 47*ps sp ae
+	end
+
+	length 194
+	piece as 2*sp 47*ps 2*sp ae
+	end
+
+	length 195
+	piece as sp 48*ps ae
+	end
+
+	length 196
+	piece as 2*sp 48*ps ae
+	end
+
+	length 197
+	piece as 2*sp 48*ps sp ae
+	end
+
+	length 198
+	piece as 2*sp 48*ps 2*sp ae
+	end
+
+	length 199
+	piece as sp 49*ps ae
+	end
+
+	length 200
+	piece as 2*sp 49*ps ae
+	end
+
+	length 201
+	piece as 2*sp 49*ps sp ae
+	end
+
+	length 202
+	piece as 2*sp 49*ps 2*sp ae
+	end
+
+	length 203
+	piece as sp 50*ps ae
+	end
+
+	length 204
+	piece as 2*sp 50*ps ae
+	end
+
+	length 205
+	piece as 2*sp 50*ps sp ae
+	end
+
+	length 206
+	piece as 2*sp 50*ps 2*sp ae
+	end
+
+	length 207
+	piece as sp 51*ps ae
+	end
+
+	length 208
+	piece as 2*sp 51*ps ae
+	end
+
+	length 209
+	piece as 2*sp 51*ps sp ae
+	end
+
+	length 210
+	piece as 2*sp 51*ps 2*sp ae
+	end
+
+	length 211
+	piece as sp 52*ps ae
+	end
+
+	length 212
+	piece as 2*sp 52*ps ae
+	end
+
+	length 213
+	piece as 2*sp 52*ps sp ae
+	end
+
+	length 214
+	piece as 2*sp 52*ps 2*sp ae
+	end
+
+	length 215
+	piece as sp 53*ps ae
+	end
+
+	length 216
+	piece as 2*sp 53*ps ae
+	end
+
+	length 217
+	piece as 2*sp 53*ps sp ae
+	end
+
+	length 218
+	piece as 2*sp 53*ps 2*sp ae
+	end
+
+	length 219
+	piece as sp 54*ps ae
+	end
+
+	length 220
+	piece as 2*sp 54*ps ae
+	end
+
+	length 221
+	piece as 2*sp 54*ps sp ae
+	end
+
+	length 222
+	piece as 2*sp 54*ps 2*sp ae
+	end
+
+	length 223
+	piece as sp 55*ps ae
+	end
+
+	length 224
+	piece as 2*sp 55*ps ae
+	end
+
+	length 225
+	piece as 2*sp 55*ps sp ae
+	end
+
+	length 226
+	piece as 2*sp 55*ps 2*sp ae
+	end
+
+	length 227
+	piece as sp 56*ps ae
+	end
+
+	length 228
+	piece as 2*sp 56*ps ae
+	end
+
+	length 229
+	piece as 2*sp 56*ps sp ae
+	end
+
+	length 230
+	piece as 2*sp 56*ps 2*sp ae
+	end
+
+	length 231
+	piece as sp 57*ps ae
+	end
+
+	length 232
+	piece as 2*sp 57*ps ae
+	end
+
+	length 233
+	piece as 2*sp 57*ps sp ae
+	end
+
+	length 234
+	piece as 2*sp 57*ps 2*sp ae
+	end
+
+	length 235
+	piece as sp 58*ps ae
+	end
+
+	length 236
+	piece as 2*sp 58*ps ae
+	end
+
+	length 237
+	piece as 2*sp 58*ps sp ae
+	end
+
+	length 238
+	piece as 2*sp 58*ps 2*sp ae
+	end
+
+	length 239
+	piece as sp 59*ps ae
+	end
+
+	length 240
+	piece as 2*sp 59*ps ae
+	end
+
+	length 241
+	piece as 2*sp 59*ps sp ae
+	end
+
+	length 242
+	piece as 2*sp 59*ps 2*sp ae
+	end
+
+	length 243
+	piece as sp 60*ps ae
+	end
+
+	length 244
+	piece as 2*sp 60*ps ae
+	end
+
+	length 245
+	piece as 2*sp 60*ps sp ae
+	end
+
+	length 246
+	piece as 2*sp 60*ps 2*sp ae
+	end
+
+	length 247
+	piece as sp 61*ps ae
+	end
+
+	length 248
+	piece as 2*sp 61*ps ae
+	end
+
+	length 249
+	piece as 2*sp 61*ps sp ae
+	end
+
+	length 250
+	piece as 2*sp 61*ps 2*sp ae
+	end
+
+	length 251
+	piece as sp 62*ps ae
+	end
+
+	length 252
+	piece as 2*sp 62*ps ae
+	end
+
+	length 253
+	piece as 2*sp 62*ps sp ae
+	end
+
+	length 254
+	piece as 2*sp 62*ps 2*sp ae
+	end
+end
+
+
 # Red Under Deck Truss Arch (OWR-2) by IDS2 (10/23)
 
 bridge 18
@@ -8362,4 +10430,1888 @@ end
 	length 254
 	piece sp pi sp ep 18*mp rev(ep) rev(sp) rev(pi) rev(sp)
 	end
+end
+
+
+# Blue Suspension (OWR-2) by IDS2 (03/2024)
+
+bridge 22
+
+# abutment - 1 tile
+section ab
+	piece <0x40640000, 0>
+end
+
+# girder - 1 tile
+section gi
+	piece <0x40641000, 0>
+end
+
+# pillar - 1 tile
+section pi
+	piece <0x40642000, 0>
+end
+
+# girder pillar - 4 tiles
+section gp
+	piece <0x40642000, 0>
+	piece <0x40641000, 0>
+	piece <0x40641000, 0>
+	piece <0x40641000, 0>
+end
+
+# middle tower - 25 tiles
+section mt
+	piece <0x40645000, 0>
+	piece <0x40645000, 0>
+	piece <0x40645000, 0>
+	piece <0x40645000, 0>
+	piece <0x40645000, 0>
+	piece <0x40645000, 0>
+	piece <0x40645000, 0>
+	piece <0x40645000, 0>
+	piece <0x40645000, 0>
+	piece <0x40645000, 0>
+	piece <0x40647000, 0>
+	piece <0x40647000, 0>
+	piece <0x40646000, 0>
+	piece <0x40647000, 0>
+	piece <0x40647000, 0>
+	piece <0x40645000, 0>
+	piece <0x40645000, 0>
+	piece <0x40645000, 0>
+	piece <0x40645000, 0>
+	piece <0x40645000, 0>
+	piece <0x40645000, 0>
+	piece <0x40645000, 0>
+	piece <0x40645000, 0>
+	piece <0x40645000, 0>
+	piece <0x40645000, 0>
+end
+
+# end tower - 19 tiles
+section et
+	piece <0x40643000, 0>
+	piece <0x40641000, 0>
+	piece <0x40642000, 0>
+	piece <0x40641000, 0>
+	piece <0x40647000, 0>
+	piece <0x40647000, 0>
+	piece <0x40644000, 0>
+	piece <0x40647000, 0>
+	piece <0x40647000, 0>
+	piece <0x40645000, 0>
+	piece <0x40645000, 0>
+	piece <0x40645000, 0>
+	piece <0x40645000, 0>
+	piece <0x40645000, 0>
+	piece <0x40645000, 0>
+	piece <0x40645000, 0>
+	piece <0x40645000, 0>
+	piece <0x40645000, 0>
+	piece <0x40645000, 0>
+end 
+
+	length 40
+	piece ab et rev(et) rev(ab)
+	end
+
+	length 41
+	piece ab gi et rev(et) rev(ab)
+	end
+	
+	length 42
+	piece ab gi et rev(et) rev(gi) rev(ab)
+	end
+	
+	length 43
+	piece ab pi gi et rev(et) rev(gi) rev(ab)
+	end
+	
+	length 44
+	piece ab pi gi et rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 45
+	piece ab gi pi gi et rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 46
+	piece ab gi pi gi et rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 47
+	piece ab 2*gi pi gi et rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 48
+	piece ab 2*gi pi gi et rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 49
+	piece ab 3*gi pi gi et rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 50
+	piece ab 3*gi pi gi et rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 51
+	piece ab gp pi gi et rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 52
+	piece ab gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 53
+	piece ab gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 54
+	piece ab gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 55
+	piece ab 2*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 56
+	piece ab 2*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 57
+	piece ab 3*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 58
+	piece ab 3*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 59
+	piece ab 2*gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 60
+	piece ab 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 61
+	piece ab gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 62
+	piece ab gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 63
+	piece ab 2*gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 64
+	piece ab 2*gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+
+	length 65
+	piece ab et mt rev(et) rev(ab)
+	end
+	
+	length 66
+	piece ab gi et mt rev(et) rev(ab)
+	end
+	
+	length 67
+	piece ab gi et mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 68
+	piece ab pi gi et mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 69
+	piece ab pi gi et mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 70
+	piece ab gi pi gi et mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 71
+	piece ab gi pi gi et mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 72
+	piece ab 2*gi pi gi et mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 73
+	piece ab 2*gi pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 74
+	piece ab 3*gi pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 75
+	piece ab 3*gi pi gi et mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 76
+	piece ab gp pi gi et mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 77
+	piece ab gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 78
+	piece ab gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 79
+	piece ab gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 80
+	piece ab 2*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 81
+	piece ab 2*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 82
+	piece ab 3*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 83
+	piece ab 3*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 84
+	piece ab 2*gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 85
+	piece ab 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 86
+	piece ab gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 87
+	piece ab gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 88
+	piece ab 2*gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 89
+	piece ab 2*gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 90
+	piece ab et 2*mt rev(et) rev(ab)
+	end
+	
+	length 91
+	piece ab gi et 2*mt rev(et) rev(ab)
+	end
+	
+	length 92
+	piece ab gi et 2*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 93
+	piece ab pi gi et 2*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 94
+	piece ab pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 95
+	piece ab gi pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 96
+	piece ab gi pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 97
+	piece ab 2*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 98
+	piece ab 2*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 99
+	piece ab 3*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 100
+	piece ab 3*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 101
+	piece ab gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 102
+	piece ab gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 103
+	piece ab gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 104
+	piece ab gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 105
+	piece ab 2*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 106
+	piece ab 2*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 107
+	piece ab 3*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 108
+	piece ab 3*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 109
+	piece ab 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 110
+	piece ab 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 111
+	piece ab gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 112
+	piece ab gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 113
+	piece ab 2*gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 114
+	piece ab 2*gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 115
+	piece ab et 3*mt rev(et) rev(ab)
+	end
+	
+	length 116
+	piece ab gi et 3*mt rev(et) rev(ab)
+	end
+	
+	length 117
+	piece ab gi et 3*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 118
+	piece ab pi gi et 3*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 119
+	piece ab pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 120
+	piece ab gi pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 121
+	piece ab gi pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 122
+	piece ab 2*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 123
+	piece ab 2*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 124
+	piece ab 3*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 125
+	piece ab 3*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 126
+	piece ab gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 127
+	piece ab gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 128
+	piece ab gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 129
+	piece ab gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 130
+	piece ab 2*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 131
+	piece ab 2*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 132
+	piece ab 3*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 133
+	piece ab 3*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 134
+	piece ab 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 135
+	piece ab 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 136
+	piece ab gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 137
+	piece ab gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 138
+	piece ab 2*gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 139
+	piece ab 2*gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 140
+	piece ab et 4*mt rev(et) rev(ab)
+	end
+	
+	length 141
+	piece ab gi et 4*mt rev(et) rev(ab)
+	end
+	
+	length 142
+	piece ab gi et 4*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 143
+	piece ab pi gi et 4*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 144
+	piece ab pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 145
+	piece ab gi pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 146
+	piece ab gi pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 147
+	piece ab 2*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 148
+	piece ab 2*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 149
+	piece ab 3*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 150
+	piece ab 3*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 151
+	piece ab gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 152
+	piece ab gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 153
+	piece ab gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 154
+	piece ab gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 155
+	piece ab 2*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 156
+	piece ab 2*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 157
+	piece ab 3*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 158
+	piece ab 3*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 159
+	piece ab 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 160
+	piece ab 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 161
+	piece ab gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 162
+	piece ab gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 163
+	piece ab 2*gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 164
+	piece ab 2*gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 165
+	piece ab et 5*mt rev(et) rev(ab)
+	end
+	
+	length 166
+	piece ab gi et 5*mt rev(et) rev(ab)
+	end
+	
+	length 167
+	piece ab gi et 5*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 168
+	piece ab pi gi et 5*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 169
+	piece ab pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 170
+	piece ab gi pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 171
+	piece ab gi pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 172
+	piece ab 2*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 173
+	piece ab 2*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 174
+	piece ab 3*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 175
+	piece ab 3*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 176
+	piece ab gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 177
+	piece ab gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 178
+	piece ab gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 179
+	piece ab gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 180
+	piece ab 2*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 181
+	piece ab 2*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 182
+	piece ab 3*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 183
+	piece ab 3*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 184
+	piece ab 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 185
+	piece ab 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 186
+	piece ab gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 187
+	piece ab gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 188
+	piece ab 2*gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 189
+	piece ab 2*gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 190
+	piece ab et 6*mt rev(et) rev(ab)
+	end
+	
+	length 191
+	piece ab gi et 6*mt rev(et) rev(ab)
+	end
+	
+	length 192
+	piece ab gi et 6*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 193
+	piece ab pi gi et 6*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 194
+	piece ab pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 195
+	piece ab gi pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 196
+	piece ab gi pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 197
+	piece ab 2*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 198
+	piece ab 2*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 199
+	piece ab 3*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 200
+	piece ab 3*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 201
+	piece ab gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 202
+	piece ab gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 203
+	piece ab gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 204
+	piece ab gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 205
+	piece ab 2*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 206
+	piece ab 2*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 207
+	piece ab 3*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 208
+	piece ab 3*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 209
+	piece ab 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 210
+	piece ab 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 211
+	piece ab gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 212
+	piece ab gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 213
+	piece ab 2*gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 214
+	piece ab 2*gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 215
+	piece ab et 7*mt rev(et) rev(ab)
+	end
+	
+	length 216
+	piece ab gi et 7*mt rev(et) rev(ab)
+	end
+	
+	length 217
+	piece ab gi et 7*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 218
+	piece ab pi gi et 7*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 219
+	piece ab pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 220
+	piece ab gi pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 221
+	piece ab gi pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 222
+	piece ab 2*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 223
+	piece ab 2*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 224
+	piece ab 3*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 225
+	piece ab 3*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 226
+	piece ab gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 227
+	piece ab gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 228
+	piece ab gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 229
+	piece ab gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 230
+	piece ab 2*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 231
+	piece ab 2*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 232
+	piece ab 3*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 233
+	piece ab 3*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 234
+	piece ab 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 235
+	piece ab 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 236
+	piece ab gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 237
+	piece ab gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 238
+	piece ab 2*gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 239
+	piece ab 2*gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 240
+	piece ab et 8*mt rev(et) rev(ab)
+	end
+
+	length 241
+	piece ab gi et 8*mt rev(et) rev(ab)
+	end
+	
+	length 242
+	piece ab gi et 8*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 243
+	piece ab pi gi et 8*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 244
+	piece ab pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 245
+	piece ab gi pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 246
+	piece ab gi pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 247
+	piece ab 2*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 248
+	piece ab 2*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 249
+	piece ab 3*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 250
+	piece ab 3*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 251
+	piece ab gp pi gi et 8*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 252
+	piece ab gp pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 253
+	piece ab gi gp pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 254
+	piece ab gi gp pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+end
+
+
+# Blue Suspension (OWR-3) by IDS2 (03/2024)
+
+bridge 23
+
+# abutment - 1 tile
+section ab
+	piece <0x40650000, 0>
+end
+
+# girder - 1 tile
+section gi
+	piece <0x40651000, 0>
+end
+
+# pillar - 1 tile
+section pi
+	piece <0x40652000, 0>
+end
+
+# girder pillar - 4 tiles
+section gp
+	piece <0x40652000, 0>
+	piece <0x40651000, 0>
+	piece <0x40651000, 0>
+	piece <0x40651000, 0>
+end
+
+# middle tower - 25 tiles
+section mt
+	piece <0x40655000, 0>
+	piece <0x40655000, 0>
+	piece <0x40655000, 0>
+	piece <0x40655000, 0>
+	piece <0x40655000, 0>
+	piece <0x40655000, 0>
+	piece <0x40655000, 0>
+	piece <0x40655000, 0>
+	piece <0x40655000, 0>
+	piece <0x40655000, 0>
+	piece <0x40657000, 0>
+	piece <0x40657000, 0>
+	piece <0x40656000, 0>
+	piece <0x40657000, 0>
+	piece <0x40657000, 0>
+	piece <0x40655000, 0>
+	piece <0x40655000, 0>
+	piece <0x40655000, 0>
+	piece <0x40655000, 0>
+	piece <0x40655000, 0>
+	piece <0x40655000, 0>
+	piece <0x40655000, 0>
+	piece <0x40655000, 0>
+	piece <0x40655000, 0>
+	piece <0x40655000, 0>
+end
+
+# end tower - 19 tiles
+section et
+	piece <0x40653000, 0>
+	piece <0x40651000, 0>
+	piece <0x40652000, 0>
+	piece <0x40651000, 0>
+	piece <0x40657000, 0>
+	piece <0x40657000, 0>
+	piece <0x40654000, 0>
+	piece <0x40657000, 0>
+	piece <0x40657000, 0>
+	piece <0x40655000, 0>
+	piece <0x40655000, 0>
+	piece <0x40655000, 0>
+	piece <0x40655000, 0>
+	piece <0x40655000, 0>
+	piece <0x40655000, 0>
+	piece <0x40655000, 0>
+	piece <0x40655000, 0>
+	piece <0x40655000, 0>
+	piece <0x40655000, 0>
+end 
+
+	length 40
+	piece ab et rev(et) rev(ab)
+	end
+
+	length 41
+	piece ab gi et rev(et) rev(ab)
+	end
+	
+	length 42
+	piece ab gi et rev(et) rev(gi) rev(ab)
+	end
+	
+	length 43
+	piece ab pi gi et rev(et) rev(gi) rev(ab)
+	end
+	
+	length 44
+	piece ab pi gi et rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 45
+	piece ab gi pi gi et rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 46
+	piece ab gi pi gi et rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 47
+	piece ab 2*gi pi gi et rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 48
+	piece ab 2*gi pi gi et rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 49
+	piece ab 3*gi pi gi et rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 50
+	piece ab 3*gi pi gi et rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 51
+	piece ab gp pi gi et rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 52
+	piece ab gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 53
+	piece ab gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 54
+	piece ab gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 55
+	piece ab 2*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 56
+	piece ab 2*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 57
+	piece ab 3*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 58
+	piece ab 3*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 59
+	piece ab 2*gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 60
+	piece ab 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 61
+	piece ab gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 62
+	piece ab gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 63
+	piece ab 2*gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 64
+	piece ab 2*gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+
+	length 65
+	piece ab et mt rev(et) rev(ab)
+	end
+	
+	length 66
+	piece ab gi et mt rev(et) rev(ab)
+	end
+	
+	length 67
+	piece ab gi et mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 68
+	piece ab pi gi et mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 69
+	piece ab pi gi et mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 70
+	piece ab gi pi gi et mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 71
+	piece ab gi pi gi et mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 72
+	piece ab 2*gi pi gi et mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 73
+	piece ab 2*gi pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 74
+	piece ab 3*gi pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 75
+	piece ab 3*gi pi gi et mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 76
+	piece ab gp pi gi et mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 77
+	piece ab gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 78
+	piece ab gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 79
+	piece ab gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 80
+	piece ab 2*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 81
+	piece ab 2*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 82
+	piece ab 3*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 83
+	piece ab 3*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 84
+	piece ab 2*gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 85
+	piece ab 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 86
+	piece ab gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 87
+	piece ab gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 88
+	piece ab 2*gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 89
+	piece ab 2*gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 90
+	piece ab et 2*mt rev(et) rev(ab)
+	end
+	
+	length 91
+	piece ab gi et 2*mt rev(et) rev(ab)
+	end
+	
+	length 92
+	piece ab gi et 2*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 93
+	piece ab pi gi et 2*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 94
+	piece ab pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 95
+	piece ab gi pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 96
+	piece ab gi pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 97
+	piece ab 2*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 98
+	piece ab 2*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 99
+	piece ab 3*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 100
+	piece ab 3*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 101
+	piece ab gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 102
+	piece ab gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 103
+	piece ab gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 104
+	piece ab gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 105
+	piece ab 2*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 106
+	piece ab 2*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 107
+	piece ab 3*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 108
+	piece ab 3*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 109
+	piece ab 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 110
+	piece ab 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 111
+	piece ab gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 112
+	piece ab gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 113
+	piece ab 2*gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 114
+	piece ab 2*gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 115
+	piece ab et 3*mt rev(et) rev(ab)
+	end
+	
+	length 116
+	piece ab gi et 3*mt rev(et) rev(ab)
+	end
+	
+	length 117
+	piece ab gi et 3*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 118
+	piece ab pi gi et 3*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 119
+	piece ab pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 120
+	piece ab gi pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 121
+	piece ab gi pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 122
+	piece ab 2*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 123
+	piece ab 2*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 124
+	piece ab 3*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 125
+	piece ab 3*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 126
+	piece ab gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 127
+	piece ab gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 128
+	piece ab gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 129
+	piece ab gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 130
+	piece ab 2*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 131
+	piece ab 2*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 132
+	piece ab 3*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 133
+	piece ab 3*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 134
+	piece ab 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 135
+	piece ab 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 136
+	piece ab gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 137
+	piece ab gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 138
+	piece ab 2*gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 139
+	piece ab 2*gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 140
+	piece ab et 4*mt rev(et) rev(ab)
+	end
+	
+	length 141
+	piece ab gi et 4*mt rev(et) rev(ab)
+	end
+	
+	length 142
+	piece ab gi et 4*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 143
+	piece ab pi gi et 4*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 144
+	piece ab pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 145
+	piece ab gi pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 146
+	piece ab gi pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 147
+	piece ab 2*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 148
+	piece ab 2*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 149
+	piece ab 3*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 150
+	piece ab 3*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 151
+	piece ab gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 152
+	piece ab gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 153
+	piece ab gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 154
+	piece ab gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 155
+	piece ab 2*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 156
+	piece ab 2*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 157
+	piece ab 3*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 158
+	piece ab 3*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 159
+	piece ab 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 160
+	piece ab 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 161
+	piece ab gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 162
+	piece ab gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 163
+	piece ab 2*gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 164
+	piece ab 2*gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 165
+	piece ab et 5*mt rev(et) rev(ab)
+	end
+	
+	length 166
+	piece ab gi et 5*mt rev(et) rev(ab)
+	end
+	
+	length 167
+	piece ab gi et 5*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 168
+	piece ab pi gi et 5*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 169
+	piece ab pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 170
+	piece ab gi pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 171
+	piece ab gi pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 172
+	piece ab 2*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 173
+	piece ab 2*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 174
+	piece ab 3*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 175
+	piece ab 3*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 176
+	piece ab gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 177
+	piece ab gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 178
+	piece ab gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 179
+	piece ab gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 180
+	piece ab 2*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 181
+	piece ab 2*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 182
+	piece ab 3*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 183
+	piece ab 3*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 184
+	piece ab 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 185
+	piece ab 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 186
+	piece ab gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 187
+	piece ab gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 188
+	piece ab 2*gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 189
+	piece ab 2*gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 190
+	piece ab et 6*mt rev(et) rev(ab)
+	end
+	
+	length 191
+	piece ab gi et 6*mt rev(et) rev(ab)
+	end
+	
+	length 192
+	piece ab gi et 6*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 193
+	piece ab pi gi et 6*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 194
+	piece ab pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 195
+	piece ab gi pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 196
+	piece ab gi pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 197
+	piece ab 2*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 198
+	piece ab 2*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 199
+	piece ab 3*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 200
+	piece ab 3*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 201
+	piece ab gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 202
+	piece ab gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 203
+	piece ab gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 204
+	piece ab gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 205
+	piece ab 2*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 206
+	piece ab 2*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 207
+	piece ab 3*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 208
+	piece ab 3*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 209
+	piece ab 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 210
+	piece ab 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 211
+	piece ab gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 212
+	piece ab gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 213
+	piece ab 2*gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 214
+	piece ab 2*gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 215
+	piece ab et 7*mt rev(et) rev(ab)
+	end
+	
+	length 216
+	piece ab gi et 7*mt rev(et) rev(ab)
+	end
+	
+	length 217
+	piece ab gi et 7*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 218
+	piece ab pi gi et 7*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 219
+	piece ab pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 220
+	piece ab gi pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 221
+	piece ab gi pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 222
+	piece ab 2*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 223
+	piece ab 2*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 224
+	piece ab 3*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 225
+	piece ab 3*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 226
+	piece ab gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 227
+	piece ab gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 228
+	piece ab gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 229
+	piece ab gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 230
+	piece ab 2*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 231
+	piece ab 2*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 232
+	piece ab 3*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 233
+	piece ab 3*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 234
+	piece ab 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 235
+	piece ab 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 236
+	piece ab gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 237
+	piece ab gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 238
+	piece ab 2*gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 239
+	piece ab 2*gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 240
+	piece ab et 8*mt rev(et) rev(ab)
+	end
+
+	length 241
+	piece ab gi et 8*mt rev(et) rev(ab)
+	end
+	
+	length 242
+	piece ab gi et 8*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 243
+	piece ab pi gi et 8*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 244
+	piece ab pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 245
+	piece ab gi pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 246
+	piece ab gi pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 247
+	piece ab 2*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 248
+	piece ab 2*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 249
+	piece ab 3*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 250
+	piece ab 3*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 251
+	piece ab gp pi gi et 8*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 252
+	piece ab gp pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 253
+	piece ab gi gp pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 254
+	piece ab gi gp pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
 end

--- a/Controller/Bridge Controller/0000100b.rul
+++ b/Controller/Bridge Controller/0000100b.rul
@@ -2167,6 +2167,1040 @@ end
 end
 
 
+# Yellow Steel Girder (RHW-2) by IDS2 (09/23)
+
+bridge 35
+
+# abutment start - 1 tile
+section as
+	piece <0x403D0000, 0>
+end 
+
+# pillar section - 3 tiles
+section pi
+	piece <0x403D1000, 0>
+	piece <0x403D2000, 0>
+	piece <0x403D1000, 0>
+end 
+
+# span only - 1 tile
+section sp
+	piece <0x403D3000, 0>
+end 
+
+# combined repeat segment - 4 tiles
+section ps
+	piece pi sp
+end
+
+#abutment end - 1 tile
+section ae
+	piece <0x403D0000, 2>
+end
+
+	length 5
+	piece as 3*sp ae
+	end
+	
+	length 6
+	piece as 4*sp ae
+	end
+	
+	length 7
+	piece as sp ps ae
+	end
+	
+	length 8
+	piece as sp ps sp ae
+	end
+	
+	length 9
+	piece as 2*sp ps sp ae
+	end
+	
+	length 10
+	piece as 2*sp ps 2*sp ae
+	end
+	
+	length 11
+	piece as sp 2*ps ae
+	end
+	
+	length 12
+	piece as 2*sp 2*ps ae
+	end
+	
+	length 13
+	piece as 2*sp 2*ps sp ae
+	end
+	
+	length 14
+	piece as 2*sp ps sp ps sp ae
+	end
+	
+	length 15
+	piece as sp 3*ps ae
+	end
+	
+	length 16
+	piece as 2*sp 3*ps ae
+	end
+	
+	length 17
+	piece as 2*sp 3*ps sp ae
+	end
+	
+	length 18
+	piece as 2*sp 3*ps 2*sp ae
+	end
+	
+	length 19
+	piece as sp 4*ps ae
+	end
+	
+	length 20
+	piece as 2*sp 4*ps ae
+	end
+	
+	length 21
+	piece as 2*sp 4*ps sp ae
+	end
+	
+	length 22
+	piece as 2*sp 4*ps 2*sp ae
+	end
+	
+	length 23
+	piece as sp 5*ps ae
+	end
+
+	length 24
+	piece as 2*sp 5*ps ae
+	end
+
+	length 25
+	piece as 2*sp 5*ps sp ae
+	end
+
+	length 26
+	piece as 2*sp 5*ps 2*sp ae
+	end
+
+	length 27
+	piece as sp 6*ps ae
+	end
+
+	length 28
+	piece as 2*sp 6*ps ae
+	end
+
+	length 29
+	piece as 2*sp 6*ps sp ae
+	end
+
+	length 30
+	piece as 2*sp 6*ps 2*sp ae
+	end
+
+	length 31
+	piece as sp 7*ps ae
+	end
+
+	length 32
+	piece as 2*sp 7*ps ae
+	end
+
+	length 33
+	piece as 2*sp 7*ps sp ae
+	end
+
+	length 34
+	piece as 2*sp 7*ps 2*sp ae
+	end
+
+	length 35
+	piece as sp 8*ps ae
+	end
+
+	length 36
+	piece as 2*sp 8*ps ae
+	end
+
+	length 37
+	piece as 2*sp 8*ps sp ae
+	end
+
+	length 38
+	piece as 2*sp 8*ps 2*sp ae
+	end
+
+	length 39
+	piece as sp 9*ps ae
+	end
+
+	length 40
+	piece as 2*sp 9*ps ae
+	end
+
+	length 41
+	piece as 2*sp 9*ps sp ae
+	end
+
+	length 42
+	piece as 2*sp 9*ps 2*sp ae
+	end
+
+	length 43
+	piece as sp 10*ps ae
+	end
+
+	length 44
+	piece as 2*sp 10*ps ae
+	end
+
+	length 45
+	piece as 2*sp 10*ps sp ae
+	end
+
+	length 46
+	piece as 2*sp 10*ps 2*sp ae
+	end
+
+	length 47
+	piece as sp 11*ps ae
+	end
+
+	length 48
+	piece as 2*sp 11*ps ae
+	end
+
+	length 49
+	piece as 2*sp 11*ps sp ae
+	end
+
+	length 50
+	piece as 2*sp 11*ps 2*sp ae
+	end
+
+	length 51
+	piece as sp 12*ps ae
+	end
+
+	length 52
+	piece as 2*sp 12*ps ae
+	end
+
+	length 53
+	piece as 2*sp 12*ps sp ae
+	end
+
+	length 54
+	piece as 2*sp 12*ps 2*sp ae
+	end
+
+	length 55
+	piece as sp 13*ps ae
+	end
+
+	length 56
+	piece as 2*sp 13*ps ae
+	end
+
+	length 57
+	piece as 2*sp 13*ps sp ae
+	end
+
+	length 58
+	piece as 2*sp 13*ps 2*sp ae
+	end
+
+	length 59
+	piece as sp 14*ps ae
+	end
+
+	length 60
+	piece as 2*sp 14*ps ae
+	end
+
+	length 61
+	piece as 2*sp 14*ps sp ae
+	end
+
+	length 62
+	piece as 2*sp 14*ps 2*sp ae
+	end
+
+	length 63
+	piece as sp 15*ps ae
+	end
+
+	length 64
+	piece as 2*sp 15*ps ae
+	end
+
+	length 65
+	piece as 2*sp 15*ps sp ae
+	end
+
+	length 66
+	piece as 2*sp 15*ps 2*sp ae
+	end
+
+	length 67
+	piece as sp 16*ps ae
+	end
+
+	length 68
+	piece as 2*sp 16*ps ae
+	end
+
+	length 69
+	piece as 2*sp 16*ps sp ae
+	end
+
+	length 70
+	piece as 2*sp 16*ps 2*sp ae
+	end
+
+	length 71
+	piece as sp 17*ps ae
+	end
+
+	length 72
+	piece as 2*sp 17*ps ae
+	end
+
+	length 73
+	piece as 2*sp 17*ps sp ae
+	end
+
+	length 74
+	piece as 2*sp 17*ps 2*sp ae
+	end
+
+	length 75
+	piece as sp 18*ps ae
+	end
+
+	length 76
+	piece as 2*sp 18*ps ae
+	end
+
+	length 77
+	piece as 2*sp 18*ps sp ae
+	end
+
+	length 78
+	piece as 2*sp 18*ps 2*sp ae
+	end
+
+	length 79
+	piece as sp 19*ps ae
+	end
+
+	length 80
+	piece as 2*sp 19*ps ae
+	end
+
+	length 81
+	piece as 2*sp 19*ps sp ae
+	end
+
+	length 82
+	piece as 2*sp 19*ps 2*sp ae
+	end
+
+	length 83
+	piece as sp 20*ps ae
+	end
+
+	length 84
+	piece as 2*sp 20*ps ae
+	end
+
+	length 85
+	piece as 2*sp 20*ps sp ae
+	end
+
+	length 86
+	piece as 2*sp 20*ps 2*sp ae
+	end
+
+	length 87
+	piece as sp 21*ps ae
+	end
+
+	length 88
+	piece as 2*sp 21*ps ae
+	end
+
+	length 89
+	piece as 2*sp 21*ps sp ae
+	end
+
+	length 90
+	piece as 2*sp 21*ps 2*sp ae
+	end
+
+	length 91
+	piece as sp 22*ps ae
+	end
+
+	length 92
+	piece as 2*sp 22*ps ae
+	end
+
+	length 93
+	piece as 2*sp 22*ps sp ae
+	end
+
+	length 94
+	piece as 2*sp 22*ps 2*sp ae
+	end
+
+	length 95
+	piece as sp 23*ps ae
+	end
+
+	length 96
+	piece as 2*sp 23*ps ae
+	end
+
+	length 97
+	piece as 2*sp 23*ps sp ae
+	end
+
+	length 98
+	piece as 2*sp 23*ps 2*sp ae
+	end
+
+	length 99
+	piece as sp 24*ps ae
+	end
+
+	length 100
+	piece as 2*sp 24*ps ae
+	end
+
+	length 101
+	piece as 2*sp 24*ps sp ae
+	end
+
+	length 102
+	piece as 2*sp 24*ps 2*sp ae
+	end
+
+	length 103
+	piece as sp 25*ps ae
+	end
+
+	length 104
+	piece as 2*sp 25*ps ae
+	end
+
+	length 105
+	piece as 2*sp 25*ps sp ae
+	end
+
+	length 106
+	piece as 2*sp 25*ps 2*sp ae
+	end
+
+	length 107
+	piece as sp 26*ps ae
+	end
+
+	length 108
+	piece as 2*sp 26*ps ae
+	end
+
+	length 109
+	piece as 2*sp 26*ps sp ae
+	end
+
+	length 110
+	piece as 2*sp 26*ps 2*sp ae
+	end
+
+	length 111
+	piece as sp 27*ps ae
+	end
+
+	length 112
+	piece as 2*sp 27*ps ae
+	end
+
+	length 113
+	piece as 2*sp 27*ps sp ae
+	end
+
+	length 114
+	piece as 2*sp 27*ps 2*sp ae
+	end
+
+	length 115
+	piece as sp 28*ps ae
+	end
+
+	length 116
+	piece as 2*sp 28*ps ae
+	end
+
+	length 117
+	piece as 2*sp 28*ps sp ae
+	end
+
+	length 118
+	piece as 2*sp 28*ps 2*sp ae
+	end
+
+	length 119
+	piece as sp 29*ps ae
+	end
+
+	length 120
+	piece as 2*sp 29*ps ae
+	end
+
+	length 121
+	piece as 2*sp 29*ps sp ae
+	end
+
+	length 122
+	piece as 2*sp 29*ps 2*sp ae
+	end
+
+	length 123
+	piece as sp 30*ps ae
+	end
+
+	length 124
+	piece as 2*sp 30*ps ae
+	end
+
+	length 125
+	piece as 2*sp 30*ps sp ae
+	end
+
+	length 126
+	piece as 2*sp 30*ps 2*sp ae
+	end
+
+	length 127
+	piece as sp 31*ps ae
+	end
+
+	length 128
+	piece as 2*sp 31*ps ae
+	end
+
+	length 129
+	piece as 2*sp 31*ps sp ae
+	end
+
+	length 130
+	piece as 2*sp 31*ps 2*sp ae
+	end
+
+	length 131
+	piece as sp 32*ps ae
+	end
+
+	length 132
+	piece as 2*sp 32*ps ae
+	end
+
+	length 133
+	piece as 2*sp 32*ps sp ae
+	end
+
+	length 134
+	piece as 2*sp 32*ps 2*sp ae
+	end
+
+	length 135
+	piece as sp 33*ps ae
+	end
+
+	length 136
+	piece as 2*sp 33*ps ae
+	end
+
+	length 137
+	piece as 2*sp 33*ps sp ae
+	end
+
+	length 138
+	piece as 2*sp 33*ps 2*sp ae
+	end
+
+	length 139
+	piece as sp 34*ps ae
+	end
+
+	length 140
+	piece as 2*sp 34*ps ae
+	end
+
+	length 141
+	piece as 2*sp 34*ps sp ae
+	end
+
+	length 142
+	piece as 2*sp 34*ps 2*sp ae
+	end
+
+	length 143
+	piece as sp 35*ps ae
+	end
+
+	length 144
+	piece as 2*sp 35*ps ae
+	end
+
+	length 145
+	piece as 2*sp 35*ps sp ae
+	end
+
+	length 146
+	piece as 2*sp 35*ps 2*sp ae
+	end
+
+	length 147
+	piece as sp 36*ps ae
+	end
+
+	length 148
+	piece as 2*sp 36*ps ae
+	end
+
+	length 149
+	piece as 2*sp 36*ps sp ae
+	end
+
+	length 150
+	piece as 2*sp 36*ps 2*sp ae
+	end
+
+	length 151
+	piece as sp 37*ps ae
+	end
+
+	length 152
+	piece as 2*sp 37*ps ae
+	end
+
+	length 153
+	piece as 2*sp 37*ps sp ae
+	end
+
+	length 154
+	piece as 2*sp 37*ps 2*sp ae
+	end
+
+	length 155
+	piece as sp 38*ps ae
+	end
+
+	length 156
+	piece as 2*sp 38*ps ae
+	end
+
+	length 157
+	piece as 2*sp 38*ps sp ae
+	end
+
+	length 158
+	piece as 2*sp 38*ps 2*sp ae
+	end
+
+	length 159
+	piece as sp 39*ps ae
+	end
+
+	length 160
+	piece as 2*sp 39*ps ae
+	end
+
+	length 161
+	piece as 2*sp 39*ps sp ae
+	end
+
+	length 162
+	piece as 2*sp 39*ps 2*sp ae
+	end
+
+	length 163
+	piece as sp 40*ps ae
+	end
+
+	length 164
+	piece as 2*sp 40*ps ae
+	end
+
+	length 165
+	piece as 2*sp 40*ps sp ae
+	end
+
+	length 166
+	piece as 2*sp 40*ps 2*sp ae
+	end
+
+	length 167
+	piece as sp 41*ps ae
+	end
+
+	length 168
+	piece as 2*sp 41*ps ae
+	end
+
+	length 169
+	piece as 2*sp 41*ps sp ae
+	end
+
+	length 170
+	piece as 2*sp 41*ps 2*sp ae
+	end
+
+	length 171
+	piece as sp 42*ps ae
+	end
+
+	length 172
+	piece as 2*sp 42*ps ae
+	end
+
+	length 173
+	piece as 2*sp 42*ps sp ae
+	end
+
+	length 174
+	piece as 2*sp 42*ps 2*sp ae
+	end
+
+	length 175
+	piece as sp 43*ps ae
+	end
+
+	length 176
+	piece as 2*sp 43*ps ae
+	end
+
+	length 177
+	piece as 2*sp 43*ps sp ae
+	end
+
+	length 178
+	piece as 2*sp 43*ps 2*sp ae
+	end
+
+	length 179
+	piece as sp 44*ps ae
+	end
+
+	length 180
+
+	piece as 2*sp 44*ps ae
+	end
+
+	length 181
+	piece as 2*sp 44*ps sp ae
+	end
+
+	length 182
+	piece as 2*sp 44*ps 2*sp ae
+	end
+
+	length 183
+	piece as sp 45*ps ae
+	end
+
+	length 184
+	piece as 2*sp 45*ps ae
+	end
+
+	length 185
+	piece as 2*sp 45*ps sp ae
+	end
+
+	length 186
+	piece as 2*sp 45*ps 2*sp ae
+	end
+
+	length 187
+	piece as sp 46*ps ae
+	end
+
+	length 188
+	piece as 2*sp 46*ps ae
+	end
+
+	length 189
+	piece as 2*sp 46*ps sp ae
+	end
+
+	length 190
+	piece as 2*sp 46*ps 2*sp ae
+	end
+
+	length 191
+	piece as sp 47*ps ae
+	end
+
+	length 192
+	piece as 2*sp 47*ps ae
+	end
+
+	length 193
+	piece as 2*sp 47*ps sp ae
+	end
+
+	length 194
+	piece as 2*sp 47*ps 2*sp ae
+	end
+
+	length 195
+	piece as sp 48*ps ae
+	end
+
+	length 196
+	piece as 2*sp 48*ps ae
+	end
+
+	length 197
+	piece as 2*sp 48*ps sp ae
+	end
+
+	length 198
+	piece as 2*sp 48*ps 2*sp ae
+	end
+
+	length 199
+	piece as sp 49*ps ae
+	end
+
+	length 200
+	piece as 2*sp 49*ps ae
+	end
+
+	length 201
+	piece as 2*sp 49*ps sp ae
+	end
+
+	length 202
+	piece as 2*sp 49*ps 2*sp ae
+	end
+
+	length 203
+	piece as sp 50*ps ae
+	end
+
+	length 204
+	piece as 2*sp 50*ps ae
+	end
+
+	length 205
+	piece as 2*sp 50*ps sp ae
+	end
+
+	length 206
+	piece as 2*sp 50*ps 2*sp ae
+	end
+
+	length 207
+	piece as sp 51*ps ae
+	end
+
+	length 208
+	piece as 2*sp 51*ps ae
+	end
+
+	length 209
+	piece as 2*sp 51*ps sp ae
+	end
+
+	length 210
+	piece as 2*sp 51*ps 2*sp ae
+	end
+
+	length 211
+	piece as sp 52*ps ae
+	end
+
+	length 212
+	piece as 2*sp 52*ps ae
+	end
+
+	length 213
+	piece as 2*sp 52*ps sp ae
+	end
+
+	length 214
+	piece as 2*sp 52*ps 2*sp ae
+	end
+
+	length 215
+	piece as sp 53*ps ae
+	end
+
+	length 216
+	piece as 2*sp 53*ps ae
+	end
+
+	length 217
+	piece as 2*sp 53*ps sp ae
+	end
+
+	length 218
+	piece as 2*sp 53*ps 2*sp ae
+	end
+
+	length 219
+	piece as sp 54*ps ae
+	end
+
+	length 220
+	piece as 2*sp 54*ps ae
+	end
+
+	length 221
+	piece as 2*sp 54*ps sp ae
+	end
+
+	length 222
+	piece as 2*sp 54*ps 2*sp ae
+	end
+
+	length 223
+	piece as sp 55*ps ae
+	end
+
+	length 224
+	piece as 2*sp 55*ps ae
+	end
+
+	length 225
+	piece as 2*sp 55*ps sp ae
+	end
+
+	length 226
+	piece as 2*sp 55*ps 2*sp ae
+	end
+
+	length 227
+	piece as sp 56*ps ae
+	end
+
+	length 228
+	piece as 2*sp 56*ps ae
+	end
+
+	length 229
+	piece as 2*sp 56*ps sp ae
+	end
+
+	length 230
+	piece as 2*sp 56*ps 2*sp ae
+	end
+
+	length 231
+	piece as sp 57*ps ae
+	end
+
+	length 232
+	piece as 2*sp 57*ps ae
+	end
+
+	length 233
+	piece as 2*sp 57*ps sp ae
+	end
+
+	length 234
+	piece as 2*sp 57*ps 2*sp ae
+	end
+
+	length 235
+	piece as sp 58*ps ae
+	end
+
+	length 236
+	piece as 2*sp 58*ps ae
+	end
+
+	length 237
+	piece as 2*sp 58*ps sp ae
+	end
+
+	length 238
+	piece as 2*sp 58*ps 2*sp ae
+	end
+
+	length 239
+	piece as sp 59*ps ae
+	end
+
+	length 240
+	piece as 2*sp 59*ps ae
+	end
+
+	length 241
+	piece as 2*sp 59*ps sp ae
+	end
+
+	length 242
+	piece as 2*sp 59*ps 2*sp ae
+	end
+
+	length 243
+	piece as sp 60*ps ae
+	end
+
+	length 244
+	piece as 2*sp 60*ps ae
+	end
+
+	length 245
+	piece as 2*sp 60*ps sp ae
+	end
+
+	length 246
+	piece as 2*sp 60*ps 2*sp ae
+	end
+
+	length 247
+	piece as sp 61*ps ae
+	end
+
+	length 248
+	piece as 2*sp 61*ps ae
+	end
+
+	length 249
+	piece as 2*sp 61*ps sp ae
+	end
+
+	length 250
+	piece as 2*sp 61*ps 2*sp ae
+	end
+
+	length 251
+	piece as sp 62*ps ae
+	end
+
+	length 252
+	piece as 2*sp 62*ps ae
+	end
+
+	length 253
+	piece as 2*sp 62*ps sp ae
+	end
+
+	length 254
+	piece as 2*sp 62*ps 2*sp ae
+	end
+end
+
+
 # Yellow Steel Girder (RHW-3) by IDS2 (09/23)
 
 bridge 36
@@ -10268,6 +11302,2926 @@ end
 	length 254
 	piece sp pi sp ep 18*mp epr spr pir spr
 	end
+end
+
+
+# Blue Suspension (RHW-2) by IDS2 (03/2024)
+
+bridge 44
+
+# abutment - 1 tile
+section ab
+	piece <0x40660000, 0>
+end
+
+# girder - 1 tile
+section gi
+	piece <0x40661000, 0>
+end
+
+# pillar - 1 tile
+section pi
+	piece <0x40662000, 0>
+end
+
+# girder pillar - 4 tiles
+section gp
+	piece <0x40662000, 0>
+	piece <0x40661000, 0>
+	piece <0x40661000, 0>
+	piece <0x40661000, 0>
+end
+
+# middle tower - 25 tiles
+section mt
+	piece <0x40665000, 0>
+	piece <0x40665000, 0>
+	piece <0x40665000, 0>
+	piece <0x40665000, 0>
+	piece <0x40665000, 0>
+	piece <0x40665000, 0>
+	piece <0x40665000, 0>
+	piece <0x40665000, 0>
+	piece <0x40665000, 0>
+	piece <0x40665000, 0>
+	piece <0x40667000, 0>
+	piece <0x40667000, 0>
+	piece <0x40666000, 0>
+	piece <0x40667000, 0>
+	piece <0x40667000, 0>
+	piece <0x40665000, 0>
+	piece <0x40665000, 0>
+	piece <0x40665000, 0>
+	piece <0x40665000, 0>
+	piece <0x40665000, 0>
+	piece <0x40665000, 0>
+	piece <0x40665000, 0>
+	piece <0x40665000, 0>
+	piece <0x40665000, 0>
+	piece <0x40665000, 0>
+end
+
+# end tower - 19 tiles
+section et
+	piece <0x40663000, 0>
+	piece <0x40661000, 0>
+	piece <0x40662000, 0>
+	piece <0x40661000, 0>
+	piece <0x40667000, 0>
+	piece <0x40667000, 0>
+	piece <0x40664000, 0>
+	piece <0x40667000, 0>
+	piece <0x40667000, 0>
+	piece <0x40665000, 0>
+	piece <0x40665000, 0>
+	piece <0x40665000, 0>
+	piece <0x40665000, 0>
+	piece <0x40665000, 0>
+	piece <0x40665000, 0>
+	piece <0x40665000, 0>
+	piece <0x40665000, 0>
+	piece <0x40665000, 0>
+	piece <0x40665000, 0>
+end 
+
+	length 40
+	piece ab et rev(et) rev(ab)
+	end
+
+	length 41
+	piece ab gi et rev(et) rev(ab)
+	end
+	
+	length 42
+	piece ab gi et rev(et) rev(gi) rev(ab)
+	end
+	
+	length 43
+	piece ab pi gi et rev(et) rev(gi) rev(ab)
+	end
+	
+	length 44
+	piece ab pi gi et rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 45
+	piece ab gi pi gi et rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 46
+	piece ab gi pi gi et rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 47
+	piece ab 2*gi pi gi et rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 48
+	piece ab 2*gi pi gi et rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 49
+	piece ab 3*gi pi gi et rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 50
+	piece ab 3*gi pi gi et rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 51
+	piece ab gp pi gi et rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 52
+	piece ab gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 53
+	piece ab gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 54
+	piece ab gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 55
+	piece ab 2*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 56
+	piece ab 2*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 57
+	piece ab 3*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 58
+	piece ab 3*gi gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 59
+	piece ab 2*gp pi gi et rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 60
+	piece ab 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 61
+	piece ab gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 62
+	piece ab gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 63
+	piece ab 2*gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 64
+	piece ab 2*gi 2*gp pi gi et rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+
+	length 65
+	piece ab et mt rev(et) rev(ab)
+	end
+	
+	length 66
+	piece ab gi et mt rev(et) rev(ab)
+	end
+	
+	length 67
+	piece ab gi et mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 68
+	piece ab pi gi et mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 69
+	piece ab pi gi et mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 70
+	piece ab gi pi gi et mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 71
+	piece ab gi pi gi et mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 72
+	piece ab 2*gi pi gi et mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 73
+	piece ab 2*gi pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 74
+	piece ab 3*gi pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 75
+	piece ab 3*gi pi gi et mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 76
+	piece ab gp pi gi et mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 77
+	piece ab gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 78
+	piece ab gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 79
+	piece ab gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 80
+	piece ab 2*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 81
+	piece ab 2*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 82
+	piece ab 3*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 83
+	piece ab 3*gi gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 84
+	piece ab 2*gp pi gi et mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 85
+	piece ab 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 86
+	piece ab gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 87
+	piece ab gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 88
+	piece ab 2*gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 89
+	piece ab 2*gi 2*gp pi gi et mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 90
+	piece ab et 2*mt rev(et) rev(ab)
+	end
+	
+	length 91
+	piece ab gi et 2*mt rev(et) rev(ab)
+	end
+	
+	length 92
+	piece ab gi et 2*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 93
+	piece ab pi gi et 2*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 94
+	piece ab pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 95
+	piece ab gi pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 96
+	piece ab gi pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 97
+	piece ab 2*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 98
+	piece ab 2*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 99
+	piece ab 3*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 100
+	piece ab 3*gi pi gi et 2*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 101
+	piece ab gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 102
+	piece ab gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 103
+	piece ab gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 104
+	piece ab gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 105
+	piece ab 2*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 106
+	piece ab 2*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 107
+	piece ab 3*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 108
+	piece ab 3*gi gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 109
+	piece ab 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 110
+	piece ab 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 111
+	piece ab gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 112
+	piece ab gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 113
+	piece ab 2*gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 114
+	piece ab 2*gi 2*gp pi gi et 2*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 115
+	piece ab et 3*mt rev(et) rev(ab)
+	end
+	
+	length 116
+	piece ab gi et 3*mt rev(et) rev(ab)
+	end
+	
+	length 117
+	piece ab gi et 3*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 118
+	piece ab pi gi et 3*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 119
+	piece ab pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 120
+	piece ab gi pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 121
+	piece ab gi pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 122
+	piece ab 2*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 123
+	piece ab 2*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 124
+	piece ab 3*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 125
+	piece ab 3*gi pi gi et 3*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 126
+	piece ab gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 127
+	piece ab gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 128
+	piece ab gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 129
+	piece ab gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 130
+	piece ab 2*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 131
+	piece ab 2*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 132
+	piece ab 3*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 133
+	piece ab 3*gi gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 134
+	piece ab 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 135
+	piece ab 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 136
+	piece ab gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 137
+	piece ab gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 138
+	piece ab 2*gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 139
+	piece ab 2*gi 2*gp pi gi et 3*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 140
+	piece ab et 4*mt rev(et) rev(ab)
+	end
+	
+	length 141
+	piece ab gi et 4*mt rev(et) rev(ab)
+	end
+	
+	length 142
+	piece ab gi et 4*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 143
+	piece ab pi gi et 4*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 144
+	piece ab pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 145
+	piece ab gi pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 146
+	piece ab gi pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 147
+	piece ab 2*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 148
+	piece ab 2*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 149
+	piece ab 3*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 150
+	piece ab 3*gi pi gi et 4*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 151
+	piece ab gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 152
+	piece ab gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 153
+	piece ab gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 154
+	piece ab gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 155
+	piece ab 2*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 156
+	piece ab 2*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 157
+	piece ab 3*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 158
+	piece ab 3*gi gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 159
+	piece ab 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 160
+	piece ab 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 161
+	piece ab gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 162
+	piece ab gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 163
+	piece ab 2*gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 164
+	piece ab 2*gi 2*gp pi gi et 4*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 165
+	piece ab et 5*mt rev(et) rev(ab)
+	end
+	
+	length 166
+	piece ab gi et 5*mt rev(et) rev(ab)
+	end
+	
+	length 167
+	piece ab gi et 5*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 168
+	piece ab pi gi et 5*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 169
+	piece ab pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 170
+	piece ab gi pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 171
+	piece ab gi pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 172
+	piece ab 2*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 173
+	piece ab 2*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 174
+	piece ab 3*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 175
+	piece ab 3*gi pi gi et 5*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 176
+	piece ab gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 177
+	piece ab gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 178
+	piece ab gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 179
+	piece ab gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 180
+	piece ab 2*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 181
+	piece ab 2*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 182
+	piece ab 3*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 183
+	piece ab 3*gi gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 184
+	piece ab 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 185
+	piece ab 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 186
+	piece ab gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 187
+	piece ab gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 188
+	piece ab 2*gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 189
+	piece ab 2*gi 2*gp pi gi et 5*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 190
+	piece ab et 6*mt rev(et) rev(ab)
+	end
+	
+	length 191
+	piece ab gi et 6*mt rev(et) rev(ab)
+	end
+	
+	length 192
+	piece ab gi et 6*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 193
+	piece ab pi gi et 6*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 194
+	piece ab pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 195
+	piece ab gi pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 196
+	piece ab gi pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 197
+	piece ab 2*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 198
+	piece ab 2*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 199
+	piece ab 3*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 200
+	piece ab 3*gi pi gi et 6*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 201
+	piece ab gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 202
+	piece ab gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 203
+	piece ab gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 204
+	piece ab gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 205
+	piece ab 2*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 206
+	piece ab 2*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 207
+	piece ab 3*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 208
+	piece ab 3*gi gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 209
+	piece ab 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 210
+	piece ab 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 211
+	piece ab gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 212
+	piece ab gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 213
+	piece ab 2*gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 214
+	piece ab 2*gi 2*gp pi gi et 6*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 215
+	piece ab et 7*mt rev(et) rev(ab)
+	end
+	
+	length 216
+	piece ab gi et 7*mt rev(et) rev(ab)
+	end
+	
+	length 217
+	piece ab gi et 7*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 218
+	piece ab pi gi et 7*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 219
+	piece ab pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 220
+	piece ab gi pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 221
+	piece ab gi pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 222
+	piece ab 2*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 223
+	piece ab 2*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 224
+	piece ab 3*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 225
+	piece ab 3*gi pi gi et 7*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 226
+	piece ab gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 227
+	piece ab gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 228
+	piece ab gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 229
+	piece ab gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 230
+	piece ab 2*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 231
+	piece ab 2*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 232
+	piece ab 3*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 233
+	piece ab 3*gi gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 234
+	piece ab 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) rev(gp) 3*rev(gi) rev(ab)
+	end
+	
+	length 235
+	piece ab 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 236
+	piece ab gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(ab)
+	end
+	
+	length 237
+	piece ab gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 238
+	piece ab 2*gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) rev(gi) rev(ab)
+	end
+	
+	length 239
+	piece ab 2*gi 2*gp pi gi et 7*mt rev(et) rev(gi) rev(pi) 2*rev(gp) 2*rev(gi) rev(ab)
+	end
+	
+	length 240
+	piece ab et 8*mt rev(et) rev(ab)
+	end
+
+	length 241
+	piece ab gi et 8*mt rev(et) rev(ab)
+	end
+	
+	length 242
+	piece ab gi et 8*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 243
+	piece ab pi gi et 8*mt rev(et) rev(gi) rev(ab)
+	end
+	
+	length 244
+	piece ab pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 245
+	piece ab gi pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(ab)
+	end	
+	
+	length 246
+	piece ab gi pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 247
+	piece ab 2*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gi) rev(ab)
+	end	
+	
+	length 248
+	piece ab 2*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 249
+	piece ab 3*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) 2*rev(gi) rev(ab)
+	end	
+	
+	length 250
+	piece ab 3*gi pi gi et 8*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 251
+	piece ab gp pi gi et 8*mt rev(et) rev(gi) rev(pi) 3*rev(gi) rev(ab)
+	end	
+	
+	length 252
+	piece ab gp pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end	
+	
+	length 253
+	piece ab gi gp pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gp) rev(ab)
+	end
+	
+	length 254
+	piece ab gi gp pi gi et 8*mt rev(et) rev(gi) rev(pi) rev(gp) rev(gi) rev(ab)
+	end
+	
+end
+
+
+# Blue Suspension (RHW-3) by IDS2 (03/2024)
+
+bridge 45
+
+# abutment - 1 tile
+section ab
+	piece <0x40670000, 0>
+end
+
+# girder - 1 tile
+section gi
+	piece <0x40671000, 0>
+end
+
+# pillar - 1 tile
+section pi
+	piece <0x40672000, 0>
+end
+
+# girder pillar - 4 tiles
+section gp
+	piece <0x40672000, 0>
+	piece <0x40671000, 0>
+	piece <0x40671000, 0>
+	piece <0x40671000, 0>
+end
+
+# middle tower - 25 tiles
+section mt
+	piece <0x40675000, 0>
+	piece <0x40675000, 0>
+	piece <0x40675000, 0>
+	piece <0x40675000, 0>
+	piece <0x40675000, 0>
+	piece <0x40675000, 0>
+	piece <0x40675000, 0>
+	piece <0x40675000, 0>
+	piece <0x40675000, 0>
+	piece <0x40675000, 0>
+	piece <0x40677000, 0>
+	piece <0x40677000, 0>
+	piece <0x40676000, 0>
+	piece <0x40677000, 0>
+	piece <0x40677000, 0>
+	piece <0x40675000, 0>
+	piece <0x40675000, 0>
+	piece <0x40675000, 0>
+	piece <0x40675000, 0>
+	piece <0x40675000, 0>
+	piece <0x40675000, 0>
+	piece <0x40675000, 0>
+	piece <0x40675000, 0>
+	piece <0x40675000, 0>
+	piece <0x40675000, 0>
+end
+
+# end tower - 19 tiles
+section et
+	piece <0x40673000, 0>
+	piece <0x40671000, 0>
+	piece <0x40672000, 0>
+	piece <0x40671000, 0>
+	piece <0x40677000, 0>
+	piece <0x40677000, 0>
+	piece <0x40674000, 0>
+	piece <0x40677000, 0>
+	piece <0x40677000, 0>
+	piece <0x40675000, 0>
+	piece <0x40675000, 0>
+	piece <0x40675000, 0>
+	piece <0x40675000, 0>
+	piece <0x40675000, 0>
+	piece <0x40675000, 0>
+	piece <0x40675000, 0>
+	piece <0x40675000, 0>
+	piece <0x40675000, 0>
+	piece <0x40675000, 0>
+end 
+
+# abutment reversed - 1 tile
+section abr
+	piece <0x405D0000, 0>
+end
+
+# girder reversed - 1 tile
+section gir
+	piece <0x405D1000, 0>
+end
+
+# pillar reversed - 1 tile
+section pir
+	piece <0x405D2000, 0>
+end
+
+# girder pillar reversed - 4 tiles
+section gpr
+	piece <0x405D1000, 0>
+	piece <0x405D1000, 0>
+	piece <0x405D1000, 0>
+	piece <0x405D2000, 0>
+end
+
+# end tower reversed - 19 tiles
+section etr
+	piece <0x405D5000, 0>
+	piece <0x405D5000, 0>
+	piece <0x405D5000, 0>
+	piece <0x405D5000, 0>
+	piece <0x405D5000, 0>
+	piece <0x405D5000, 0>
+	piece <0x405D5000, 0>
+	piece <0x405D5000, 0>
+	piece <0x405D5000, 0>
+	piece <0x405D5000, 0>
+	piece <0x405D6000, 0>
+	piece <0x405D6000, 0>
+	piece <0x405D4000, 0>
+	piece <0x405D6000, 0>
+	piece <0x405D6000, 0>
+	piece <0x405D1000, 0>
+	piece <0x405D2000, 0>
+	piece <0x405D1000, 0>
+	piece <0x405D3000, 0>
+end 
+
+	length 40
+	piece ab et etr abr
+	end
+
+	length 41
+	piece ab gi et etr abr
+	end
+	
+	length 42
+	piece ab gi et etr gir abr
+	end
+	
+	length 43
+	piece ab pi gi et etr gir abr
+	end
+	
+	length 44
+	piece ab pi gi et etr gir pir abr
+	end	
+	
+	length 45
+	piece ab gi pi gi et etr gir pir abr
+	end	
+	
+	length 46
+	piece ab gi pi gi et etr gir pir gir abr
+	end	
+	
+	length 47
+	piece ab 2*gi pi gi et etr gir pir gir abr
+	end	
+	
+	length 48
+	piece ab 2*gi pi gi et etr gir pir 2*gir abr
+	end	
+	
+	length 49
+	piece ab 3*gi pi gi et etr gir pir 2*gir abr
+	end	
+	
+	length 50
+	piece ab 3*gi pi gi et etr gir pir 3*gir abr
+	end	
+	
+	length 51
+	piece ab gp pi gi et etr gir pir 3*gir abr
+	end	
+	
+	length 52
+	piece ab gp pi gi et etr gir pir gpr abr
+	end	
+	
+	length 53
+	piece ab gi gp pi gi et etr gir pir gpr abr
+	end
+	
+	length 54
+	piece ab gi gp pi gi et etr gir pir gpr gir abr
+	end
+	
+	length 55
+	piece ab 2*gi gp pi gi et etr gir pir gpr gir abr
+	end
+	
+	length 56
+	piece ab 2*gi gp pi gi et etr gir pir gpr 2*gir abr
+	end
+	
+	length 57
+	piece ab 3*gi gp pi gi et etr gir pir gpr 2*gir abr
+	end
+	
+	length 58
+	piece ab 3*gi gp pi gi et etr gir pir gpr 3*gir abr
+	end
+	
+	length 59
+	piece ab 2*gp pi gi et etr gir pir gpr 3*gir abr
+	end
+	
+	length 60
+	piece ab 2*gp pi gi et etr gir pir 2*gpr abr
+	end
+	
+	length 61
+	piece ab gi 2*gp pi gi et etr gir pir 2*gpr abr
+	end
+	
+	length 62
+	piece ab gi 2*gp pi gi et etr gir pir 2*gpr gir abr
+	end
+	
+	length 63
+	piece ab 2*gi 2*gp pi gi et etr gir pir 2*gpr gir abr
+	end
+	
+	length 64
+	piece ab 2*gi 2*gp pi gi et etr gir pir 2*gpr 2*gir abr
+	end
+
+	length 65
+	piece ab et mt etr abr
+	end
+	
+	length 66
+	piece ab gi et mt etr abr
+	end
+	
+	length 67
+	piece ab gi et mt etr gir abr
+	end
+	
+	length 68
+	piece ab pi gi et mt etr gir abr
+	end
+	
+	length 69
+	piece ab pi gi et mt etr gir pir abr
+	end	
+	
+	length 70
+	piece ab gi pi gi et mt etr gir pir abr
+	end	
+	
+	length 71
+	piece ab gi pi gi et mt etr gir pir gir abr
+	end	
+	
+	length 72
+	piece ab 2*gi pi gi et mt etr gir pir gir abr
+	end	
+	
+	length 73
+	piece ab 2*gi pi gi et mt etr gir pir 2*gir abr
+	end	
+	
+	length 74
+	piece ab 3*gi pi gi et mt etr gir pir 2*gir abr
+	end	
+	
+	length 75
+	piece ab 3*gi pi gi et mt etr gir pir 3*gir abr
+	end	
+	
+	length 76
+	piece ab gp pi gi et mt etr gir pir 3*gir abr
+	end	
+	
+	length 77
+	piece ab gp pi gi et mt etr gir pir gpr abr
+	end	
+	
+	length 78
+	piece ab gi gp pi gi et mt etr gir pir gpr abr
+	end
+	
+	length 79
+	piece ab gi gp pi gi et mt etr gir pir gpr gir abr
+	end
+	
+	length 80
+	piece ab 2*gi gp pi gi et mt etr gir pir gpr gir abr
+	end
+	
+	length 81
+	piece ab 2*gi gp pi gi et mt etr gir pir gpr 2*gir abr
+	end
+	
+	length 82
+	piece ab 3*gi gp pi gi et mt etr gir pir gpr 2*gir abr
+	end
+	
+	length 83
+	piece ab 3*gi gp pi gi et mt etr gir pir gpr 3*gir abr
+	end
+	
+	length 84
+	piece ab 2*gp pi gi et mt etr gir pir gpr 3*gir abr
+	end
+	
+	length 85
+	piece ab 2*gp pi gi et mt etr gir pir 2*gpr abr
+	end
+	
+	length 86
+	piece ab gi 2*gp pi gi et mt etr gir pir 2*gpr abr
+	end
+	
+	length 87
+	piece ab gi 2*gp pi gi et mt etr gir pir 2*gpr gir abr
+	end
+	
+	length 88
+	piece ab 2*gi 2*gp pi gi et mt etr gir pir 2*gpr gir abr
+	end
+	
+	length 89
+	piece ab 2*gi 2*gp pi gi et mt etr gir pir 2*gpr 2*gir abr
+	end
+	
+	length 90
+	piece ab et 2*mt etr abr
+	end
+	
+	length 91
+	piece ab gi et 2*mt etr abr
+	end
+	
+	length 92
+	piece ab gi et 2*mt etr gir abr
+	end
+	
+	length 93
+	piece ab pi gi et 2*mt etr gir abr
+	end
+	
+	length 94
+	piece ab pi gi et 2*mt etr gir pir abr
+	end	
+	
+	length 95
+	piece ab gi pi gi et 2*mt etr gir pir abr
+	end	
+	
+	length 96
+	piece ab gi pi gi et 2*mt etr gir pir gir abr
+	end	
+	
+	length 97
+	piece ab 2*gi pi gi et 2*mt etr gir pir gir abr
+	end	
+	
+	length 98
+	piece ab 2*gi pi gi et 2*mt etr gir pir 2*gir abr
+	end	
+	
+	length 99
+	piece ab 3*gi pi gi et 2*mt etr gir pir 2*gir abr
+	end	
+	
+	length 100
+	piece ab 3*gi pi gi et 2*mt etr gir pir 3*gir abr
+	end	
+	
+	length 101
+	piece ab gp pi gi et 2*mt etr gir pir 3*gir abr
+	end	
+	
+	length 102
+	piece ab gp pi gi et 2*mt etr gir pir gpr abr
+	end	
+	
+	length 103
+	piece ab gi gp pi gi et 2*mt etr gir pir gpr abr
+	end
+	
+	length 104
+	piece ab gi gp pi gi et 2*mt etr gir pir gpr gir abr
+	end
+	
+	length 105
+	piece ab 2*gi gp pi gi et 2*mt etr gir pir gpr gir abr
+	end
+	
+	length 106
+	piece ab 2*gi gp pi gi et 2*mt etr gir pir gpr 2*gir abr
+	end
+	
+	length 107
+	piece ab 3*gi gp pi gi et 2*mt etr gir pir gpr 2*gir abr
+	end
+	
+	length 108
+	piece ab 3*gi gp pi gi et 2*mt etr gir pir gpr 3*gir abr
+	end
+	
+	length 109
+	piece ab 2*gp pi gi et 2*mt etr gir pir gpr 3*gir abr
+	end
+	
+	length 110
+	piece ab 2*gp pi gi et 2*mt etr gir pir 2*gpr abr
+	end
+	
+	length 111
+	piece ab gi 2*gp pi gi et 2*mt etr gir pir 2*gpr abr
+	end
+	
+	length 112
+	piece ab gi 2*gp pi gi et 2*mt etr gir pir 2*gpr gir abr
+	end
+	
+	length 113
+	piece ab 2*gi 2*gp pi gi et 2*mt etr gir pir 2*gpr gir abr
+	end
+	
+	length 114
+	piece ab 2*gi 2*gp pi gi et 2*mt etr gir pir 2*gpr 2*gir abr
+	end
+	
+	length 115
+	piece ab et 3*mt etr abr
+	end
+	
+	length 116
+	piece ab gi et 3*mt etr abr
+	end
+	
+	length 117
+	piece ab gi et 3*mt etr gir abr
+	end
+	
+	length 118
+	piece ab pi gi et 3*mt etr gir abr
+	end
+	
+	length 119
+	piece ab pi gi et 3*mt etr gir pir abr
+	end	
+	
+	length 120
+	piece ab gi pi gi et 3*mt etr gir pir abr
+	end	
+	
+	length 121
+	piece ab gi pi gi et 3*mt etr gir pir gir abr
+	end	
+	
+	length 122
+	piece ab 2*gi pi gi et 3*mt etr gir pir gir abr
+	end	
+	
+	length 123
+	piece ab 2*gi pi gi et 3*mt etr gir pir 2*gir abr
+	end	
+	
+	length 124
+	piece ab 3*gi pi gi et 3*mt etr gir pir 2*gir abr
+	end	
+	
+	length 125
+	piece ab 3*gi pi gi et 3*mt etr gir pir 3*gir abr
+	end	
+	
+	length 126
+	piece ab gp pi gi et 3*mt etr gir pir 3*gir abr
+	end	
+	
+	length 127
+	piece ab gp pi gi et 3*mt etr gir pir gpr abr
+	end	
+	
+	length 128
+	piece ab gi gp pi gi et 3*mt etr gir pir gpr abr
+	end
+	
+	length 129
+	piece ab gi gp pi gi et 3*mt etr gir pir gpr gir abr
+	end
+	
+	length 130
+	piece ab 2*gi gp pi gi et 3*mt etr gir pir gpr gir abr
+	end
+	
+	length 131
+	piece ab 2*gi gp pi gi et 3*mt etr gir pir gpr 2*gir abr
+	end
+	
+	length 132
+	piece ab 3*gi gp pi gi et 3*mt etr gir pir gpr 2*gir abr
+	end
+	
+	length 133
+	piece ab 3*gi gp pi gi et 3*mt etr gir pir gpr 3*gir abr
+	end
+	
+	length 134
+	piece ab 2*gp pi gi et 3*mt etr gir pir gpr 3*gir abr
+	end
+	
+	length 135
+	piece ab 2*gp pi gi et 3*mt etr gir pir 2*gpr abr
+	end
+	
+	length 136
+	piece ab gi 2*gp pi gi et 3*mt etr gir pir 2*gpr abr
+	end
+	
+	length 137
+	piece ab gi 2*gp pi gi et 3*mt etr gir pir 2*gpr gir abr
+	end
+	
+	length 138
+	piece ab 2*gi 2*gp pi gi et 3*mt etr gir pir 2*gpr gir abr
+	end
+	
+	length 139
+	piece ab 2*gi 2*gp pi gi et 3*mt etr gir pir 2*gpr 2*gir abr
+	end
+	
+	length 140
+	piece ab et 4*mt etr abr
+	end
+	
+	length 141
+	piece ab gi et 4*mt etr abr
+	end
+	
+	length 142
+	piece ab gi et 4*mt etr gir abr
+	end
+	
+	length 143
+	piece ab pi gi et 4*mt etr gir abr
+	end
+	
+	length 144
+	piece ab pi gi et 4*mt etr gir pir abr
+	end	
+	
+	length 145
+	piece ab gi pi gi et 4*mt etr gir pir abr
+	end	
+	
+	length 146
+	piece ab gi pi gi et 4*mt etr gir pir gir abr
+	end	
+	
+	length 147
+	piece ab 2*gi pi gi et 4*mt etr gir pir gir abr
+	end	
+	
+	length 148
+	piece ab 2*gi pi gi et 4*mt etr gir pir 2*gir abr
+	end	
+	
+	length 149
+	piece ab 3*gi pi gi et 4*mt etr gir pir 2*gir abr
+	end	
+	
+	length 150
+	piece ab 3*gi pi gi et 4*mt etr gir pir 3*gir abr
+	end	
+	
+	length 151
+	piece ab gp pi gi et 4*mt etr gir pir 3*gir abr
+	end	
+	
+	length 152
+	piece ab gp pi gi et 4*mt etr gir pir gpr abr
+	end	
+	
+	length 153
+	piece ab gi gp pi gi et 4*mt etr gir pir gpr abr
+	end
+	
+	length 154
+	piece ab gi gp pi gi et 4*mt etr gir pir gpr gir abr
+	end
+	
+	length 155
+	piece ab 2*gi gp pi gi et 4*mt etr gir pir gpr gir abr
+	end
+	
+	length 156
+	piece ab 2*gi gp pi gi et 4*mt etr gir pir gpr 2*gir abr
+	end
+	
+	length 157
+	piece ab 3*gi gp pi gi et 4*mt etr gir pir gpr 2*gir abr
+	end
+	
+	length 158
+	piece ab 3*gi gp pi gi et 4*mt etr gir pir gpr 3*gir abr
+	end
+	
+	length 159
+	piece ab 2*gp pi gi et 4*mt etr gir pir gpr 3*gir abr
+	end
+	
+	length 160
+
+	piece ab 2*gp pi gi et 4*mt etr gir pir 2*gpr abr
+	end
+	
+	length 161
+	piece ab gi 2*gp pi gi et 4*mt etr gir pir 2*gpr abr
+	end
+	
+	length 162
+	piece ab gi 2*gp pi gi et 4*mt etr gir pir 2*gpr gir abr
+	end
+	
+	length 163
+	piece ab 2*gi 2*gp pi gi et 4*mt etr gir pir 2*gpr gir abr
+	end
+	
+	length 164
+	piece ab 2*gi 2*gp pi gi et 4*mt etr gir pir 2*gpr 2*gir abr
+	end
+	
+	length 165
+	piece ab et 5*mt etr abr
+	end
+	
+	length 166
+	piece ab gi et 5*mt etr abr
+	end
+	
+	length 167
+	piece ab gi et 5*mt etr gir abr
+	end
+	
+	length 168
+	piece ab pi gi et 5*mt etr gir abr
+	end
+	
+	length 169
+	piece ab pi gi et 5*mt etr gir pir abr
+	end	
+	
+	length 170
+	piece ab gi pi gi et 5*mt etr gir pir abr
+	end	
+	
+	length 171
+	piece ab gi pi gi et 5*mt etr gir pir gir abr
+	end	
+	
+	length 172
+	piece ab 2*gi pi gi et 5*mt etr gir pir gir abr
+	end	
+	
+	length 173
+	piece ab 2*gi pi gi et 5*mt etr gir pir 2*gir abr
+	end	
+	
+	length 174
+	piece ab 3*gi pi gi et 5*mt etr gir pir 2*gir abr
+	end	
+	
+	length 175
+	piece ab 3*gi pi gi et 5*mt etr gir pir 3*gir abr
+	end	
+	
+	length 176
+	piece ab gp pi gi et 5*mt etr gir pir 3*gir abr
+	end	
+	
+	length 177
+	piece ab gp pi gi et 5*mt etr gir pir gpr abr
+	end	
+	
+	length 178
+	piece ab gi gp pi gi et 5*mt etr gir pir gpr abr
+	end
+	
+	length 179
+	piece ab gi gp pi gi et 5*mt etr gir pir gpr gir abr
+	end
+	
+	length 180
+	piece ab 2*gi gp pi gi et 5*mt etr gir pir gpr gir abr
+	end
+	
+	length 181
+	piece ab 2*gi gp pi gi et 5*mt etr gir pir gpr 2*gir abr
+	end
+	
+	length 182
+	piece ab 3*gi gp pi gi et 5*mt etr gir pir gpr 2*gir abr
+	end
+	
+	length 183
+	piece ab 3*gi gp pi gi et 5*mt etr gir pir gpr 3*gir abr
+	end
+	
+	length 184
+	piece ab 2*gp pi gi et 5*mt etr gir pir gpr 3*gir abr
+	end
+	
+	length 185
+	piece ab 2*gp pi gi et 5*mt etr gir pir 2*gpr abr
+	end
+	
+	length 186
+	piece ab gi 2*gp pi gi et 5*mt etr gir pir 2*gpr abr
+	end
+	
+	length 187
+	piece ab gi 2*gp pi gi et 5*mt etr gir pir 2*gpr gir abr
+	end
+	
+	length 188
+	piece ab 2*gi 2*gp pi gi et 5*mt etr gir pir 2*gpr gir abr
+	end
+	
+	length 189
+	piece ab 2*gi 2*gp pi gi et 5*mt etr gir pir 2*gpr 2*gir abr
+	end
+	
+	length 190
+	piece ab et 6*mt etr abr
+	end
+	
+	length 191
+	piece ab gi et 6*mt etr abr
+	end
+	
+	length 192
+	piece ab gi et 6*mt etr gir abr
+	end
+	
+	length 193
+	piece ab pi gi et 6*mt etr gir abr
+	end
+	
+	length 194
+	piece ab pi gi et 6*mt etr gir pir abr
+	end	
+	
+	length 195
+	piece ab gi pi gi et 6*mt etr gir pir abr
+	end	
+	
+	length 196
+	piece ab gi pi gi et 6*mt etr gir pir gir abr
+	end	
+	
+	length 197
+	piece ab 2*gi pi gi et 6*mt etr gir pir gir abr
+	end	
+	
+	length 198
+	piece ab 2*gi pi gi et 6*mt etr gir pir 2*gir abr
+	end	
+	
+	length 199
+	piece ab 3*gi pi gi et 6*mt etr gir pir 2*gir abr
+	end	
+	
+	length 200
+	piece ab 3*gi pi gi et 6*mt etr gir pir 3*gir abr
+	end	
+	
+	length 201
+	piece ab gp pi gi et 6*mt etr gir pir 3*gir abr
+	end	
+	
+	length 202
+	piece ab gp pi gi et 6*mt etr gir pir gpr abr
+	end	
+	
+	length 203
+	piece ab gi gp pi gi et 6*mt etr gir pir gpr abr
+	end
+	
+	length 204
+	piece ab gi gp pi gi et 6*mt etr gir pir gpr gir abr
+	end
+	
+	length 205
+	piece ab 2*gi gp pi gi et 6*mt etr gir pir gpr gir abr
+	end
+	
+	length 206
+	piece ab 2*gi gp pi gi et 6*mt etr gir pir gpr 2*gir abr
+	end
+	
+	length 207
+	piece ab 3*gi gp pi gi et 6*mt etr gir pir gpr 2*gir abr
+	end
+	
+	length 208
+	piece ab 3*gi gp pi gi et 6*mt etr gir pir gpr 3*gir abr
+	end
+	
+	length 209
+	piece ab 2*gp pi gi et 6*mt etr gir pir gpr 3*gir abr
+	end
+	
+	length 210
+	piece ab 2*gp pi gi et 6*mt etr gir pir 2*gpr abr
+	end
+	
+	length 211
+	piece ab gi 2*gp pi gi et 6*mt etr gir pir 2*gpr abr
+	end
+	
+	length 212
+	piece ab gi 2*gp pi gi et 6*mt etr gir pir 2*gpr gir abr
+	end
+	
+	length 213
+	piece ab 2*gi 2*gp pi gi et 6*mt etr gir pir 2*gpr gir abr
+	end
+	
+	length 214
+	piece ab 2*gi 2*gp pi gi et 6*mt etr gir pir 2*gpr 2*gir abr
+	end
+	
+	length 215
+	piece ab et 7*mt etr abr
+	end
+	
+	length 216
+	piece ab gi et 7*mt etr abr
+	end
+	
+	length 217
+	piece ab gi et 7*mt etr gir abr
+	end
+	
+	length 218
+	piece ab pi gi et 7*mt etr gir abr
+	end
+	
+	length 219
+	piece ab pi gi et 7*mt etr gir pir abr
+	end	
+	
+	length 220
+	piece ab gi pi gi et 7*mt etr gir pir abr
+	end	
+	
+	length 221
+	piece ab gi pi gi et 7*mt etr gir pir gir abr
+	end	
+	
+	length 222
+	piece ab 2*gi pi gi et 7*mt etr gir pir gir abr
+	end	
+	
+	length 223
+	piece ab 2*gi pi gi et 7*mt etr gir pir 2*gir abr
+	end	
+	
+	length 224
+	piece ab 3*gi pi gi et 7*mt etr gir pir 2*gir abr
+	end	
+	
+	length 225
+	piece ab 3*gi pi gi et 7*mt etr gir pir 3*gir abr
+	end	
+	
+	length 226
+	piece ab gp pi gi et 7*mt etr gir pir 3*gir abr
+	end	
+	
+	length 227
+	piece ab gp pi gi et 7*mt etr gir pir gpr abr
+	end	
+	
+	length 228
+	piece ab gi gp pi gi et 7*mt etr gir pir gpr abr
+	end
+	
+	length 229
+	piece ab gi gp pi gi et 7*mt etr gir pir gpr gir abr
+	end
+	
+	length 230
+	piece ab 2*gi gp pi gi et 7*mt etr gir pir gpr gir abr
+	end
+	
+	length 231
+	piece ab 2*gi gp pi gi et 7*mt etr gir pir gpr 2*gir abr
+	end
+	
+	length 232
+	piece ab 3*gi gp pi gi et 7*mt etr gir pir gpr 2*gir abr
+	end
+	
+	length 233
+	piece ab 3*gi gp pi gi et 7*mt etr gir pir gpr 3*gir abr
+	end
+	
+	length 234
+	piece ab 2*gp pi gi et 7*mt etr gir pir gpr 3*gir abr
+	end
+	
+	length 235
+	piece ab 2*gp pi gi et 7*mt etr gir pir 2*gpr abr
+	end
+	
+	length 236
+	piece ab gi 2*gp pi gi et 7*mt etr gir pir 2*gpr abr
+	end
+	
+	length 237
+	piece ab gi 2*gp pi gi et 7*mt etr gir pir 2*gpr gir abr
+	end
+	
+	length 238
+	piece ab 2*gi 2*gp pi gi et 7*mt etr gir pir 2*gpr gir abr
+	end
+	
+	length 239
+	piece ab 2*gi 2*gp pi gi et 7*mt etr gir pir 2*gpr 2*gir abr
+	end
+	
+	length 240
+	piece ab et 8*mt etr abr
+	end
+
+	length 241
+	piece ab gi et 8*mt etr abr
+	end
+	
+	length 242
+	piece ab gi et 8*mt etr gir abr
+	end
+	
+	length 243
+	piece ab pi gi et 8*mt etr gir abr
+	end
+	
+	length 244
+	piece ab pi gi et 8*mt etr gir pir abr
+	end	
+	
+	length 245
+	piece ab gi pi gi et 8*mt etr gir pir abr
+	end	
+	
+	length 246
+	piece ab gi pi gi et 8*mt etr gir pir gir abr
+	end	
+	
+	length 247
+	piece ab 2*gi pi gi et 8*mt etr gir pir gir abr
+	end	
+	
+	length 248
+	piece ab 2*gi pi gi et 8*mt etr gir pir 2*gir abr
+	end	
+	
+	length 249
+	piece ab 3*gi pi gi et 8*mt etr gir pir 2*gir abr
+	end	
+	
+	length 250
+	piece ab 3*gi pi gi et 8*mt etr gir pir 3*gir abr
+	end	
+	
+	length 251
+	piece ab gp pi gi et 8*mt etr gir pir 3*gir abr
+	end	
+	
+	length 252
+	piece ab gp pi gi et 8*mt etr gir pir gpr abr
+	end	
+	
+	length 253
+	piece ab gi gp pi gi et 8*mt etr gir pir gpr abr
+	end
+	
+	length 254
+	piece ab gi gp pi gi et 8*mt etr gir pir gpr gir abr
+	end
+	
+end
+
+
+# Blue Suspension (RHW-4S) by IDS2 (03/2024)
+
+bridge 46
+
+# abutment - 1 tile
+section ab
+	piece <0x40680000, 0>
+end
+
+# girder - 1 tile
+section gi
+	piece <0x40681000, 0>
+end
+
+# pillar - 1 tile
+section pi
+	piece <0x40682000, 0>
+end
+
+# girder pillar - 4 tiles
+section gp
+	piece <0x40682000, 0>
+	piece <0x40681000, 0>
+	piece <0x40681000, 0>
+	piece <0x40681000, 0>
+end
+
+# middle tower - 25 tiles
+section mt
+	piece <0x40685000, 0>
+	piece <0x40685000, 0>
+	piece <0x40685000, 0>
+	piece <0x40685000, 0>
+	piece <0x40685000, 0>
+	piece <0x40685000, 0>
+	piece <0x40685000, 0>
+	piece <0x40685000, 0>
+	piece <0x40685000, 0>
+	piece <0x40685000, 0>
+	piece <0x40687000, 0>
+	piece <0x40687000, 0>
+	piece <0x40686000, 0>
+	piece <0x40687000, 0>
+	piece <0x40687000, 0>
+	piece <0x40685000, 0>
+	piece <0x40685000, 0>
+	piece <0x40685000, 0>
+	piece <0x40685000, 0>
+	piece <0x40685000, 0>
+	piece <0x40685000, 0>
+	piece <0x40685000, 0>
+	piece <0x40685000, 0>
+	piece <0x40685000, 0>
+	piece <0x40685000, 0>
+end
+
+# end tower - 19 tiles
+section et
+	piece <0x40683000, 0>
+	piece <0x40681000, 0>
+	piece <0x40682000, 0>
+	piece <0x40681000, 0>
+	piece <0x40687000, 0>
+	piece <0x40687000, 0>
+	piece <0x40684000, 0>
+	piece <0x40687000, 0>
+	piece <0x40687000, 0>
+	piece <0x40685000, 0>
+	piece <0x40685000, 0>
+	piece <0x40685000, 0>
+	piece <0x40685000, 0>
+	piece <0x40685000, 0>
+	piece <0x40685000, 0>
+	piece <0x40685000, 0>
+	piece <0x40685000, 0>
+	piece <0x40685000, 0>
+	piece <0x40685000, 0>
+end 
+
+# abutment reversed - 1 tile
+section abr
+	piece <0x405E0000, 0>
+end
+
+# girder reversed - 1 tile
+section gir
+	piece <0x405E1000, 0>
+end
+
+# pillar reversed - 1 tile
+section pir
+	piece <0x405E2000, 0>
+end
+
+# girder pillar reversed - 4 tiles
+section gpr
+	piece <0x405E1000, 0>
+	piece <0x405E1000, 0>
+	piece <0x405E1000, 0>
+	piece <0x405E2000, 0>
+end
+
+# end tower reversed - 19 tiles
+section etr
+	piece <0x405E5000, 0>
+	piece <0x405E5000, 0>
+	piece <0x405E5000, 0>
+	piece <0x405E5000, 0>
+	piece <0x405E5000, 0>
+	piece <0x405E5000, 0>
+	piece <0x405E5000, 0>
+	piece <0x405E5000, 0>
+	piece <0x405E5000, 0>
+	piece <0x405E5000, 0>
+	piece <0x405E6000, 0>
+	piece <0x405E6000, 0>
+	piece <0x405E4000, 0>
+	piece <0x405E6000, 0>
+	piece <0x405E6000, 0>
+	piece <0x405E1000, 0>
+	piece <0x405E2000, 0>
+	piece <0x405E1000, 0>
+	piece <0x405E3000, 0>
+end 
+
+	length 40
+	piece ab et etr abr
+	end
+
+	length 41
+	piece ab gi et etr abr
+	end
+	
+	length 42
+	piece ab gi et etr gir abr
+	end
+	
+	length 43
+	piece ab pi gi et etr gir abr
+	end
+	
+	length 44
+	piece ab pi gi et etr gir pir abr
+	end	
+	
+	length 45
+	piece ab gi pi gi et etr gir pir abr
+	end	
+	
+	length 46
+	piece ab gi pi gi et etr gir pir gir abr
+	end	
+	
+	length 47
+	piece ab 2*gi pi gi et etr gir pir gir abr
+	end	
+	
+	length 48
+	piece ab 2*gi pi gi et etr gir pir 2*gir abr
+	end	
+	
+	length 49
+	piece ab 3*gi pi gi et etr gir pir 2*gir abr
+	end	
+	
+	length 50
+	piece ab 3*gi pi gi et etr gir pir 3*gir abr
+	end	
+	
+	length 51
+	piece ab gp pi gi et etr gir pir 3*gir abr
+	end	
+	
+	length 52
+	piece ab gp pi gi et etr gir pir gpr abr
+	end	
+	
+	length 53
+	piece ab gi gp pi gi et etr gir pir gpr abr
+	end
+	
+	length 54
+	piece ab gi gp pi gi et etr gir pir gpr gir abr
+	end
+	
+	length 55
+	piece ab 2*gi gp pi gi et etr gir pir gpr gir abr
+	end
+	
+	length 56
+	piece ab 2*gi gp pi gi et etr gir pir gpr 2*gir abr
+	end
+	
+	length 57
+	piece ab 3*gi gp pi gi et etr gir pir gpr 2*gir abr
+	end
+	
+	length 58
+	piece ab 3*gi gp pi gi et etr gir pir gpr 3*gir abr
+	end
+	
+	length 59
+	piece ab 2*gp pi gi et etr gir pir gpr 3*gir abr
+	end
+	
+	length 60
+	piece ab 2*gp pi gi et etr gir pir 2*gpr abr
+	end
+	
+	length 61
+	piece ab gi 2*gp pi gi et etr gir pir 2*gpr abr
+	end
+	
+	length 62
+	piece ab gi 2*gp pi gi et etr gir pir 2*gpr gir abr
+	end
+	
+	length 63
+	piece ab 2*gi 2*gp pi gi et etr gir pir 2*gpr gir abr
+	end
+	
+	length 64
+	piece ab 2*gi 2*gp pi gi et etr gir pir 2*gpr 2*gir abr
+	end
+
+	length 65
+	piece ab et mt etr abr
+	end
+	
+	length 66
+	piece ab gi et mt etr abr
+	end
+	
+	length 67
+	piece ab gi et mt etr gir abr
+	end
+	
+	length 68
+	piece ab pi gi et mt etr gir abr
+	end
+	
+	length 69
+	piece ab pi gi et mt etr gir pir abr
+	end	
+	
+	length 70
+	piece ab gi pi gi et mt etr gir pir abr
+	end	
+	
+	length 71
+	piece ab gi pi gi et mt etr gir pir gir abr
+	end	
+	
+	length 72
+	piece ab 2*gi pi gi et mt etr gir pir gir abr
+	end	
+	
+	length 73
+	piece ab 2*gi pi gi et mt etr gir pir 2*gir abr
+	end	
+	
+	length 74
+	piece ab 3*gi pi gi et mt etr gir pir 2*gir abr
+	end	
+	
+	length 75
+	piece ab 3*gi pi gi et mt etr gir pir 3*gir abr
+	end	
+	
+	length 76
+	piece ab gp pi gi et mt etr gir pir 3*gir abr
+	end	
+	
+	length 77
+	piece ab gp pi gi et mt etr gir pir gpr abr
+	end	
+	
+	length 78
+	piece ab gi gp pi gi et mt etr gir pir gpr abr
+	end
+	
+	length 79
+	piece ab gi gp pi gi et mt etr gir pir gpr gir abr
+	end
+	
+	length 80
+	piece ab 2*gi gp pi gi et mt etr gir pir gpr gir abr
+	end
+	
+	length 81
+	piece ab 2*gi gp pi gi et mt etr gir pir gpr 2*gir abr
+	end
+	
+	length 82
+	piece ab 3*gi gp pi gi et mt etr gir pir gpr 2*gir abr
+	end
+	
+	length 83
+	piece ab 3*gi gp pi gi et mt etr gir pir gpr 3*gir abr
+	end
+	
+	length 84
+	piece ab 2*gp pi gi et mt etr gir pir gpr 3*gir abr
+	end
+	
+	length 85
+	piece ab 2*gp pi gi et mt etr gir pir 2*gpr abr
+	end
+	
+	length 86
+	piece ab gi 2*gp pi gi et mt etr gir pir 2*gpr abr
+	end
+	
+	length 87
+	piece ab gi 2*gp pi gi et mt etr gir pir 2*gpr gir abr
+	end
+	
+	length 88
+	piece ab 2*gi 2*gp pi gi et mt etr gir pir 2*gpr gir abr
+	end
+	
+	length 89
+	piece ab 2*gi 2*gp pi gi et mt etr gir pir 2*gpr 2*gir abr
+	end
+	
+	length 90
+	piece ab et 2*mt etr abr
+	end
+	
+	length 91
+	piece ab gi et 2*mt etr abr
+	end
+	
+	length 92
+	piece ab gi et 2*mt etr gir abr
+	end
+	
+	length 93
+	piece ab pi gi et 2*mt etr gir abr
+	end
+	
+	length 94
+	piece ab pi gi et 2*mt etr gir pir abr
+	end	
+	
+	length 95
+	piece ab gi pi gi et 2*mt etr gir pir abr
+	end	
+	
+	length 96
+	piece ab gi pi gi et 2*mt etr gir pir gir abr
+	end	
+	
+	length 97
+	piece ab 2*gi pi gi et 2*mt etr gir pir gir abr
+	end	
+	
+	length 98
+	piece ab 2*gi pi gi et 2*mt etr gir pir 2*gir abr
+	end	
+	
+	length 99
+	piece ab 3*gi pi gi et 2*mt etr gir pir 2*gir abr
+	end	
+	
+	length 100
+	piece ab 3*gi pi gi et 2*mt etr gir pir 3*gir abr
+	end	
+	
+	length 101
+	piece ab gp pi gi et 2*mt etr gir pir 3*gir abr
+	end	
+	
+	length 102
+	piece ab gp pi gi et 2*mt etr gir pir gpr abr
+	end	
+	
+	length 103
+	piece ab gi gp pi gi et 2*mt etr gir pir gpr abr
+	end
+	
+	length 104
+	piece ab gi gp pi gi et 2*mt etr gir pir gpr gir abr
+	end
+	
+	length 105
+	piece ab 2*gi gp pi gi et 2*mt etr gir pir gpr gir abr
+	end
+	
+	length 106
+	piece ab 2*gi gp pi gi et 2*mt etr gir pir gpr 2*gir abr
+	end
+	
+	length 107
+	piece ab 3*gi gp pi gi et 2*mt etr gir pir gpr 2*gir abr
+	end
+	
+	length 108
+	piece ab 3*gi gp pi gi et 2*mt etr gir pir gpr 3*gir abr
+	end
+	
+	length 109
+	piece ab 2*gp pi gi et 2*mt etr gir pir gpr 3*gir abr
+	end
+	
+	length 110
+	piece ab 2*gp pi gi et 2*mt etr gir pir 2*gpr abr
+	end
+	
+	length 111
+	piece ab gi 2*gp pi gi et 2*mt etr gir pir 2*gpr abr
+	end
+	
+	length 112
+	piece ab gi 2*gp pi gi et 2*mt etr gir pir 2*gpr gir abr
+	end
+	
+	length 113
+	piece ab 2*gi 2*gp pi gi et 2*mt etr gir pir 2*gpr gir abr
+	end
+	
+	length 114
+	piece ab 2*gi 2*gp pi gi et 2*mt etr gir pir 2*gpr 2*gir abr
+	end
+	
+	length 115
+	piece ab et 3*mt etr abr
+	end
+	
+	length 116
+	piece ab gi et 3*mt etr abr
+	end
+	
+	length 117
+	piece ab gi et 3*mt etr gir abr
+	end
+	
+	length 118
+	piece ab pi gi et 3*mt etr gir abr
+	end
+	
+	length 119
+	piece ab pi gi et 3*mt etr gir pir abr
+	end	
+	
+	length 120
+	piece ab gi pi gi et 3*mt etr gir pir abr
+	end	
+	
+	length 121
+	piece ab gi pi gi et 3*mt etr gir pir gir abr
+	end	
+	
+	length 122
+	piece ab 2*gi pi gi et 3*mt etr gir pir gir abr
+	end	
+	
+	length 123
+	piece ab 2*gi pi gi et 3*mt etr gir pir 2*gir abr
+	end	
+	
+	length 124
+	piece ab 3*gi pi gi et 3*mt etr gir pir 2*gir abr
+	end	
+	
+	length 125
+	piece ab 3*gi pi gi et 3*mt etr gir pir 3*gir abr
+	end	
+	
+	length 126
+	piece ab gp pi gi et 3*mt etr gir pir 3*gir abr
+	end	
+	
+	length 127
+	piece ab gp pi gi et 3*mt etr gir pir gpr abr
+	end	
+	
+	length 128
+	piece ab gi gp pi gi et 3*mt etr gir pir gpr abr
+	end
+	
+	length 129
+	piece ab gi gp pi gi et 3*mt etr gir pir gpr gir abr
+	end
+	
+	length 130
+	piece ab 2*gi gp pi gi et 3*mt etr gir pir gpr gir abr
+	end
+	
+	length 131
+	piece ab 2*gi gp pi gi et 3*mt etr gir pir gpr 2*gir abr
+	end
+	
+	length 132
+	piece ab 3*gi gp pi gi et 3*mt etr gir pir gpr 2*gir abr
+	end
+	
+	length 133
+	piece ab 3*gi gp pi gi et 3*mt etr gir pir gpr 3*gir abr
+	end
+	
+	length 134
+	piece ab 2*gp pi gi et 3*mt etr gir pir gpr 3*gir abr
+	end
+	
+	length 135
+	piece ab 2*gp pi gi et 3*mt etr gir pir 2*gpr abr
+	end
+	
+	length 136
+	piece ab gi 2*gp pi gi et 3*mt etr gir pir 2*gpr abr
+	end
+	
+	length 137
+	piece ab gi 2*gp pi gi et 3*mt etr gir pir 2*gpr gir abr
+	end
+	
+	length 138
+	piece ab 2*gi 2*gp pi gi et 3*mt etr gir pir 2*gpr gir abr
+	end
+	
+	length 139
+	piece ab 2*gi 2*gp pi gi et 3*mt etr gir pir 2*gpr 2*gir abr
+	end
+	
+	length 140
+	piece ab et 4*mt etr abr
+	end
+	
+	length 141
+	piece ab gi et 4*mt etr abr
+	end
+	
+	length 142
+	piece ab gi et 4*mt etr gir abr
+	end
+	
+	length 143
+	piece ab pi gi et 4*mt etr gir abr
+	end
+	
+	length 144
+	piece ab pi gi et 4*mt etr gir pir abr
+	end	
+	
+	length 145
+	piece ab gi pi gi et 4*mt etr gir pir abr
+	end	
+	
+	length 146
+	piece ab gi pi gi et 4*mt etr gir pir gir abr
+	end	
+	
+	length 147
+	piece ab 2*gi pi gi et 4*mt etr gir pir gir abr
+	end	
+	
+	length 148
+	piece ab 2*gi pi gi et 4*mt etr gir pir 2*gir abr
+	end	
+	
+	length 149
+	piece ab 3*gi pi gi et 4*mt etr gir pir 2*gir abr
+	end	
+	
+	length 150
+	piece ab 3*gi pi gi et 4*mt etr gir pir 3*gir abr
+	end	
+	
+	length 151
+	piece ab gp pi gi et 4*mt etr gir pir 3*gir abr
+	end	
+	
+	length 152
+	piece ab gp pi gi et 4*mt etr gir pir gpr abr
+	end	
+	
+	length 153
+	piece ab gi gp pi gi et 4*mt etr gir pir gpr abr
+	end
+	
+	length 154
+	piece ab gi gp pi gi et 4*mt etr gir pir gpr gir abr
+	end
+	
+	length 155
+	piece ab 2*gi gp pi gi et 4*mt etr gir pir gpr gir abr
+	end
+	
+	length 156
+	piece ab 2*gi gp pi gi et 4*mt etr gir pir gpr 2*gir abr
+	end
+	
+	length 157
+	piece ab 3*gi gp pi gi et 4*mt etr gir pir gpr 2*gir abr
+	end
+	
+	length 158
+	piece ab 3*gi gp pi gi et 4*mt etr gir pir gpr 3*gir abr
+	end
+	
+	length 159
+	piece ab 2*gp pi gi et 4*mt etr gir pir gpr 3*gir abr
+	end
+	
+	length 160
+
+	piece ab 2*gp pi gi et 4*mt etr gir pir 2*gpr abr
+	end
+	
+	length 161
+	piece ab gi 2*gp pi gi et 4*mt etr gir pir 2*gpr abr
+	end
+	
+	length 162
+	piece ab gi 2*gp pi gi et 4*mt etr gir pir 2*gpr gir abr
+	end
+	
+	length 163
+	piece ab 2*gi 2*gp pi gi et 4*mt etr gir pir 2*gpr gir abr
+	end
+	
+	length 164
+	piece ab 2*gi 2*gp pi gi et 4*mt etr gir pir 2*gpr 2*gir abr
+	end
+	
+	length 165
+	piece ab et 5*mt etr abr
+	end
+	
+	length 166
+	piece ab gi et 5*mt etr abr
+	end
+	
+	length 167
+	piece ab gi et 5*mt etr gir abr
+	end
+	
+	length 168
+	piece ab pi gi et 5*mt etr gir abr
+	end
+	
+	length 169
+	piece ab pi gi et 5*mt etr gir pir abr
+	end	
+	
+	length 170
+	piece ab gi pi gi et 5*mt etr gir pir abr
+	end	
+	
+	length 171
+	piece ab gi pi gi et 5*mt etr gir pir gir abr
+	end	
+	
+	length 172
+	piece ab 2*gi pi gi et 5*mt etr gir pir gir abr
+	end	
+	
+	length 173
+	piece ab 2*gi pi gi et 5*mt etr gir pir 2*gir abr
+	end	
+	
+	length 174
+	piece ab 3*gi pi gi et 5*mt etr gir pir 2*gir abr
+	end	
+	
+	length 175
+	piece ab 3*gi pi gi et 5*mt etr gir pir 3*gir abr
+	end	
+	
+	length 176
+	piece ab gp pi gi et 5*mt etr gir pir 3*gir abr
+	end	
+	
+	length 177
+	piece ab gp pi gi et 5*mt etr gir pir gpr abr
+	end	
+	
+	length 178
+	piece ab gi gp pi gi et 5*mt etr gir pir gpr abr
+	end
+	
+	length 179
+	piece ab gi gp pi gi et 5*mt etr gir pir gpr gir abr
+	end
+	
+	length 180
+	piece ab 2*gi gp pi gi et 5*mt etr gir pir gpr gir abr
+	end
+	
+	length 181
+	piece ab 2*gi gp pi gi et 5*mt etr gir pir gpr 2*gir abr
+	end
+	
+	length 182
+	piece ab 3*gi gp pi gi et 5*mt etr gir pir gpr 2*gir abr
+	end
+	
+	length 183
+	piece ab 3*gi gp pi gi et 5*mt etr gir pir gpr 3*gir abr
+	end
+	
+	length 184
+	piece ab 2*gp pi gi et 5*mt etr gir pir gpr 3*gir abr
+	end
+	
+	length 185
+	piece ab 2*gp pi gi et 5*mt etr gir pir 2*gpr abr
+	end
+	
+	length 186
+	piece ab gi 2*gp pi gi et 5*mt etr gir pir 2*gpr abr
+	end
+	
+	length 187
+	piece ab gi 2*gp pi gi et 5*mt etr gir pir 2*gpr gir abr
+	end
+	
+	length 188
+	piece ab 2*gi 2*gp pi gi et 5*mt etr gir pir 2*gpr gir abr
+	end
+	
+	length 189
+	piece ab 2*gi 2*gp pi gi et 5*mt etr gir pir 2*gpr 2*gir abr
+	end
+	
+	length 190
+	piece ab et 6*mt etr abr
+	end
+	
+	length 191
+	piece ab gi et 6*mt etr abr
+	end
+	
+	length 192
+	piece ab gi et 6*mt etr gir abr
+	end
+	
+	length 193
+	piece ab pi gi et 6*mt etr gir abr
+	end
+	
+	length 194
+	piece ab pi gi et 6*mt etr gir pir abr
+	end	
+	
+	length 195
+	piece ab gi pi gi et 6*mt etr gir pir abr
+	end	
+	
+	length 196
+	piece ab gi pi gi et 6*mt etr gir pir gir abr
+	end	
+	
+	length 197
+	piece ab 2*gi pi gi et 6*mt etr gir pir gir abr
+	end	
+	
+	length 198
+	piece ab 2*gi pi gi et 6*mt etr gir pir 2*gir abr
+	end	
+	
+	length 199
+	piece ab 3*gi pi gi et 6*mt etr gir pir 2*gir abr
+	end	
+	
+	length 200
+	piece ab 3*gi pi gi et 6*mt etr gir pir 3*gir abr
+	end	
+	
+	length 201
+	piece ab gp pi gi et 6*mt etr gir pir 3*gir abr
+	end	
+	
+	length 202
+	piece ab gp pi gi et 6*mt etr gir pir gpr abr
+	end	
+	
+	length 203
+	piece ab gi gp pi gi et 6*mt etr gir pir gpr abr
+	end
+	
+	length 204
+	piece ab gi gp pi gi et 6*mt etr gir pir gpr gir abr
+	end
+	
+	length 205
+	piece ab 2*gi gp pi gi et 6*mt etr gir pir gpr gir abr
+	end
+	
+	length 206
+	piece ab 2*gi gp pi gi et 6*mt etr gir pir gpr 2*gir abr
+	end
+	
+	length 207
+	piece ab 3*gi gp pi gi et 6*mt etr gir pir gpr 2*gir abr
+	end
+	
+	length 208
+	piece ab 3*gi gp pi gi et 6*mt etr gir pir gpr 3*gir abr
+	end
+	
+	length 209
+	piece ab 2*gp pi gi et 6*mt etr gir pir gpr 3*gir abr
+	end
+	
+	length 210
+	piece ab 2*gp pi gi et 6*mt etr gir pir 2*gpr abr
+	end
+	
+	length 211
+	piece ab gi 2*gp pi gi et 6*mt etr gir pir 2*gpr abr
+	end
+	
+	length 212
+	piece ab gi 2*gp pi gi et 6*mt etr gir pir 2*gpr gir abr
+	end
+	
+	length 213
+	piece ab 2*gi 2*gp pi gi et 6*mt etr gir pir 2*gpr gir abr
+	end
+	
+	length 214
+	piece ab 2*gi 2*gp pi gi et 6*mt etr gir pir 2*gpr 2*gir abr
+	end
+	
+	length 215
+	piece ab et 7*mt etr abr
+	end
+	
+	length 216
+	piece ab gi et 7*mt etr abr
+	end
+	
+	length 217
+	piece ab gi et 7*mt etr gir abr
+	end
+	
+	length 218
+	piece ab pi gi et 7*mt etr gir abr
+	end
+	
+	length 219
+	piece ab pi gi et 7*mt etr gir pir abr
+	end	
+	
+	length 220
+	piece ab gi pi gi et 7*mt etr gir pir abr
+	end	
+	
+	length 221
+	piece ab gi pi gi et 7*mt etr gir pir gir abr
+	end	
+	
+	length 222
+	piece ab 2*gi pi gi et 7*mt etr gir pir gir abr
+	end	
+	
+	length 223
+	piece ab 2*gi pi gi et 7*mt etr gir pir 2*gir abr
+	end	
+	
+	length 224
+	piece ab 3*gi pi gi et 7*mt etr gir pir 2*gir abr
+	end	
+	
+	length 225
+	piece ab 3*gi pi gi et 7*mt etr gir pir 3*gir abr
+	end	
+	
+	length 226
+	piece ab gp pi gi et 7*mt etr gir pir 3*gir abr
+	end	
+	
+	length 227
+	piece ab gp pi gi et 7*mt etr gir pir gpr abr
+	end	
+	
+	length 228
+	piece ab gi gp pi gi et 7*mt etr gir pir gpr abr
+	end
+	
+	length 229
+	piece ab gi gp pi gi et 7*mt etr gir pir gpr gir abr
+	end
+	
+	length 230
+	piece ab 2*gi gp pi gi et 7*mt etr gir pir gpr gir abr
+	end
+	
+	length 231
+	piece ab 2*gi gp pi gi et 7*mt etr gir pir gpr 2*gir abr
+	end
+	
+	length 232
+	piece ab 3*gi gp pi gi et 7*mt etr gir pir gpr 2*gir abr
+	end
+	
+	length 233
+	piece ab 3*gi gp pi gi et 7*mt etr gir pir gpr 3*gir abr
+	end
+	
+	length 234
+	piece ab 2*gp pi gi et 7*mt etr gir pir gpr 3*gir abr
+	end
+	
+	length 235
+	piece ab 2*gp pi gi et 7*mt etr gir pir 2*gpr abr
+	end
+	
+	length 236
+	piece ab gi 2*gp pi gi et 7*mt etr gir pir 2*gpr abr
+	end
+	
+	length 237
+	piece ab gi 2*gp pi gi et 7*mt etr gir pir 2*gpr gir abr
+	end
+	
+	length 238
+	piece ab 2*gi 2*gp pi gi et 7*mt etr gir pir 2*gpr gir abr
+	end
+	
+	length 239
+	piece ab 2*gi 2*gp pi gi et 7*mt etr gir pir 2*gpr 2*gir abr
+	end
+	
+	length 240
+	piece ab et 8*mt etr abr
+	end
+
+	length 241
+	piece ab gi et 8*mt etr abr
+	end
+	
+	length 242
+	piece ab gi et 8*mt etr gir abr
+	end
+	
+	length 243
+	piece ab pi gi et 8*mt etr gir abr
+	end
+	
+	length 244
+	piece ab pi gi et 8*mt etr gir pir abr
+	end	
+	
+	length 245
+	piece ab gi pi gi et 8*mt etr gir pir abr
+	end	
+	
+	length 246
+	piece ab gi pi gi et 8*mt etr gir pir gir abr
+	end	
+	
+	length 247
+	piece ab 2*gi pi gi et 8*mt etr gir pir gir abr
+	end	
+	
+	length 248
+	piece ab 2*gi pi gi et 8*mt etr gir pir 2*gir abr
+	end	
+	
+	length 249
+	piece ab 3*gi pi gi et 8*mt etr gir pir 2*gir abr
+	end	
+	
+	length 250
+	piece ab 3*gi pi gi et 8*mt etr gir pir 3*gir abr
+	end	
+	
+	length 251
+	piece ab gp pi gi et 8*mt etr gir pir 3*gir abr
+	end	
+	
+	length 252
+	piece ab gp pi gi et 8*mt etr gir pir gpr abr
+	end	
+	
+	length 253
+	piece ab gi gp pi gi et 8*mt etr gir pir gpr abr
+	end
+	
+	length 254
+	piece ab gi gp pi gi et 8*mt etr gir pir gpr gir abr
+	end
+	
 end
 
 

--- a/Controller/INI/NetworkINI.ini
+++ b/Controller/INI/NetworkINI.ini
@@ -153,7 +153,8 @@ Debug=0
 8    = 0x40181000,0xFFFFF00F,0x4018100F,0x00000FF0 ;Custom Rail Bridges Draggable
 9    = 0x40182000,0xFFFFF00F,0x4018200F,0x00000FF0 ;Custom Rail Bridges Draggable
 10   = 0x40183000,0xFFFFF00F,0x4018300F,0x00000FF0 ;Custom Rail Bridges Draggable
-11   = 0x40330000,0xFFFF000F,0x4033000F,0x0000FFF0 ;Custom Rail Bridges Draggable	
+11   = 0x402D0000,0xFFFF000F,0x402D000F,0x0000FFF0 ;Custom Rail Bridges Draggable
+12   = 0x40330000,0xFFFF000F,0x4033000F,0x0000FFF0 ;Custom Rail Bridges Draggable	
 
 ;Custom Items Path files
 ;Custom Items Path files
@@ -4211,6 +4212,8 @@ HtOfNetworkAboveTerrain=0.0
 20 = 0x6534284a, 0xa82ca30f, 0x10200F20, Maxis 15m level bridge
 21 = 0x6534284a, 0xa82ca30f, 0x10210F21, Maxis 15m overdeck truss
 22 = 0x6534284a, 0xa82ca30f, 0x10220F01, GÃƒÂ¶ltzschtalbrÃ‚ÂEke
+40 = 0x6534284a, 0xa82ca30f, 0x10400F00, Maxis DTR stone arch (Pont du Train, Ceret, France) (Citymax)
+41 = 0x6534284a, 0xa82ca30f, 0x10410F00, Maxis DTR truss (Pont Eiffel de Reynes, Ceret, France) (Citymax)
 ;Custom RRW
 23 = 0x6534284a, 0xa82ca30f, 0x10230F00, RRW Dual-Track Steel Overtruss Bridge by eggman121
 24 = 0x6534284a, 0xa82ca30f, 0x10240F01, Repurposed Saltash bridge STR (eggman121)

--- a/ltext/bridges.pot
+++ b/ltext/bridges.pot
@@ -1040,3 +1040,71 @@ msgstr ""
 msgctxt "2026960B-6A231EAA-30531F01"
 msgid "Green Over Deck Truss (SAM-11)"
 msgstr ""
+
+msgctxt "2026960B-6A231EAA-B0449F01"
+msgid "Blue Suspension (RHW-2)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-B0459F01"
+msgid "Blue Suspension (RHW-3)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-B0469F01"
+msgid "Blue Suspension (RHW-4S)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-A0223F01"
+msgid "Blue Suspension (OWR-2)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-A0233F01"
+msgid "Blue Suspension (OWR-3)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-00382F01"
+msgid "Blue Suspension (Road)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-0039AF01"
+msgid "Blue Suspension (AVE-2)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-0040AF01"
+msgid "Blue Suspension (ARD-3)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-0041AF01"
+msgid "Blue Suspension (NRD-4)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30541F01"
+msgid "Blue Suspension (Street)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30551F01"
+msgid "Blue Suspension (SAM-2)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30561F01"
+msgid "Blue Suspension (SAM-6)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30571F01"
+msgid "Blue Suspension (SAM-7)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30581F01"
+msgid "Blue Suspension (SAM-8)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30591F01"
+msgid "Blue Suspension (SAM-9)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30601F01"
+msgid "Blue Suspension (SAM-10)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30611F01"
+msgid "Blue Suspension (SAM-11)"
+msgstr ""

--- a/ltext/bridges.pot
+++ b/ltext/bridges.pot
@@ -1108,3 +1108,7 @@ msgstr ""
 msgctxt "2026960B-6A231EAA-30611F01"
 msgid "Blue Suspension (SAM-11)"
 msgstr ""
+
+msgctxt "2026960B-6A231EAA-10260F01"
+msgid "Ponte di Piacenza (RRW-2)"
+msgstr ""

--- a/ltext/de/bridges.po
+++ b/ltext/de/bridges.po
@@ -1040,3 +1040,75 @@ msgstr ""
 msgctxt "2026960B-6A231EAA-30531F01"
 msgid "Green Over Deck Truss (SAM-11)"
 msgstr ""
+
+msgctxt "2026960B-6A231EAA-B0449F01"
+msgid "Blue Suspension (RHW-2)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-B0459F01"
+msgid "Blue Suspension (RHW-3)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-B0469F01"
+msgid "Blue Suspension (RHW-4S)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-A0223F01"
+msgid "Blue Suspension (OWR-2)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-A0233F01"
+msgid "Blue Suspension (OWR-3)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-00382F01"
+msgid "Blue Suspension (Road)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-0039AF01"
+msgid "Blue Suspension (AVE-2)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-0040AF01"
+msgid "Blue Suspension (ARD-3)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-0041AF01"
+msgid "Blue Suspension (NRD-4)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30541F01"
+msgid "Blue Suspension (Street)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30551F01"
+msgid "Blue Suspension (SAM-2)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30561F01"
+msgid "Blue Suspension (SAM-6)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30571F01"
+msgid "Blue Suspension (SAM-7)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30581F01"
+msgid "Blue Suspension (SAM-8)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30591F01"
+msgid "Blue Suspension (SAM-9)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30601F01"
+msgid "Blue Suspension (SAM-10)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30611F01"
+msgid "Blue Suspension (SAM-11)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-10260F01"
+msgid "Ponte di Piacenza (RRW-2)"
+msgstr ""

--- a/ltext/es/bridges.po
+++ b/ltext/es/bridges.po
@@ -1100,3 +1100,75 @@ msgstr ""
 msgctxt "2026960B-6A231EAA-30531F01"
 msgid "Green Over Deck Truss (SAM-11)"
 msgstr ""
+
+msgctxt "2026960B-6A231EAA-B0449F01"
+msgid "Blue Suspension (RHW-2)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-B0459F01"
+msgid "Blue Suspension (RHW-3)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-B0469F01"
+msgid "Blue Suspension (RHW-4S)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-A0223F01"
+msgid "Blue Suspension (OWR-2)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-A0233F01"
+msgid "Blue Suspension (OWR-3)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-00382F01"
+msgid "Blue Suspension (Road)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-0039AF01"
+msgid "Blue Suspension (AVE-2)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-0040AF01"
+msgid "Blue Suspension (ARD-3)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-0041AF01"
+msgid "Blue Suspension (NRD-4)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30541F01"
+msgid "Blue Suspension (Street)"
+msgstr "Puente de suspensión mediano"
+
+msgctxt "2026960B-6A231EAA-30551F01"
+msgid "Blue Suspension (SAM-2)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30561F01"
+msgid "Blue Suspension (SAM-6)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30571F01"
+msgid "Blue Suspension (SAM-7)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30581F01"
+msgid "Blue Suspension (SAM-8)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30591F01"
+msgid "Blue Suspension (SAM-9)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30601F01"
+msgid "Blue Suspension (SAM-10)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30611F01"
+msgid "Blue Suspension (SAM-11)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-10260F01"
+msgid "Ponte di Piacenza (RRW-2)"
+msgstr ""

--- a/ltext/fr/bridges.po
+++ b/ltext/fr/bridges.po
@@ -1040,3 +1040,75 @@ msgstr ""
 msgctxt "2026960B-6A231EAA-30531F01"
 msgid "Green Over Deck Truss (SAM-11)"
 msgstr ""
+
+msgctxt "2026960B-6A231EAA-B0449F01"
+msgid "Blue Suspension (RHW-2)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-B0459F01"
+msgid "Blue Suspension (RHW-3)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-B0469F01"
+msgid "Blue Suspension (RHW-4S)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-A0223F01"
+msgid "Blue Suspension (OWR-2)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-A0233F01"
+msgid "Blue Suspension (OWR-3)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-00382F01"
+msgid "Blue Suspension (Road)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-0039AF01"
+msgid "Blue Suspension (AVE-2)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-0040AF01"
+msgid "Blue Suspension (ARD-3)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-0041AF01"
+msgid "Blue Suspension (NRD-4)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30541F01"
+msgid "Blue Suspension (Street)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30551F01"
+msgid "Blue Suspension (SAM-2)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30561F01"
+msgid "Blue Suspension (SAM-6)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30571F01"
+msgid "Blue Suspension (SAM-7)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30581F01"
+msgid "Blue Suspension (SAM-8)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30591F01"
+msgid "Blue Suspension (SAM-9)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30601F01"
+msgid "Blue Suspension (SAM-10)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30611F01"
+msgid "Blue Suspension (SAM-11)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-10260F01"
+msgid "Ponte di Piacenza (RRW-2)"
+msgstr ""

--- a/ltext/it/bridges.po
+++ b/ltext/it/bridges.po
@@ -1042,3 +1042,75 @@ msgstr ""
 msgctxt "2026960B-6A231EAA-30531F01"
 msgid "Green Over Deck Truss (SAM-11)"
 msgstr ""
+
+msgctxt "2026960B-6A231EAA-B0449F01"
+msgid "Blue Suspension (RHW-2)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-B0459F01"
+msgid "Blue Suspension (RHW-3)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-B0469F01"
+msgid "Blue Suspension (RHW-4S)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-A0223F01"
+msgid "Blue Suspension (OWR-2)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-A0233F01"
+msgid "Blue Suspension (OWR-3)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-00382F01"
+msgid "Blue Suspension (Road)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-0039AF01"
+msgid "Blue Suspension (AVE-2)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-0040AF01"
+msgid "Blue Suspension (ARD-3)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-0041AF01"
+msgid "Blue Suspension (NRD-4)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30541F01"
+msgid "Blue Suspension (Street)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30551F01"
+msgid "Blue Suspension (SAM-2)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30561F01"
+msgid "Blue Suspension (SAM-6)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30571F01"
+msgid "Blue Suspension (SAM-7)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30581F01"
+msgid "Blue Suspension (SAM-8)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30591F01"
+msgid "Blue Suspension (SAM-9)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30601F01"
+msgid "Blue Suspension (SAM-10)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30611F01"
+msgid "Blue Suspension (SAM-11)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-10260F01"
+msgid "Ponte di Piacenza (RRW-2)"
+msgstr ""

--- a/ltext/ko/bridges.po
+++ b/ltext/ko/bridges.po
@@ -1043,3 +1043,75 @@ msgstr ""
 msgctxt "2026960B-6A231EAA-30531F01"
 msgid "Green Over Deck Truss (SAM-11)"
 msgstr ""
+
+msgctxt "2026960B-6A231EAA-B0449F01"
+msgid "Blue Suspension (RHW-2)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-B0459F01"
+msgid "Blue Suspension (RHW-3)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-B0469F01"
+msgid "Blue Suspension (RHW-4S)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-A0223F01"
+msgid "Blue Suspension (OWR-2)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-A0233F01"
+msgid "Blue Suspension (OWR-3)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-00382F01"
+msgid "Blue Suspension (Road)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-0039AF01"
+msgid "Blue Suspension (AVE-2)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-0040AF01"
+msgid "Blue Suspension (ARD-3)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-0041AF01"
+msgid "Blue Suspension (NRD-4)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30541F01"
+msgid "Blue Suspension (Street)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30551F01"
+msgid "Blue Suspension (SAM-2)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30561F01"
+msgid "Blue Suspension (SAM-6)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30571F01"
+msgid "Blue Suspension (SAM-7)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30581F01"
+msgid "Blue Suspension (SAM-8)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30591F01"
+msgid "Blue Suspension (SAM-9)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30601F01"
+msgid "Blue Suspension (SAM-10)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30611F01"
+msgid "Blue Suspension (SAM-11)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-10260F01"
+msgid "Ponte di Piacenza (RRW-2)"
+msgstr ""

--- a/ltext/nl/bridges.po
+++ b/ltext/nl/bridges.po
@@ -1040,3 +1040,75 @@ msgstr ""
 msgctxt "2026960B-6A231EAA-30531F01"
 msgid "Green Over Deck Truss (SAM-11)"
 msgstr ""
+
+msgctxt "2026960B-6A231EAA-B0449F01"
+msgid "Blue Suspension (RHW-2)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-B0459F01"
+msgid "Blue Suspension (RHW-3)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-B0469F01"
+msgid "Blue Suspension (RHW-4S)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-A0223F01"
+msgid "Blue Suspension (OWR-2)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-A0233F01"
+msgid "Blue Suspension (OWR-3)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-00382F01"
+msgid "Blue Suspension (Road)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-0039AF01"
+msgid "Blue Suspension (AVE-2)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-0040AF01"
+msgid "Blue Suspension (ARD-3)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-0041AF01"
+msgid "Blue Suspension (NRD-4)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30541F01"
+msgid "Blue Suspension (Street)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30551F01"
+msgid "Blue Suspension (SAM-2)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30561F01"
+msgid "Blue Suspension (SAM-6)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30571F01"
+msgid "Blue Suspension (SAM-7)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30581F01"
+msgid "Blue Suspension (SAM-8)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30591F01"
+msgid "Blue Suspension (SAM-9)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30601F01"
+msgid "Blue Suspension (SAM-10)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30611F01"
+msgid "Blue Suspension (SAM-11)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-10260F01"
+msgid "Ponte di Piacenza (RRW-2)"
+msgstr ""

--- a/ltext/pt/bridges.po
+++ b/ltext/pt/bridges.po
@@ -1042,3 +1042,75 @@ msgstr ""
 msgctxt "2026960B-6A231EAA-30531F01"
 msgid "Green Over Deck Truss (SAM-11)"
 msgstr ""
+
+msgctxt "2026960B-6A231EAA-B0449F01"
+msgid "Blue Suspension (RHW-2)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-B0459F01"
+msgid "Blue Suspension (RHW-3)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-B0469F01"
+msgid "Blue Suspension (RHW-4S)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-A0223F01"
+msgid "Blue Suspension (OWR-2)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-A0233F01"
+msgid "Blue Suspension (OWR-3)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-00382F01"
+msgid "Blue Suspension (Road)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-0039AF01"
+msgid "Blue Suspension (AVE-2)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-0040AF01"
+msgid "Blue Suspension (ARD-3)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-0041AF01"
+msgid "Blue Suspension (NRD-4)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30541F01"
+msgid "Blue Suspension (Street)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30551F01"
+msgid "Blue Suspension (SAM-2)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30561F01"
+msgid "Blue Suspension (SAM-6)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30571F01"
+msgid "Blue Suspension (SAM-7)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30581F01"
+msgid "Blue Suspension (SAM-8)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30591F01"
+msgid "Blue Suspension (SAM-9)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30601F01"
+msgid "Blue Suspension (SAM-10)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30611F01"
+msgid "Blue Suspension (SAM-11)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-10260F01"
+msgid "Ponte di Piacenza (RRW-2)"
+msgstr ""

--- a/ltext/sv/bridges.po
+++ b/ltext/sv/bridges.po
@@ -1042,3 +1042,75 @@ msgstr ""
 msgctxt "2026960B-6A231EAA-30531F01"
 msgid "Green Over Deck Truss (SAM-11)"
 msgstr ""
+
+msgctxt "2026960B-6A231EAA-B0449F01"
+msgid "Blue Suspension (RHW-2)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-B0459F01"
+msgid "Blue Suspension (RHW-3)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-B0469F01"
+msgid "Blue Suspension (RHW-4S)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-A0223F01"
+msgid "Blue Suspension (OWR-2)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-A0233F01"
+msgid "Blue Suspension (OWR-3)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-00382F01"
+msgid "Blue Suspension (Road)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-0039AF01"
+msgid "Blue Suspension (AVE-2)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-0040AF01"
+msgid "Blue Suspension (ARD-3)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-0041AF01"
+msgid "Blue Suspension (NRD-4)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30541F01"
+msgid "Blue Suspension (Street)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30551F01"
+msgid "Blue Suspension (SAM-2)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30561F01"
+msgid "Blue Suspension (SAM-6)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30571F01"
+msgid "Blue Suspension (SAM-7)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30581F01"
+msgid "Blue Suspension (SAM-8)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30591F01"
+msgid "Blue Suspension (SAM-9)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30601F01"
+msgid "Blue Suspension (SAM-10)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-30611F01"
+msgid "Blue Suspension (SAM-11)"
+msgstr ""
+
+msgctxt "2026960B-6A231EAA-10260F01"
+msgid "Ponte di Piacenza (RRW-2)"
+msgstr ""


### PR DESCRIPTION
Adds bridge RULs and LTEXTs for all new (qty. 17) blue suspension bridges. 

Adds bridge RULs to all previously included yellow girder bridges in order to fix a T21 issue.

Creates placeholder declarations in network.ini for qty. 2 rail bridges by Citymax.