### PR TITLE
decrease radius of NWM intersection paths

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ import io.github.memo33.metarules.meta._, com.sc4nam.module, module.syntax._
 import Implicits._, Network._, Flags._, RotFlip._, Rule.{CopyTile => %}, group.SymGroup._
 lazy val resolve = module.Main.resolveSafely
 lazy val preimage = module.ReverseResolver.create()
-implicit lazy val context: RuleTransducer.Context = RuleTransducer.Context(resolve, module.RegenerateTileOrientationCache.loadCache(), module.MirrorVariants.preprocessor)
+implicit lazy val context: RuleTransducer.Context = RuleTransducer.Context(module.Main.resolve, module.RegenerateTileOrientationCache.loadCache(), module.MirrorVariants.preprocessor)
 def transduce(rule: Rule[SymTile]): Unit = RuleTransducer(rule)(context).map(_.toRul2String).foreach(println)
 """
 
@@ -71,4 +71,4 @@ libraryDependencies += "tv.cntt" %% "scaposer" % "1.11.1" cross CrossVersion.for
 
 libraryDependencies += "io.github.memo33" %% "scdbpf" % "0.2.0" cross CrossVersion.for3Use2_13
 
-libraryDependencies += "io.github.memo33" %% "metarules" % "0.7.0"
+libraryDependencies += "io.github.memo33" %% "metarules" % "0.7.1"

--- a/src/main/scala/module/CompileAllMetarules.scala
+++ b/src/main/scala/module/CompileAllMetarules.scala
@@ -31,7 +31,7 @@ object CompileAllMetarules {
 
   /** Add additional rule generators here.
     */
-  def compileMetarulesOnce(tileOrientationCache: collection.mutable.Map[Int, Set[RotFlip]]): Unit = {
+  def compileMetarulesOnce(tileOrientationCache: RuleTransducer.TileOrientationCache): Unit = {
     LOGGER.info("compiling FlexFly metarule code")
     flexfly.CompileFlexFlyCode.start(tileOrientationCache = tileOrientationCache)
     LOGGER.info("compiling RRW metarule code")

--- a/src/main/scala/module/Main.scala
+++ b/src/main/scala/module/Main.scala
@@ -25,15 +25,15 @@ abstract class AbstractMain {
   lazy val resolveSafely: IdResolver = new PartialFunction[Tile, IdTile] {
     def isDefinedAt(tile: Tile) = resolve.isDefinedAt(tile)
     def apply(tile: Tile) = try resolve.apply(tile) catch {
-      case scala.util.control.NonFatal(e) =>
-        throw new IllegalArgumentException(s"ID resolution failed for tile $tile", e)
+      case e: RuleTransducer.ResolutionFailed => throw e
+      case scala.util.control.NonFatal(e) => throw new RuleTransducer.ResolutionFailed(tile, rule = None, reason = e, frame = None)
     }
   }
 
   def main(args: Array[String]): Unit = start()
 
   /** Creates a generator with a new context, runs its start method and outputs the resulting RUL2 code to file. */
-  def start(file: File = file, tileOrientationCache: collection.mutable.Map[Int, Set[RotFlip]] = null): Unit = {
+  def start(file: File = file, tileOrientationCache: RuleTransducer.TileOrientationCache = null): Unit = {
     if (tileOrientationCache == null) {
       RegenerateTileOrientationCache.withCache { cache =>
         start(file, cache)

--- a/src/main/scala/module/RegenerateTileOrientationCache.scala
+++ b/src/main/scala/module/RegenerateTileOrientationCache.scala
@@ -2,6 +2,7 @@ package com.sc4nam.module
 
 import java.io.File
 import io.github.memo33.metarules.meta.RotFlip
+import syntax.RuleTransducer.TileOrientationCache
 
 /** Manages the tile orientation cache. The cache is necessary to maintain
   * information about non-standard orientations:
@@ -23,19 +24,24 @@ object RegenerateTileOrientationCache {
 
   /** Repeatedly compiles the metarule code until the cache does not get changed anymore.
     */
-  def compileMetarulesUntilStable(tileOrientationCache: collection.mutable.Map[Int, Set[RotFlip]]): Unit = {
+  def compileMetarulesUntilStable(cache: collection.mutable.Map[Int, Set[RotFlip]]): Unit = {
+    val tileOrientationCache = TileOrientationCache(cache = cache, accum = collection.mutable.Map.empty[Int, Set[RotFlip]])
     var j = 0
     var stabilized = false
-    var previous: collection.immutable.Map[Int, Set[RotFlip]] = tileOrientationCache.toMap
-    while (j < 3 && !stabilized) {
-      LOGGER.info(s"> metarules compilation: iteration $j")
+    val maxIter = 5
+    while (j < 5 && !stabilized) {
       j += 1
+      LOGGER.info(s"> metarules compilation: iteration $j")
       CompileAllMetarules.compileMetarulesOnce(tileOrientationCache)
-      val next = tileOrientationCache.toMap
-      if (next == previous) {
+      if (tileOrientationCache.accum.nonEmpty) {
+        tileOrientationCache.cache ++= tileOrientationCache.accum
+        tileOrientationCache.accum.clear()
+        if (j == maxIter) {
+          LOGGER.warning(s"Tile orientation cache could not be regenerated in $maxIter iterations. Increase the number of iterations or check if there is a bug.")
+        }
+      } else {
         stabilized = true
       }
-      previous = next
     }
   }
 
@@ -50,7 +56,7 @@ object RegenerateTileOrientationCache {
     }
   }
 
-  def loadCache(): collection.mutable.Map[Int, Set[RotFlip]] = {
+  def loadCache(): TileOrientationCache = {
     scala.util.Using.resource(new java.util.Scanner(cacheFile, "UTF-8")) { scanner =>
       val cache = collection.mutable.Map.empty[Int, Set[RotFlip]]
       while(scanner.hasNextLine()) {
@@ -62,21 +68,18 @@ object RegenerateTileOrientationCache {
           cache(id) = orientations
         }
       }
-      cache
+      TileOrientationCache(cache = cache, accum = collection.mutable.Map.empty[Int, Set[RotFlip]])
     }
   }
 
   /** Loads the cache and gives a warning at the end if it was changed.
     */
-  def withCache[U](body: collection.mutable.Map[Int, Set[RotFlip]] => U): U = {
-    var previous: collection.immutable.Map[Int, Set[RotFlip]] = null
-    val cache = loadCache()
+  def withCache[U](body: TileOrientationCache => U): U = {
+    val tileOrientationCache = loadCache()
     try {
-      previous = cache.toMap
-      body(cache)
+      body(tileOrientationCache)
     } finally {
-      assert(previous != null)
-      if (previous != cache.toMap) {
+      if (tileOrientationCache.accum.nonEmpty) {
         LOGGER.warning(s"The file ${cacheFile} is outdated. Rebuild it with `sbt regenerateTileOrientationCache` and commit the changes.")
       }
     }

--- a/src/main/scala/pathing/nwmpaths/PathCreator.scala
+++ b/src/main/scala/pathing/nwmpaths/PathCreator.scala
@@ -23,7 +23,7 @@ object PathCreator {
   }
 
   def generateNwmPaths(implicit resolver: IdResolver): Iterable[BufferedEntry[Sc4Path]] = {
-    val ids = scala.collection.mutable.Map.empty[Int, Sc4Path]
+    val ids = scala.collection.mutable.Map.empty[Int, (Sc4Path, Boolean)]
     // TODO provisional
     val mainNetworks = NwmNetworks -- Set(Ave8)
     val minorNetworks = NwmNetworks ++ Set(Road, Street, Onewayroad, Avenue) -- Set(Ave8)
@@ -32,13 +32,13 @@ object PathCreator {
       minor <- minorNetworks
     } /*do*/ {
       import Flags._, Implicits._
-      def add(seg1: Segment, seg2: Segment) = {
+      def add(seg1: Segment, seg2: Segment, modelBased: Boolean) = {
         val tile0 = NetworkProperties.transformSharedDiagonals(seg1 & seg2)
         if (!seg1.network.isTla && !seg2.network.isTla) {
           val idTile = resolver(tile0)
           if (!ids.contains(idTile.id)) {
             val intersection = new PlusIntersection(seg1, seg2)
-            ids(idTile.id) = intersection.buildSc4Path * (R0F0 / idTile.rf)
+            ids(idTile.id) = (intersection.buildSc4Path * (R0F0 / idTile.rf), modelBased)
           }
         } else {
           // special handling for center turning lanes of TLAs
@@ -48,33 +48,53 @@ object PathCreator {
           val idTile2 = resolver(NetworkProperties.projectTlaLeft(tile0 * R0F1))
           if (!ids.contains(idTile1.id)) {
             val intersection = new PlusIntersection(seg1, seg2)
-            ids(idTile1.id) = intersection.buildSc4Path * (R0F0 / idTile1.rf)
+            ids(idTile1.id) = (intersection.buildSc4Path * (R0F0 / idTile1.rf), modelBased)
           }
           if (!ids.contains(idTile2.id)) {
             val intersection = new PlusIntersection(seg1 * R0F1, seg2 * R0F1)
             val stop = intersection.buildSc4Path * (R0F0 / idTile2.rf)
-            ids(idTile2.id) = stop.copy(stopPaths = stop.stopPaths.map(p => p.copy(uk = !p.uk)))  // flip uk flag to account for mirroring
+            ids(idTile2.id) = (stop.copy(stopPaths = stop.stopPaths.map(p => p.copy(uk = !p.uk))), modelBased)  // flip uk flag to account for mirroring
           }
         }
       }
+      def hasDiagonalOverhangs(n: Network): Boolean = n.isNwm && NetworkProperties.isSingleTile(n) && n != Owr1
       // In the following, it is important to choose the same directions as in
       // the IID scheme, since otherwise the uk flags can end up flipped.
       for { // OxD
         mainDir <- Seq(NS, SN)
         minDir <- Seq(SW, WS)
       } /*do*/ {
-        add(main~mainDir, minor~minDir)
+        add(main~mainDir, minor~minDir, modelBased =
+          hasDiagonalOverhangs(main) && hasDiagonalOverhangs(minor)
+          || main.height != 0 || minor.height != 0,
+        )
       }
-      for { // DxO, DxD
+      for { // DxO
         mainDir <- Seq(ES, SE)
-        minDir <- Seq(EW, WE, SW, WS)
+        minDir <- Seq(EW, WE)
       } /*do*/ {
-        add(main~mainDir, minor~minDir)
+        add(main~mainDir, minor~minDir, modelBased =
+          hasDiagonalOverhangs(main) && hasDiagonalOverhangs(minor)
+          || main.height != 0 || minor.height != 0,
+        )
+      }
+      for { // DxD
+        mainDir <- Seq(ES, SE)
+        minDir <- Seq(SW, WS)
+      } /*do*/ {
+        add(main~mainDir, minor~minDir, modelBased =
+          (hasDiagonalOverhangs(main) || hasDiagonalOverhangs(minor)) && (main != Owr1 && minor != Owr1)
+          || main.height != 0 || minor.height != 0,
+        )
       }
     }
-    ids.map { case (id, p) =>
+    ids.map { case (id, (p, modelBased)) =>
       require(p.validateClassNumbers, "duplicate class numbers detected in " + p.toString)
-      BufferedEntry(tgi = Tgi(0,0,id).copy(Tgi.Sc4Path2d), content = p.copy(decFormat = Some(Sc4Path.threeDecimals)), compressed = true)
+      BufferedEntry(
+        tgi = Tgi(0,0,id).copy(if (modelBased) Tgi.Sc4Path3d else Tgi.Sc4Path2d),
+        content = p.copy(decFormat = Some(Sc4Path.threeDecimals)),
+        compressed = true,
+      )
     }
   }
 }

--- a/src/main/scala/pathing/nwmpaths/plusIntersection.scala
+++ b/src/main/scala/pathing/nwmpaths/plusIntersection.scala
@@ -2,6 +2,7 @@ package com.sc4nam.pathing.nwmpaths
 
 import io.github.memo33.metarules.pathing._, Bezier._
 import com.sc4nam.module.syntax.{Network, Segment}
+import com.sc4nam.module.{NetworkProperties => NP}
 import io.github.memo33.scdbpf, scdbpf.Sc4Path.Cardinal, Cardinal._, scdbpf.DbpfUtil.RotFlip._, scdbpf.Sc4Path.{TransportType => TT}
 import PathCreator.{SPath, SPaths}
 
@@ -70,6 +71,11 @@ class PlusIntersection(major: Segment, minor: Segment) extends CommonIntersectio
     val n = network(c)
     n == Network.Onewayroad || n.base.exists(_ == Network.Onewayroad)
   }
+
+  override val MaxRadius =
+    if (NP.isTripleTile(major.network) || NP.isTripleTile(minor.network)) 6.0
+    else if (NP.isDoubleTile(major.network) && NP.isDoubleTile(minor.network)) 14.0
+    else 8.5  // single/single or mixed double/single
 
   protected def rightTurnPaths(c: Cardinal, tt: TT) = if (tt == TT.Sim || tt == TT.Car) {
     sortedPaths(c).find(_.tt == tt).toSeq

--- a/src/test/scala/meta/RuleTransducerSpec.scala
+++ b/src/test/scala/meta/RuleTransducerSpec.scala
@@ -10,21 +10,20 @@ import RuleTransducer._
 class RuleTransducerSpec extends AnyWordSpec with Matchers {
 
   val resolver = new module.RhwResolver orElse new module.NwmResolver orElse new module.MiscResolver
-  val tileOrientationCache = collection.mutable.Map.empty[Int, Set[RotFlip]]
-  val context = RuleTransducer.Context(resolver, tileOrientationCache, module.MirrorVariants.preprocessor)
+  val context = RuleTransducer.Context(resolver, preprocess = module.MirrorVariants.preprocessor)
 
   "preprocessor" should {
     "produce expected number of rules for Tla3" in {
       val orth: Seq[Rule[SymTile]] = context.preprocess( Tla3~WE | (Road ~> Tla3)~WE ).toSeq
       orth should have size (1)
       orth.asInstanceOf[Seq[Rule[Tile]]].exists(_.exists(_.segs.exists(s => s.flags.manifest == Flag.RightSpinBi && s.flags.exists(_ == 2)))) should be (false)
-      createRules(orth.head.map(_.toIdSymTile(resolver)), tileOrientationCache).toSeq should have size (2)
+      createRules(orth.head.map(_.toIdSymTile(resolver)), context.tileOrientationCache.cache, context.tileOrientationCache.accum).toSeq should have size (2)
 
       context.preprocess( Tla3~WE & Road~NS | (Road ~> Tla3)~WE ).toSeq should have size (1)
       val diag = context.preprocess( Tla3~WE & Road~WS | (Road ~> Tla3)~WE ).toSeq
       diag should have size (2)
       for (r <- diag) {
-        createRules(r.map(_.toIdSymTile(resolver)), tileOrientationCache).toSeq should have size (2)
+        createRules(r.map(_.toIdSymTile(resolver)), context.tileOrientationCache.cache, context.tileOrientationCache.accum).toSeq should have size (2)
       }
     }
   }
@@ -53,7 +52,7 @@ class RuleTransducerSpec extends AnyWordSpec with Matchers {
     "find RHS for TLA" in {
       val rule = (Tla3~WE | (Road ~> Tla3)~(2,0,11,0)) map makeTileLeft map (_.toIdSymTile(resolver))
       possibleMapOrientation(Set(R0F0, R1F0), R3F0/R2F1, Quotient.Dih4, R1F1/R2F1) should not be (Symbol("empty"))
-      createRules(rule, tileOrientationCache)
+      createRules(rule, context.tileOrientationCache.cache, context.tileOrientationCache.accum)
     }
     "resolve diagonal TLA intersections" in {
       val t1 = makeTileLeft(Tla3~ES & Road~WS)


### PR DESCRIPTION
On some NWM intersections, especially the triple tilers, the generated NWM paths had a very large radius. This created problems as the outer tiles of AVE-6/TLA-7 are shared, so the turning lanes shouldn't extend to the outer tiles.

This PR sets a smaller maximum radius for the turning lane paths generated by the script. It also reduces the asymmetry to a ratio of at most 1.33, to avoid some of the very asymmetrical turns (e.g. at intersections between triple- and single-tile networks).

Additionally, it attempts to set a better Group ID for the generated paths (2D vs 3D), depending on whether the network tile is likely to be model-based due to overhangs. This may not be perfect yet. Feedback welcome.

Generate new paths with: `sbt "runMain com.sc4nam.pathing.nwmpaths.Main"`

(Setting this PR as draft for now in case further tweaking is needed for the GIDs or the turn path shape, but it's ready from my point of view.)