### PR TITLE
update GH action for compatibility with GH runner Ubuntu 24.04

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -20,11 +20,12 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up JDK 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: '17'
         distribution: 'temurin'
         cache: 'sbt'
+    - uses: sbt/setup-sbt@v1
     - name: Run tests
       run: sbt test
     - name: Generate locale files


### PR DESCRIPTION
With Ubuntu 24.04, sbt is not part of the default environment anymore.