### PR TITLE
add new HRW bridge exemplars

### DIFF
--- a/Controller/INI/NetworkINI.ini
+++ b/Controller/INI/NetworkINI.ini
@@ -4392,6 +4392,12 @@ HtOfNetworkAboveTerrain=0.0
 14 = 0x6534284a, 0xa82ca30f, 0x0000A14E 9014DF00, warren thru-truss GHSR bridge
 15 = 0x6534284a, 0xa82ca30f, 0x0000A14F 9015DF00, box girder GHSR bridge
 16 = 0x6534284a, 0xa82ca30f, 0x0000A155 9016DF01, cable stayed GHSR bridge
+;17 = 0x6534284a, 0xa82ca30f, 0x0000A166, HRW Iron Girder Bridge       ;Not included yet!
+;18 = 0x6534284a, 0xa82ca30f, 0x0000A169, HRW Steel Overtruss Bridge > ;These reference the
+;19 = 0x6534284a, 0xa82ca30f, 0x0000A16c, HRW Stone Arch Bridge        ;RRW bridge models
+20 = 0x6534284a, 0xa82ca30f, 0x0000A170, Plain HRW L0 Bridge
+21 = 0x6534284a, 0xa82ca30f, 0x0000A171, Plain HRW L1 Bridge
+22 = 0x6534284a, 0xa82ca30f, 0x0000A172, Plain HRW L2 Bridge
 
 
 ;--------------------------------------------------------


### PR DESCRIPTION
Adds exemplar IDs for Plain HRW Bridge (L0, L1, L2) as well as three placeholders for not yet enabled HRW bridges.