### PR TITLE
FIx typo in RUL0 6600_DiagonalStreets.txt

### DIFF
--- a/Controller/RUL0/6000_Street_PedMall_SAM/6600_DiagonalStreets.txt
+++ b/Controller/RUL0/6000_Street_PedMall_SAM/6600_DiagonalStreets.txt
@@ -79,7 +79,7 @@ CellLayout =..ba<
 CellLayout =.....
 CellLayout =..^..
 
-CheckType = a - street: 0x00000002,0xff00fffff check
+CheckType = a - street: 0x00000002,0xff00ffff check
 CheckType = b - street: 0x00000000;0x01030103
 
 ConsLayout =.....

--- a/Lite Controller/RUL0/6000_Street_PedMall_SAM/6600_DiagonalStreets.txt
+++ b/Lite Controller/RUL0/6000_Street_PedMall_SAM/6600_DiagonalStreets.txt
@@ -79,7 +79,7 @@ CellLayout =..ba<
 CellLayout =.....
 CellLayout =..^..
 
-CheckType = a - street: 0x00000002,0xff00fffff check
+CheckType = a - street: 0x00000002,0xff00ffff check
 CheckType = b - street: 0x00000000;0x01030103
 
 ConsLayout =.....


### PR DESCRIPTION
Fix typo (extra f in a CheckType) in 6600_DiagonalStreets.txt in the Lite and Full controller