### PR TITLE
disable AutoPlace for FAR pieces to prevent TE-lot conflicts

### DIFF
--- a/Controller/RUL0/7000_Road_NWM/7600_FARPieces.txt
+++ b/Controller/RUL0/7000_Road_NWM/7600_FARPieces.txt
@@ -266,7 +266,6 @@ ConsLayout =...^.....
 AutoTileBase=	0x50465000
 ReplacementIntersection = 0, 0
 PlaceQueryID = 0x50465000
-AutoPlace = 1
 Costs = 155; edited by dedgren 081229
 [HighwayIntersectionInfo_0x00017603]
 CopyFrom = 0x7603
@@ -404,7 +403,6 @@ ConsLayout =...^.....
 AutoTileBase=   0x50467000
 ReplacementIntersection = 0, 0
 PlaceQueryID = 0x50467000
-AutoPlace = 1
 Costs = 105
 [HighwayIntersectionInfo_0x00017605]
 CopyFrom = 0x7605
@@ -473,7 +471,6 @@ ConsLayout =...^.....
 AutoTileBase=   0x50468000
 ReplacementIntersection = 0, 0
 PlaceQueryID = 0x50468000
-AutoPlace = 1
 Costs = 85
 [HighwayIntersectionInfo_0x00017606]
 CopyFrom = 0x7606
@@ -543,7 +540,6 @@ AutoTileBase=   0x50469000
 ReplacementIntersection = 0, 0
 PlaceQueryID = 0x50469000
 Costs = 85
-AutoPlace = 1
 [HighwayIntersectionInfo_0x00017607]
 CopyFrom = 0x7607
 Rotate = 1


### PR DESCRIPTION
Otherwise, this can lead to immortal lots (or CTDs without sc4fix) if a lot uses the same Road pattern as the AutoPlace piece.