### PR TITLE
Fix ReplacementIntersection0 typos in multiple RUL0 files

### DIFF
--- a/Controller/RUL0/7000_Road_NWM/7800_RoadxRHW.txt
+++ b/Controller/RUL0/7000_Road_NWM/7800_RoadxRHW.txt
@@ -1397,7 +1397,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e6a600
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e6a600
 Costs       = 50
 [HighwayIntersectionInfo_0x00017816]
@@ -1427,7 +1427,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e6a000
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e6a000
 Costs       = 50
 [HighwayIntersectionInfo_0x00057816]
@@ -1451,7 +1451,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e6a100
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e6a100
 Costs       = 50
 [HighwayIntersectionInfo_0x00077816]
@@ -1485,7 +1485,7 @@ ConsLayout =....+....
 ConsLayout =....^....
 
 AutoTileBase=	0x53e6a300
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e6a300
 Costs       = 50
 [HighwayIntersectionInfo_0x000B7816]
@@ -1521,7 +1521,7 @@ ConsLayout =....+....
 ConsLayout =....^....
 
 AutoTileBase=	0x53e6a200
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e6a200
 Costs       = 50
 [HighwayIntersectionInfo_0x00017817]
@@ -1554,7 +1554,7 @@ ConsLayout =....+....
 ConsLayout =....^....
 
 AutoTileBase=	0x53e6a400
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e6a400
 Costs       = 50
 [HighwayIntersectionInfo_0x00057817]
@@ -1586,7 +1586,7 @@ ConsLayout =....+....
 ConsLayout =....^....
 
 AutoTileBase=	0x53e6a500
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e6a500
 Costs       = 50
 [HighwayIntersectionInfo_0x00097817]

--- a/Controller/RUL0/7000_Road_NWM/7A00_NWM/7A00_URoad.txt
+++ b/Controller/RUL0/7000_Road_NWM/7A00_NWM/7A00_URoad.txt
@@ -360,7 +360,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e64000
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e64000
 Costs       = 50
 [HighwayIntersectionInfo_0x00017A10]
@@ -388,7 +388,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e64100
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e64100
 Costs       = 50
 [HighwayIntersectionInfo_0x00057A10]
@@ -431,7 +431,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e64200
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e64200
 Costs       = 50
 [HighwayIntersectionInfo_0x00017A11]
@@ -482,7 +482,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e64300
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e64300
 Costs       = 50
 [HighwayIntersectionInfo_0x00017A12]
@@ -524,7 +524,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e64400
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e64400
 Costs       = 50
 [HighwayIntersectionInfo_0x00097A12]
@@ -555,7 +555,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=  0x53e64500
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e64500
 Costs       = 50
 [HighwayIntersectionInfo_0x00017A13]
@@ -606,7 +606,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e64600
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e64600
 Costs       = 50
 [HighwayIntersectionInfo_0x00017A14]
@@ -648,7 +648,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e64700
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e64700
 Costs       = 50
 [HighwayIntersectionInfo_0x00097A14]
@@ -679,7 +679,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e66000
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e66000
 Costs       = 50
 [HighwayIntersectionInfo_0x00017A20]
@@ -703,7 +703,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e66200
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e66200
 Costs       = 50
 [HighwayIntersectionInfo_0x00037A20]
@@ -727,7 +727,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e66100
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e66100
 Costs       = 50
 [HighwayIntersectionInfo_0x00057A20]
@@ -770,7 +770,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=  0x53e66500
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e66500
 Costs       = 50
 [HighwayIntersectionInfo_0x00017A21]
@@ -812,7 +812,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e66b00
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e66b00
 Costs       = 50
 [HighwayIntersectionInfo_0x00097A21]
@@ -843,7 +843,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e66600
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e66600
 Costs       = 50
 [HighwayIntersectionInfo_0x00017A22]
@@ -885,7 +885,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e66700
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e66700
 Costs       = 50
 [HighwayIntersectionInfo_0x00097A22]
@@ -916,7 +916,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e66300
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e66300
 Costs       = 50
 [HighwayIntersectionInfo_0x00017A23]
@@ -940,7 +940,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e66400
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e66400
 Costs       = 50
 [HighwayIntersectionInfo_0x00037A23]
@@ -984,7 +984,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e64800
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e64800
 Costs       = 50
 [HighwayIntersectionInfo_0x00017A30]
@@ -1014,7 +1014,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e64900
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e64900
 Costs       = 50
 [HighwayIntersectionInfo_0x00057A30]
@@ -1058,7 +1058,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e67000
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e67000
 Costs       = 50
 OneWayDir	= 0
@@ -1089,7 +1089,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e67100
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e67100
 Costs       = 50
 OneWayDir	= 0
@@ -1120,7 +1120,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e67200
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e67200
 Costs       = 50
 OneWayDir	= 0
@@ -1153,7 +1153,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e67000
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e67000
 Costs       = 50
 OneWayDir	= 4
@@ -1184,7 +1184,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e67300
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e67300
 Costs       = 50
 OneWayDir	= 4
@@ -1215,7 +1215,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e67400
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e67400
 Costs       = 50
 OneWayDir	= 4
@@ -1250,7 +1250,7 @@ ConsLayout =....|....
 ConsLayout =....^....
 
 AutoTileBase=	0x53e65000
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e65000
 Costs       = 50
 [HighwayIntersectionInfo_0x00017A33]
@@ -1298,7 +1298,7 @@ ConsLayout =....|....
 ConsLayout =....^....
 
 AutoTileBase=	0x53e65400
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e65400
 Costs       = 50
 [HighwayIntersectionInfo_0x00017A34]
@@ -1328,7 +1328,7 @@ ConsLayout =..../....
 ConsLayout =....^....
 
 AutoTileBase=	0x53e65600
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e65600
 Costs       = 50
 [HighwayIntersectionInfo_0x00037A34]
@@ -1372,7 +1372,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e62000
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e62000
 Costs       = 50
 [HighwayIntersectionInfo_0x00017A35]
@@ -1396,7 +1396,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e62100
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e62100
 Costs       = 50
 [HighwayIntersectionInfo_0x00037A35]
@@ -1426,7 +1426,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e62200
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e62200
 Costs       = 50
 [HighwayIntersectionInfo_0x00077A35]
@@ -1450,7 +1450,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e62300
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e62300
 Costs       = 50
 [HighwayIntersectionInfo_0x00097A35]
@@ -1481,7 +1481,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e62400
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e62400
 Costs       = 50
 [HighwayIntersectionInfo_0x00017A36]
@@ -1505,7 +1505,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e62500
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e62500
 Costs       = 50
 [HighwayIntersectionInfo_0x00037A36]
@@ -1535,7 +1535,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e62600
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e62600
 Costs       = 50
 [HighwayIntersectionInfo_0x00077A36]
@@ -1559,7 +1559,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e62700
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e62700
 Costs       = 50
 [HighwayIntersectionInfo_0x00097A36]
@@ -1590,7 +1590,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e62800
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e62800
 Costs       = 50
 [HighwayIntersectionInfo_0x00017A37]
@@ -1614,7 +1614,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e62900
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e62900
 Costs       = 50
 [HighwayIntersectionInfo_0x00037A37]
@@ -1658,7 +1658,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e66800
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e66800
 Costs       = 50
 [HighwayIntersectionInfo_0x00017A38]
@@ -1687,7 +1687,7 @@ CopyFrom    = 0x17A38
 ;ConsLayout =....^....
 ;
 ;AutoTileBase=	0x53e66a00
-;ReplacementIntersection0 = 0, 0
+;ReplacementIntersection = 0, 0
 ;PlaceQueryID = 0x53e66a00
 ;Costs       = 50
 ;[HighwayIntersectionInfo_0x00037A38]
@@ -1711,7 +1711,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e66900
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e66900
 Costs       = 50
 [HighwayIntersectionInfo_0x00057A38]
@@ -1757,7 +1757,7 @@ ConsLayout =....|....
 ConsLayout =....^....
 
 AutoTileBase=	0x53e65800
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e65800
 Costs       = 50
 [HighwayIntersectionInfo_0x00017A39]
@@ -1803,7 +1803,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e61800
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e61800
 Costs       = 50
 [HighwayIntersectionInfo_0x00017A3A]
@@ -1834,7 +1834,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e61900
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e61900
 Costs       = 50
 [HighwayIntersectionInfo_0x00057A3A]
@@ -1865,7 +1865,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e61a00
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e61a00
 Costs       = 50
 [HighwayIntersectionInfo_0x00097A3A]
@@ -1896,7 +1896,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e61b00
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e61b00
 Costs       = 50
 [HighwayIntersectionInfo_0x00017A3B]
@@ -1927,7 +1927,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e61c00
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e61c00
 Costs       = 50
 [HighwayIntersectionInfo_0x00057A3B]
@@ -1958,7 +1958,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e61d00
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e61d00
 Costs       = 50
 [HighwayIntersectionInfo_0x00097A3B]
@@ -1989,7 +1989,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e61200
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e61200
 Costs       = 50
 [HighwayIntersectionInfo_0x00017A3C]
@@ -2013,7 +2013,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e61300
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e61300
 Costs       = 50
 [HighwayIntersectionInfo_0x00037A3C]
@@ -2043,7 +2043,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e61600
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e61600
 Costs       = 50
 [HighwayIntersectionInfo_0x00077A3C]
@@ -2067,7 +2067,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e61700
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e61700
 Costs       = 50
 [HighwayIntersectionInfo_0x00097A3C]
@@ -2098,7 +2098,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e61000
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e61000
 Costs       = 50
 [HighwayIntersectionInfo_0x00017A3D]
@@ -2122,7 +2122,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e61100
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e61100
 Costs       = 50
 [HighwayIntersectionInfo_0x00037A3D]
@@ -2152,7 +2152,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e61400
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e61400
 Costs       = 50
 [HighwayIntersectionInfo_0x00077A3D]
@@ -2176,7 +2176,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e61500
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e61500
 Costs       = 50
 [HighwayIntersectionInfo_0x00097A3D]

--- a/Controller/RUL0/B000_Lightrail/B400_UTram.txt
+++ b/Controller/RUL0/B000_Lightrail/B400_UTram.txt
@@ -146,7 +146,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e68000
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e68000
 Costs       = 50
 [HighwayIntersectionInfo_0x0001B403]
@@ -175,7 +175,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e68100
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e68100
 Costs       = 50
 [HighwayIntersectionInfo_0x0001B404]
@@ -199,7 +199,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e68200
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e68200
 Costs       = 50
 [HighwayIntersectionInfo_0x0003B404]
@@ -224,7 +224,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e68300
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e68300
 Costs       = 50
 [HighwayIntersectionInfo_0x0001B405]
@@ -255,7 +255,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e68400
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e68400
 Costs       = 50
 [HighwayIntersectionInfo_0x0001B406]
@@ -289,7 +289,7 @@ ConsLayout =...|...
 ConsLayout =...^...
 
 AutoTileBase=	0x53e69000
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e69000
 Costs       = 50
 [HighwayIntersectionInfo_0x0001B407]
@@ -321,7 +321,7 @@ ConsLayout =...|...
 ConsLayout =...^...
 
 AutoTileBase=	0x53e69100
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e69100
 Costs       = 50
 [HighwayIntersectionInfo_0x0001B408]
@@ -355,7 +355,7 @@ ConsLayout =.......
 ConsLayout =...^...
 
 AutoTileBase = 0x53e69700
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e69700
 Costs        = 50
 [HighwayIntersectionInfo_0x0003B408]
@@ -386,7 +386,7 @@ ConsLayout =...+...
 ConsLayout =...^...
 
 AutoTileBase = 0x53e69600
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e69600
 Costs        = 50
 [HighwayIntersectionInfo_0x0001B409]
@@ -434,7 +434,7 @@ ConsLayout =........
 ConsLayout =...^....	
 
 AutoTileBase = 0x53e69400
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e69400
 Costs        = 50
 [HighwayIntersectionInfo_0x0001B40A]
@@ -476,7 +476,7 @@ ConsLayout =...++...
 ConsLayout =...^....
 
 AutoTileBase = 0x53e69200
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e69200
 Costs        = 50
 [HighwayIntersectionInfo_0x0001B40B]
@@ -512,7 +512,7 @@ ConsLayout =..++.<
 ConsLayout =..^...
 
 AutoTileBase = 0x53e69800
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e69800
 Costs        = 50
 [HighwayIntersectionInfo_0x0001B40C]

--- a/Controller/RUL0/C000_Monorail/C000_HSRP.txt
+++ b/Controller/RUL0/C000_Monorail/C000_HSRP.txt
@@ -1123,7 +1123,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e67c00
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e67c00
 Costs       = 50
 [HighwayIntersectionInfo_0x0001C017]
@@ -1147,7 +1147,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e67e00
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e67e00
 Costs       = 50
 [HighwayIntersectionInfo_0x0003C017]

--- a/Controller/RUL0/C000_Monorail/C200_GHSR.txt
+++ b/Controller/RUL0/C000_Monorail/C200_GHSR.txt
@@ -1218,7 +1218,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e66c00
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e66c00
 Costs       = 50
 [HighwayIntersectionInfo_0x0001C217]
@@ -1242,7 +1242,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e66e00
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e66e00
 Costs       = 50
 [HighwayIntersectionInfo_0x0003C217]
@@ -1266,7 +1266,7 @@ ConsLayout =....+...<
 ConsLayout =....^....
 
 AutoTileBase=	0x53e66d00
-ReplacementIntersection0 = 0, 0
+ReplacementIntersection = 0, 0
 PlaceQueryID = 0x53e66d00
 Costs       = 50
 [HighwayIntersectionInfo_0x0005C217]


### PR DESCRIPTION
See also Discord message https://discord.com/channels/383313438065033228/383313497964150785/1450731169208598579
Clearly it makes no difference in game, but can't hurt to comply to the spec on the Wiki.